### PR TITLE
Foolproofing use of .transform()

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -487,9 +487,7 @@ public class Picasso {
 
       // If the transformation returned a new bitmap ensure they recycled the original.
       if (newResult != result && !result.isRecycled()) {
-        throw new IllegalStateException("Transformation "
-            + transformation.key()
-            + " mutated input Bitmap but failed to recycle the original.");
+          result.recycle();
       }
       result = newResult;
     }


### PR DESCRIPTION
If transformation returns a new bitmap ensure the original is recycled,
just like it reads in the comment :)

Nowhere on the signatures of RequestBuilder.transform() you're warned of
these possible runtime exceptions. 

Nowhere on the comments of .transform() there's a mention that you
should be recycling your old bitmap.

From the perspective of an API user:
1. You're throwing an unnecessary runtime exception when you can
perfectly fix the problem foolproofing your API.
2. You should be avoiding runtime exceptions (and boy do you guys like
to throw exceptions), not enforcing logic and contracts through them,
they just make apps crash, one thing is coding
for yourself, another for an API. (My eye starts ticking when I see
stuff like this, sorry)

Other minor patches removing unnecessary mutability coming.
