### PR TITLE
Add centerInside option.

### DIFF
--- a/picasso-sample/src/main/java/com/example/picasso/SampleListDetailAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleListDetailAdapter.java
@@ -44,7 +44,7 @@ final class SampleListDetailAdapter extends BaseAdapter {
         .placeholder(R.drawable.placeholder)
         .error(R.drawable.error)
         .resizeDimen(R.dimen.list_detail_image_size, R.dimen.list_detail_image_size)
-        .centerCrop()
+        .centerInside()
         .into(holder.image);
 
     return view;

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -430,6 +430,11 @@ public class Picasso {
           drawWidth = newSize;
         }
         matrix.preScale(scale, scale);
+      } else if (options.centerInside) {
+        float widthRatio = targetWidth / (float) inWidth;
+        float heightRatio = targetHeight / (float) inHeight;
+        float scale = widthRatio < heightRatio ? widthRatio : heightRatio;
+        matrix.preScale(scale, scale);
       } else if (targetWidth != 0 && targetHeight != 0 //
           && (targetWidth != inWidth || targetHeight != inHeight)) {
         // If an explicit target size has been specified and they do not match the results bounds,

--- a/picasso/src/main/java/com/squareup/picasso/PicassoBitmapOptions.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoBitmapOptions.java
@@ -7,6 +7,7 @@ class PicassoBitmapOptions extends BitmapFactory.Options {
   int targetHeight;
   boolean deferredResize;
   boolean centerCrop;
+  boolean centerInside;
 
   float targetScaleX;
   float targetScaleY;

--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -199,10 +199,10 @@ final class PicassoDrawable extends Drawable {
   @Override protected void onBoundsChange(Rect bounds) {
     super.onBoundsChange(bounds);
     if (bitmapDrawable != null) {
-      bitmapDrawable.setBounds(bounds);
+      setBounds(this.bitmapDrawable);
     }
     if (placeHolderDrawable != null) {
-      placeHolderDrawable.setBounds(bounds);
+      this.placeHolderDrawable.setBounds(getBounds());
     }
   }
 
@@ -238,7 +238,7 @@ final class PicassoDrawable extends Drawable {
     }
 
     bitmapDrawable = new BitmapDrawable(context.getResources(), bitmap);
-    bitmapDrawable.setBounds(getBounds());
+    setBounds(bitmapDrawable);
 
     this.loadedFrom = loadedFrom;
 
@@ -246,6 +246,32 @@ final class PicassoDrawable extends Drawable {
     animating = fade;
 
     invalidateSelf();
+  }
+
+  private void setBounds(Drawable drawable) {
+    Rect bounds = getBounds();
+
+    final int width = bounds.width();
+    final int height = bounds.height();
+    final float ratio = (float) width / height;
+
+    final int drawableWidth = drawable.getIntrinsicWidth();
+    final int drawableHeight = drawable.getIntrinsicHeight();
+    final float drawableRatio = (float) drawableWidth / drawableHeight;
+
+    if (drawableRatio < ratio) {
+      final float scale = (float) height / drawableHeight;
+      final int scaledDrawableWidth = (int) (drawableWidth * scale);
+      final int drawableLeft = bounds.left - (scaledDrawableWidth - width) / 2;
+      final int drawableRight = drawableLeft + scaledDrawableWidth;
+      drawable.setBounds(drawableLeft, bounds.top, drawableRight, bounds.bottom);
+    } else {
+      final float scale = (float) width / drawableWidth;
+      final int scaledDrawableHeight = (int) (drawableHeight * scale);
+      final int drawableTop = bounds.top - (scaledDrawableHeight - height) / 2;
+      final int drawableBottom = drawableTop + scaledDrawableHeight;
+      drawable.setBounds(bounds.left, drawableTop, bounds.right, drawableBottom);
+    }
   }
 
   private void drawDebugIndicator(Canvas canvas) {

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -180,8 +180,29 @@ public class RequestBuilder {
     if (options.targetWidth == 0 || options.targetHeight == 0) {
       throw new IllegalStateException("Center crop can only be used after calling resize.");
     }
+    if (options.centerInside) {
+      throw new IllegalStateException("Center crop can not be used after calling centerInside");
+    }
 
     options.centerCrop = true;
+    return this;
+  }
+
+  /**
+   * Centers an image inside of the bounds specified by {@link #resize(int, int)}. This scales
+   * the image so that both dimensions are equal to or less than the requested bounds.
+   */
+  public RequestBuilder centerInside() {
+    PicassoBitmapOptions options = getOptions();
+
+    if (options.targetWidth == 0 || options.targetHeight == 0) {
+      throw new IllegalStateException("Center inside can only be used after calling resize.");
+    }
+    if (options.centerCrop) {
+      throw new IllegalStateException("Center inside can not be used after calling centerCrop");
+    }
+
+    options.centerInside = true;
     return this;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -128,6 +128,9 @@ final class Utils {
       if (options.centerCrop) {
         builder.append("centerCrop\n");
       }
+      if (options.centerInside) {
+        builder.append("centerInside\n");
+      }
       float targetScaleX = options.targetScaleX;
       float targetScaleY = options.targetScaleY;
       if (targetScaleX != 0) {

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTransformTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTransformTest.java
@@ -196,6 +196,74 @@ public class PicassoTransformTest {
     assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
   }
 
+  @Test public void centerInsideTallTooSmall() {
+    Bitmap source = Bitmap.createBitmap(20, 10, ARGB_8888);
+    PicassoBitmapOptions options = new PicassoBitmapOptions();
+    options.targetWidth = 50;
+    options.targetHeight = 50;
+    options.centerInside = true;
+
+    Bitmap result = Picasso.transformResult(options, source, 0);
+
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.5 2.5");
+  }
+
+  @Test public void centerInsideTallTooLarge() {
+    Bitmap source = Bitmap.createBitmap(100, 50, ARGB_8888);
+    PicassoBitmapOptions options = new PicassoBitmapOptions();
+    options.targetWidth = 50;
+    options.targetHeight = 50;
+    options.centerInside = true;
+
+    Bitmap result = Picasso.transformResult(options, source, 0);
+
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+  }
+
+  @Test public void centerInsideWideTooSmall() {
+    Bitmap source = Bitmap.createBitmap(10, 20, ARGB_8888);
+    PicassoBitmapOptions options = new PicassoBitmapOptions();
+    options.targetWidth = 50;
+    options.targetHeight = 50;
+    options.centerInside = true;
+
+    Bitmap result = Picasso.transformResult(options, source, 0);
+
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.5 2.5");
+  }
+
+  @Test public void centerInsideWideTooLarge() {
+    Bitmap source = Bitmap.createBitmap(50, 100, ARGB_8888);
+    PicassoBitmapOptions options = new PicassoBitmapOptions();
+    options.targetWidth = 50;
+    options.targetHeight = 50;
+    options.centerInside = true;
+
+    Bitmap result = Picasso.transformResult(options, source, 0);
+
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+  }
+
   @Test public void reusedBitmapIsNotRecycled() {
     Bitmap source = Bitmap.createBitmap(10, 10, ARGB_8888);
     Bitmap result = Picasso.transformResult(null, source, 0);

--- a/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
@@ -138,6 +138,24 @@ public class RequestBuilderTest {
       fail("Center crop without resize should throw exception.");
     } catch (IllegalStateException expected) {
     }
+    try {
+      new RequestBuilder().resize(10, 10).centerInside().centerCrop();
+      fail("Calling center crop after center inside should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void invalidCenterInside() {
+    try {
+      new RequestBuilder().centerInside();
+      fail("Center inside without resize should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
+    try {
+      new RequestBuilder().resize(10, 10).centerInside().centerCrop();
+      fail("Calling center inside after center crop should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Added centerInside method to RequestBuilder.
Additionally, PicassoDrawable will always center the Bitmap inside it.

The placeholder will always have the same bounds as PicassoDrawable.
