### PR TITLE
Scale memory and disk cache sizes.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/LruCache.java
+++ b/picasso/src/main/java/com/squareup/picasso/LruCache.java
@@ -15,15 +15,10 @@
  */
 package com.squareup.picasso;
 
-import android.app.ActivityManager;
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.os.Build;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import static android.content.Context.ACTIVITY_SERVICE;
-import static android.content.pm.ApplicationInfo.FLAG_LARGE_HEAP;
 
 /** A memory cache which uses a least-recently used eviction policy. */
 public class LruCache implements Cache {
@@ -38,7 +33,7 @@ public class LruCache implements Cache {
 
   /** Create a cache using an appropriate portion of the available RAM as the maximum size. */
   public LruCache(Context context) {
-    this(calculateMaxSize(context));
+    this(Utils.calculateMemoryCacheSize(context));
   }
 
   /** Create a cache with a given maximum size in bytes. */
@@ -143,21 +138,5 @@ public class LruCache implements Cache {
   /** Returns the number of values that have been evicted. */
   public final synchronized int evictionCount() {
     return evictionCount;
-  }
-
-  private static int calculateMaxSize(Context context) {
-    ActivityManager am = (ActivityManager) context.getSystemService(ACTIVITY_SERVICE);
-    boolean largeHeap = (context.getApplicationInfo().flags & FLAG_LARGE_HEAP) != 0;
-    int memoryClass = am.getMemoryClass();
-    if (largeHeap && Build.VERSION.SDK_INT <= Build.VERSION_CODES.HONEYCOMB) {
-      memoryClass = ActivityManagerHoneycomb.getLargeMemoryClass(am);
-    }
-    return 1024 * 1024 * memoryClass / 6;
-  }
-
-  private static class ActivityManagerHoneycomb {
-    static int getLargeMemoryClass(ActivityManager activityManager) {
-      return activityManager.getLargeMemoryClass();
-    }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/OkHttpLoader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttpLoader.java
@@ -14,7 +14,6 @@ import static com.squareup.picasso.Utils.parseResponseSourceHeader;
 public class OkHttpLoader implements Loader {
   static final String RESPONSE_SOURCE = "X-Android-Response-Source";
   private static final String PICASSO_CACHE = "picasso-cache";
-  private static final int MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
   private final OkHttpClient client;
 
@@ -26,7 +25,8 @@ public class OkHttpLoader implements Loader {
     this(new OkHttpClient());
     try {
       File cacheDir = new File(context.getApplicationContext().getCacheDir(), PICASSO_CACHE);
-      client.setResponseCache(new HttpResponseCache(cacheDir, MAX_SIZE));
+      int maxSize = Utils.calculateDiskCacheSize(cacheDir);
+      client.setResponseCache(new HttpResponseCache(cacheDir, maxSize));
     } catch (IOException ignored) {
     }
   }

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -491,7 +491,22 @@ public class Picasso {
     return result;
   }
 
-  /** The global default {@link Picasso} instance. */
+  /**
+   * The global default {@link Picasso} instance.
+   * <p>
+   * This instance is automatically initialized with defaults that are suitable to most
+   * implementations.
+   * <ul>
+   * <li>LRU memory cache of 15% the available application RAM up to 20MB</li>
+   * <li>Disk cache of 2% storage space up to 50MB but no less than 5MB. (Note: this is only
+   * available on API 14+ <em>or</em> if you are using a standalone library that provides a disk
+   * cache on all API levels like OkHttp)</li>
+   * <li>Three download threads for disk and network access.</li>
+   * </ul>
+   * <p>
+   * If these settings do not meet the requirements of your application you can construct your own
+   * instance with full control over the configuration by using {@link Picasso.Builder}.
+   */
   public static Picasso with(Context context) {
     if (singleton == null) {
       singleton = new Builder(context).build();

--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionLoader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionLoader.java
@@ -17,7 +17,6 @@ import static com.squareup.picasso.Utils.parseResponseSourceHeader;
 public class UrlConnectionLoader implements Loader {
   static final String RESPONSE_SOURCE = "X-Android-Response-Source";
   private static final String PICASSO_CACHE = "picasso-cache";
-  private static final int MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
   private static final Object lock = new Object();
   static volatile Object cache;
@@ -67,7 +66,8 @@ public class UrlConnectionLoader implements Loader {
       File cacheDir = new File(context.getCacheDir(), PICASSO_CACHE);
       HttpResponseCache cache = HttpResponseCache.getInstalled();
       if (cache == null) {
-        cache = HttpResponseCache.install(cacheDir, MAX_SIZE);
+        int maxSize = Utils.calculateDiskCacheSize(cacheDir);
+        cache = HttpResponseCache.install(cacheDir, maxSize);
       }
       return cache;
     }

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -1,18 +1,24 @@
 package com.squareup.picasso;
 
+import android.app.ActivityManager;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.media.ExifInterface;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Looper;
 import android.os.Process;
+import android.os.StatFs;
 import android.provider.MediaStore;
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 
+import static android.content.Context.ACTIVITY_SERVICE;
+import static android.content.pm.ApplicationInfo.FLAG_LARGE_HEAP;
 import static android.media.ExifInterface.ORIENTATION_NORMAL;
 import static android.media.ExifInterface.ORIENTATION_ROTATE_180;
 import static android.media.ExifInterface.ORIENTATION_ROTATE_270;
@@ -26,6 +32,9 @@ final class Utils {
   static final String THREAD_PREFIX = "Picasso-";
   static final String THREAD_IDLE_NAME = THREAD_PREFIX + "Idle";
   private static final int KEY_PADDING = 50; // Determined by exact science.
+  private static final int MIN_DISK_CACHE_SIZE = 5 * 1024 * 1024; // 5MB
+  private static final int MAX_DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
+  private static final int MAX_MEM_CACHE_SIZE = 20 * 1024 * 1024; // 20MB
   private static final String[] CONTENT_ORIENTATION = new String[] {
       MediaStore.Images.ImageColumns.ORIENTATION
   };
@@ -178,6 +187,34 @@ final class Utils {
       return OkHttpLoaderCreator.create(context);
     } catch (ClassNotFoundException e) {
       return new UrlConnectionLoader(context);
+    }
+  }
+
+  static int calculateDiskCacheSize(File dir) {
+    StatFs statFs = new StatFs(dir.getAbsolutePath());
+    int available = statFs.getBlockCount() * statFs.getBlockSize();
+    // Target 2% of the total space.
+    int size = available / 50;
+    // Bound inside min/max size for disk cache.
+    return Math.max(Math.min(size, MAX_DISK_CACHE_SIZE), MIN_DISK_CACHE_SIZE);
+  }
+
+  static int calculateMemoryCacheSize(Context context) {
+    ActivityManager am = (ActivityManager) context.getSystemService(ACTIVITY_SERVICE);
+    boolean largeHeap = (context.getApplicationInfo().flags & FLAG_LARGE_HEAP) != 0;
+    int memoryClass = am.getMemoryClass();
+    if (largeHeap && Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+      memoryClass = ActivityManagerHoneycomb.getLargeMemoryClass(am);
+    }
+    // Target 15% of the available RAM.
+    int size = 1024 * 1024 * memoryClass / 7;
+    // Bound to max size for mem cache.
+    return Math.min(size, MAX_MEM_CACHE_SIZE);
+  }
+
+  private static class ActivityManagerHoneycomb {
+    static int getLargeMemoryClass(ActivityManager activityManager) {
+      return activityManager.getLargeMemoryClass();
     }
   }
 


### PR DESCRIPTION
Memory cache now has a ceiling of 20MB. Also fixes a logic error for looking up the large memory class when the large heap flag was set.

Disk cache now scales between 5MB and 50MB, favoring 2% of the storage space on the target filesystem.

Closes #4.

@swankjesse @dnkoutso 
