### PR TITLE
Fixed crash on Android 4.2.2 devices

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/OkHttpLoader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttpLoader.java
@@ -13,7 +13,6 @@ import static com.squareup.picasso.Utils.parseResponseSourceHeader;
 /** A {@link Loader} which uses OkHttp to download images. */
 public class OkHttpLoader implements Loader {
   static final String RESPONSE_SOURCE = "X-Android-Response-Source";
-  private static final String PICASSO_CACHE = "picasso-cache";
 
   private final OkHttpClient client;
 
@@ -24,7 +23,7 @@ public class OkHttpLoader implements Loader {
   public OkHttpLoader(Context context) {
     this(new OkHttpClient());
     try {
-      File cacheDir = new File(context.getApplicationContext().getCacheDir(), PICASSO_CACHE);
+      File cacheDir = Utils.createDefaultCacheDir(context);
       int maxSize = Utils.calculateDiskCacheSize(cacheDir);
       client.setResponseCache(new HttpResponseCache(cacheDir, maxSize));
     } catch (IOException ignored) {

--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionLoader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionLoader.java
@@ -16,7 +16,6 @@ import static com.squareup.picasso.Utils.parseResponseSourceHeader;
  */
 public class UrlConnectionLoader implements Loader {
   static final String RESPONSE_SOURCE = "X-Android-Response-Source";
-  private static final String PICASSO_CACHE = "picasso-cache";
 
   private static final Object lock = new Object();
   static volatile Object cache;
@@ -63,7 +62,7 @@ public class UrlConnectionLoader implements Loader {
 
   private static class ResponseCacheIcs {
     static Object install(Context context) throws IOException {
-      File cacheDir = new File(context.getCacheDir(), PICASSO_CACHE);
+      File cacheDir = Utils.createDefaultCacheDir(context);
       HttpResponseCache cache = HttpResponseCache.getInstalled();
       if (cache == null) {
         int maxSize = Utils.calculateDiskCacheSize(cacheDir);

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -31,6 +31,8 @@ import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
 final class Utils {
   static final String THREAD_PREFIX = "Picasso-";
   static final String THREAD_IDLE_NAME = THREAD_PREFIX + "Idle";
+  private static final String PICASSO_CACHE = "picasso-cache";
+
   private static final int KEY_PADDING = 50; // Determined by exact science.
   private static final int MIN_DISK_CACHE_SIZE = 5 * 1024 * 1024; // 5MB
   private static final int MAX_DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
@@ -188,6 +190,14 @@ final class Utils {
     } catch (ClassNotFoundException e) {
       return new UrlConnectionLoader(context);
     }
+  }
+
+  static File createDefaultCacheDir(Context context) {
+    File cache = new File(context.getApplicationContext().getCacheDir(), PICASSO_CACHE);
+    if (!cache.exists()) {
+      cache.mkdirs();
+    }
+    return cache;
   }
 
   static int calculateDiskCacheSize(File dir) {


### PR DESCRIPTION
Utils.calculateDiskCacheSize throws java.lang.IllegalArgumentException: Invalid path on Nexus 4 (Android 4.2.2) if cache directory doesn't exist. Calling cacheDir.mkdirs solves the problem.
