### PR TITLE
Use Uri to manage paths internally.

### DIFF
--- a/picasso-sample/pom.xml
+++ b/picasso-sample/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.picasso</groupId>
     <artifactId>picasso-parent</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/picasso/pom.xml
+++ b/picasso/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.squareup.picasso</groupId>
     <artifactId>picasso-parent</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/picasso/src/main/java/com/squareup/picasso/Loader.java
+++ b/picasso/src/main/java/com/squareup/picasso/Loader.java
@@ -1,5 +1,6 @@
 package com.squareup.picasso;
 
+import android.net.Uri;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -8,14 +9,14 @@ public interface Loader {
   /**
    * Download the specified image {@code url} from the internet.
    *
-   * @param url Remote image URL.
+   * @param uri Remote image URL.
    * @param localCacheOnly If {@code true} the URL should only be loaded if available in a local
    * disk cache.
    * @return {@link InputStream} and {@code boolean} indicating whether or not the image is being
    *         loaded from a local disk cache. <strong>Must not be {@code null}.</strong>
    * @throws IOException if the requested URL cannot successfully be loaded.
    */
-  Response load(String url, boolean localCacheOnly) throws IOException;
+  Response load(Uri uri, boolean localCacheOnly) throws IOException;
 
   /** Response stream and info. */
   class Response {

--- a/picasso/src/main/java/com/squareup/picasso/OkHttpLoader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttpLoader.java
@@ -1,6 +1,7 @@
 package com.squareup.picasso;
 
 import android.content.Context;
+import android.net.Uri;
 import com.squareup.okhttp.HttpResponseCache;
 import com.squareup.okhttp.OkHttpClient;
 import java.io.File;
@@ -38,8 +39,8 @@ public class OkHttpLoader implements Loader {
     this.client = client;
   }
 
-  @Override public Response load(String url, boolean localCacheOnly) throws IOException {
-    HttpURLConnection connection = client.open(new URL(url));
+  @Override public Response load(Uri uri, boolean localCacheOnly) throws IOException {
+    HttpURLConnection connection = client.open(new URL(uri.toString()));
     connection.setUseCaches(true);
     if (localCacheOnly) {
       connection.setRequestProperty("Cache-Control", "only-if-cached");

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.widget.ImageView;
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -13,13 +14,6 @@ import static com.squareup.picasso.Utils.createKey;
 
 class Request implements Runnable {
   static final int DEFAULT_RETRY_COUNT = 2;
-
-  enum Type {
-    CONTENT,
-    FILE,
-    NETWORK,
-    RESOURCE
-  }
 
   enum LoadedFrom {
     MEMORY(Color.GREEN),
@@ -34,12 +28,11 @@ class Request implements Runnable {
   }
 
   final Picasso picasso;
-  final String path;
+  final Uri uri;
   final int resourceId;
   final WeakReference<ImageView> target;
   final PicassoBitmapOptions options;
   final List<Transformation> transformations;
-  final Type type;
   final boolean skipCache;
   final boolean noFade;
   final int errorResId;
@@ -52,16 +45,15 @@ class Request implements Runnable {
   int retryCount;
   boolean retryCancelled;
 
-  Request(Picasso picasso, String path, int resourceId, ImageView imageView,
-      PicassoBitmapOptions options, List<Transformation> transformations, Type type,
-      boolean skipCache, boolean noFade, int errorResId, Drawable errorDrawable) {
+  Request(Picasso picasso, Uri uri, int resourceId, ImageView imageView,
+      PicassoBitmapOptions options, List<Transformation> transformations, boolean skipCache,
+      boolean noFade, int errorResId, Drawable errorDrawable) {
     this.picasso = picasso;
-    this.path = path;
+    this.uri = uri;
     this.resourceId = resourceId;
     this.target = new WeakReference<ImageView>(imageView);
     this.options = options;
     this.transformations = transformations;
-    this.type = type;
     this.skipCache = skipCache;
     this.noFade = noFade;
     this.errorResId = errorResId;
@@ -103,7 +95,7 @@ class Request implements Runnable {
   @Override public void run() {
     try {
       // Change the thread name to contain the target URL for debugging purposes.
-      Thread.currentThread().setName(Utils.THREAD_PREFIX + path);
+      Thread.currentThread().setName(Utils.THREAD_PREFIX + getName());
 
       picasso.run(this);
     } catch (final Throwable e) {
@@ -119,14 +111,19 @@ class Request implements Runnable {
     }
   }
 
+  private String getName() {
+    Uri uri = this.uri;
+    return uri != null ? uri.getPath() : Integer.toString(resourceId);
+  }
+
   @Override public String toString() {
     return "Request["
         + "hashCode="
         + hashCode()
         + ", picasso="
         + picasso
-        + ", path="
-        + path
+        + ", uri="
+        + uri
         + ", resourceId="
         + resourceId
         + ", target="

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -3,6 +3,7 @@ package com.squareup.picasso;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.widget.ImageView;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -17,9 +18,8 @@ import static com.squareup.picasso.Utils.createKey;
 @SuppressWarnings("UnusedDeclaration") // Public API.
 public class RequestBuilder {
   private final Picasso picasso;
-  private final String path;
+  private final Uri uri;
   private final int resourceId;
-  private final Request.Type type;
 
   PicassoBitmapOptions options;
   private List<Transformation> transformations;
@@ -31,25 +31,16 @@ public class RequestBuilder {
   private int errorResId;
   private Drawable errorDrawable;
 
-  RequestBuilder(Picasso picasso, int resourceId) {
+  RequestBuilder(Picasso picasso, Uri uri, int resourceId) {
     this.picasso = picasso;
-    this.path = null;
+    this.uri = uri;
     this.resourceId = resourceId;
-    this.type = Request.Type.RESOURCE;
-  }
-
-  RequestBuilder(Picasso picasso, String path, Request.Type type) {
-    this.picasso = picasso;
-    this.path = path;
-    this.resourceId = 0;
-    this.type = type;
   }
 
   @TestOnly RequestBuilder() {
     this.picasso = null;
-    this.path = null;
+    this.uri = null;
     this.resourceId = 0;
-    this.type = null;
   }
 
   private PicassoBitmapOptions getOptions() {
@@ -160,11 +151,7 @@ public class RequestBuilder {
 
     options.targetWidth = targetWidth;
     options.targetHeight = targetHeight;
-
-    // Use bounds decoding optimization when reading local resources.
-    if (type != Request.Type.NETWORK) {
-      options.inJustDecodeBounds = true;
-    }
+    options.inJustDecodeBounds = true;
 
     return this;
   }
@@ -290,8 +277,8 @@ public class RequestBuilder {
   public Bitmap get() throws IOException {
     checkNotMain();
     Request request =
-        new Request(picasso, path, resourceId, null, options, transformations, type, skipCache,
-            false, 0, null);
+        new Request(picasso, uri, resourceId, null, options, transformations, skipCache, false, 0,
+            null);
     return picasso.resolveRequest(request);
   }
 
@@ -326,8 +313,8 @@ public class RequestBuilder {
     }
 
     // Look for the target bitmap in the memory cache without moving to a background thread.
-    String requestKey = createKey(path, resourceId, options, transformations);
-    Bitmap bitmap = picasso.quickMemoryCacheCheck(target, requestKey);
+    String requestKey = createKey(uri, resourceId, options, transformations);
+    Bitmap bitmap = picasso.quickMemoryCacheCheck(target, uri, requestKey);
     if (bitmap != null) {
       PicassoDrawable.setBitmap(target, picasso.context, bitmap, MEMORY, noFade, picasso.debugging);
       return;
@@ -341,8 +328,8 @@ public class RequestBuilder {
     }
 
     Request request =
-        new Request(picasso, path, resourceId, target, options, transformations, type, skipCache,
-            noFade, errorResId, errorDrawable);
+        new Request(picasso, uri, resourceId, target, options, transformations, skipCache, noFade,
+            errorResId, errorDrawable);
     picasso.submit(request);
   }
 
@@ -351,15 +338,15 @@ public class RequestBuilder {
       throw new IllegalArgumentException("Target must not be null.");
     }
 
-    String requestKey = createKey(path, resourceId, options, transformations);
-    Bitmap bitmap = picasso.quickMemoryCacheCheck(target, requestKey);
+    String requestKey = createKey(uri, resourceId, options, transformations);
+    Bitmap bitmap = picasso.quickMemoryCacheCheck(target, uri, requestKey);
     if (bitmap != null) {
       target.onSuccess(bitmap);
       return;
     }
 
     Request request =
-        new TargetRequest(picasso, path, resourceId, target, strong, options, transformations, type,
+        new TargetRequest(picasso, uri, resourceId, target, strong, options, transformations,
             skipCache);
     picasso.submit(request);
   }

--- a/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
+++ b/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
@@ -1,5 +1,6 @@
 package com.squareup.picasso;
 
+import android.net.Uri;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
@@ -8,11 +9,10 @@ final class TargetRequest extends Request {
   private final WeakReference<Target> weakTarget;
   private final Target strongTarget;
 
-  TargetRequest(Picasso picasso, String path, int resourceId, Target target, boolean strong,
-      PicassoBitmapOptions bitmapOptions, List<Transformation> transformations, Type type,
-      boolean skipCache) {
-    super(picasso, path, resourceId, null, bitmapOptions, transformations, type, skipCache, false,
-        0, null);
+  TargetRequest(Picasso picasso, Uri uri, int resourceId, Target target, boolean strong,
+      PicassoBitmapOptions bitmapOptions, List<Transformation> transformations, boolean skipCache) {
+    super(picasso, uri, resourceId, null, bitmapOptions, transformations, skipCache, false, 0,
+        null);
     this.weakTarget = strong ? null : new WeakReference<Target>(target);
     this.strongTarget = strong ? target : null;
   }

--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionLoader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionLoader.java
@@ -1,6 +1,7 @@
 package com.squareup.picasso;
 
 import android.content.Context;
+import android.net.Uri;
 import android.net.http.HttpResponseCache;
 import android.os.Build;
 import java.io.File;
@@ -30,12 +31,12 @@ public class UrlConnectionLoader implements Loader {
     return (HttpURLConnection) new URL(path).openConnection();
   }
 
-  @Override public Response load(String url, boolean localCacheOnly) throws IOException {
+  @Override public Response load(Uri uri, boolean localCacheOnly) throws IOException {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
       installCacheIfNeeded(context);
     }
 
-    HttpURLConnection connection = openConnection(url);
+    HttpURLConnection connection = openConnection(uri.toString());
     connection.setUseCaches(true);
     if (localCacheOnly) {
       connection.setRequestProperty("Cache-Control", "only-if-cached");

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -94,14 +94,15 @@ final class Utils {
   }
 
   static String createKey(Request request) {
-    return createKey(request.path, request.resourceId, request.options, request.transformations);
+    return createKey(request.uri, request.resourceId, request.options, request.transformations);
   }
 
-  static String createKey(String path, int resourceId, PicassoBitmapOptions options,
+  static String createKey(Uri uri, int resourceId, PicassoBitmapOptions options,
       List<Transformation> transformations) {
     StringBuilder builder;
 
-    if (path != null) {
+    if (uri != null) {
+      String path = uri.toString();
       builder = new StringBuilder(path.length() + KEY_PADDING);
       builder.append(path);
     } else {

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -10,7 +10,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
@@ -26,7 +25,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.squareup.picasso.Picasso.Listener;
-import static com.squareup.picasso.Request.Type;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
 import static org.mockito.Matchers.any;
@@ -51,12 +49,12 @@ import static org.robolectric.Robolectric.unPauseMainLooper;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class PicassoTest {
-  private static final String URI_1 = "URI1";
-  private static final String URI_2 = "URI2";
+  private static final Uri URI_1 = Uri.parse("http://example.com/1.png");
+  private static final Uri URI_2 = Uri.parse("http://example.com/2.png");
   private static final File FILE_1 = new File("C:\\windows\\system32\\logo.exe");
-  private static final String FILE_1_URL = "file:///" + FILE_1.getPath();
-  private static final String FILE_1_URL_NO_AUTHORITY = "file:/" + FILE_1.getParent();
-  private static final String CONTENT_1_URL = "content://zip/zap/zoop.jpg";
+  private static final Uri FILE_1_URL = Uri.parse("file:///" + FILE_1.getPath());
+  private static final Uri FILE_1_URL_NO_AUTHORITY = Uri.parse("file:/" + FILE_1.getParent());
+  private static final Uri CONTENT_1_URL = Uri.parse("content://zip/zap/zoop.jpg");
 
   private static final Answer LOADER_ANSWER = new Answer() {
     @Override public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
@@ -383,7 +381,6 @@ public class PicassoTest {
     Picasso picasso = create(LOADER_ANSWER, BITMAP1_ANSWER);
     picasso.load(URI_1).placeholder(android.R.drawable.ic_delete).into(target);
 
-
     ArgumentCaptor<PicassoDrawable> actual = ArgumentCaptor.forClass(PicassoDrawable.class);
     verify(target).setImageDrawable(actual.capture());
     PicassoDrawable capturedActual = actual.getValue();
@@ -413,8 +410,7 @@ public class PicassoTest {
 
     Picasso picasso = create(LOADER_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, URI_1, 0, target, null, null, Request.Type.NETWORK, false, false, 0,
-            errorDrawable);
+        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -430,8 +426,7 @@ public class PicassoTest {
 
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, FILE_1_URL, 0, target, null, null, Type.FILE, false, false, 0,
-            errorDrawable);
+        new Request(picasso, FILE_1_URL, 0, target, null, null, false, false, 0, errorDrawable);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -447,8 +442,7 @@ public class PicassoTest {
 
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, CONTENT_1_URL, 0, target, null, null, Type.CONTENT, false, false, 0,
-            errorDrawable);
+        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, errorDrawable);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -463,9 +457,7 @@ public class PicassoTest {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
 
-    Request request =
-        new Request(picasso, URI_1, 0, target, null, null, Request.Type.NETWORK, false, false, 0,
-            null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -479,8 +471,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, FILE_1.getPath(), 0, target, null, null, Type.FILE, false, false, 0,
-            null);
+        new Request(picasso, Uri.fromFile(FILE_1), 0, target, null, null, false, false, 0, null);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -495,8 +486,8 @@ public class PicassoTest {
     Picasso picasso = create(NULL_ANSWER, IO_EXCEPTION_ANSWER);
     ImageView target = mock(ImageView.class);
 
-    Request request = new Request(picasso, CONTENT_1_URL, 0, target, null,
-        Collections.<Transformation>emptyList(), Type.CONTENT, false, false, 0, null);
+    Request request =
+        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, null);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -511,8 +502,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, null, Request.Type.NETWORK, false, false, 0,
-            errorDrawable);
+        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable);
 
     retryRequest(picasso, request);
     verify(target).setImageDrawable(errorDrawable);
@@ -524,9 +514,7 @@ public class PicassoTest {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
 
-    Request request =
-        new Request(picasso, URI_1, 0, target, null, null, Request.Type.NETWORK, false, false, 0,
-            null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
 
     retryRequest(picasso, request);
     assertThat(picasso.targetsToRequests).isEmpty();
@@ -565,8 +553,7 @@ public class PicassoTest {
 
   @Test public void whenTargetRequestFailsCleansUpTargetMap() throws Exception {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
-    Request request =
-        new TargetRequest(picasso, URI_1, 0, null, false, null, null, Type.NETWORK, false);
+    Request request = new TargetRequest(picasso, URI_1, 0, null, false, null, null, false);
 
     retryRequest(picasso, request);
     assertThat(picasso.targetsToRequests).isEmpty();
@@ -701,8 +688,7 @@ public class PicassoTest {
     transformations.add(resize);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, transformations, Request.Type.NETWORK, false,
-            false, 0, null);
+        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null);
     picasso.submit(request);
 
     executor.flush();
@@ -753,8 +739,7 @@ public class PicassoTest {
     transformations.add(resize);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, transformations, Request.Type.NETWORK, false,
-            false, 0, null);
+        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null);
     picasso.submit(request);
 
     executor.flush();
@@ -891,8 +876,7 @@ public class PicassoTest {
   @Test public void cancelRequestBeforeExecution() throws Exception {
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request =
-        new Request(picasso, null, 0, target, null, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -905,7 +889,7 @@ public class PicassoTest {
   @Test public void cancelTargetRequestBeforeExecution() throws Exception {
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Target target = mock(Target.class);
-    Request request = new TargetRequest(picasso, null, 0, target, true, null, null, null, false);
+    Request request = new TargetRequest(picasso, URI_1, 0, target, true, null, null, false);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -918,8 +902,7 @@ public class PicassoTest {
   @Test public void cancelRequestBetweenRetries() throws Exception {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, NULL_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request =
-        new Request(picasso, null, 0, target, null, null, Type.NETWORK, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -936,8 +919,7 @@ public class PicassoTest {
   @Test public void cancelRequestAfterResult() throws Exception {
     Picasso picasso = create(LOADER_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request =
-        new Request(picasso, null, 0, target, null, null, Type.FILE, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     pauseMainLooper();
@@ -986,9 +968,7 @@ public class PicassoTest {
     Picasso picasso = create(NULL_ANSWER, IO_EXCEPTION_ANSWER);
 
     ImageView target = mock(ImageView.class);
-    Request request =
-        new Request(picasso, URI_1, 0, target, null, null, Request.Type.NETWORK, false, false, 0,
-            null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
 
     retryRequest(picasso, request);
 
@@ -1008,8 +988,7 @@ public class PicassoTest {
     Picasso picasso = new Picasso(context, loader, executor, cache, listener, stats);
     picasso = spy(picasso);
 
-    doAnswer(loaderAnswer).when(loader).load(anyString(), anyBoolean());
-    doAnswer(decoderAnswer).when(picasso).decodeFile(anyString(), any(PicassoBitmapOptions.class));
+    doAnswer(loaderAnswer).when(loader).load(any(Uri.class), anyBoolean());
     doAnswer(decoderAnswer).when(picasso)
         .decodeContentStream(any(Uri.class), any(PicassoBitmapOptions.class));
     doAnswer(decoderAnswer).when(picasso)

--- a/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
@@ -84,13 +84,6 @@ public class RequestBuilderTest {
     assertThat(b.options).isNull();
   }
 
-  @Test public void streamDoesNotUseBoundsDecoding() {
-    for (Request.Type type : Request.Type.values()) {
-      RequestBuilder b = new RequestBuilder(null, "", type).resize(10, 10);
-      assertThat(b.options.inJustDecodeBounds).isEqualTo(type != Request.Type.NETWORK);
-    }
-  }
-
   @Test public void invalidResize() {
     try {
       new RequestBuilder().resize(-1, 10);

--- a/picasso/src/test/java/com/squareup/picasso/TargetRequestTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/TargetRequestTest.java
@@ -1,6 +1,7 @@
 package com.squareup.picasso;
 
 import android.graphics.Bitmap;
+import android.net.Uri;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -11,6 +12,8 @@ import static org.junit.Assert.fail;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class TargetRequestTest {
+  private static final Uri URL = Uri.parse("http://example.com/1.png");
+
   @Test public void recyclingInSuccessThrowsException() {
     Target recycler = new Target() {
       @Override public void onSuccess(Bitmap bitmap) {
@@ -21,8 +24,7 @@ public class TargetRequestTest {
         throw new AssertionError();
       }
     };
-    TargetRequest tr =
-        new TargetRequest(null, null, 0, recycler, false, null, null, null, false);
+    TargetRequest tr = new TargetRequest(null, URL, 0, recycler, false, null, null, false);
     tr.result = Bitmap.createBitmap(10, 10, null);
     try {
       tr.complete();

--- a/picasso/src/test/java/com/squareup/picasso/UrlConnectionLoaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UrlConnectionLoaderTest.java
@@ -1,6 +1,7 @@
 package com.squareup.picasso;
 
 import android.app.Activity;
+import android.net.Uri;
 import com.google.mockwebserver.MockResponse;
 import com.google.mockwebserver.MockWebServer;
 import com.google.mockwebserver.RecordedRequest;
@@ -21,6 +22,8 @@ import static org.fest.assertions.api.Assertions.assertThat;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class UrlConnectionLoaderTest {
+  private static final Uri URL = Uri.parse("/bees.gif");
+
   private MockWebServer server;
   private UrlConnectionLoader loader;
 
@@ -44,12 +47,12 @@ public class UrlConnectionLoaderTest {
     UrlConnectionLoader.cache = null;
 
     server.enqueue(new MockResponse());
-    loader.load("/", false);
+    loader.load(URL, false);
     Object cache = UrlConnectionLoader.cache;
     assertThat(cache).isNotNull();
 
     server.enqueue(new MockResponse());
-    loader.load("/", false);
+    loader.load(URL, false);
     assertThat(UrlConnectionLoader.cache).isSameAs(cache);
   }
 
@@ -58,7 +61,7 @@ public class UrlConnectionLoaderTest {
     UrlConnectionLoader.cache = null;
 
     server.enqueue(new MockResponse());
-    loader.load("/", false);
+    loader.load(URL, false);
     Object cache = UrlConnectionLoader.cache;
     assertThat(cache).isNull();
   }
@@ -66,12 +69,12 @@ public class UrlConnectionLoaderTest {
   @Config(reportSdk = GINGERBREAD)
   @Test public void allowExpiredSetsCacheControl() throws Exception {
     server.enqueue(new MockResponse());
-    loader.load("/", false);
+    loader.load(URL, false);
     RecordedRequest request1 = server.takeRequest();
     assertThat(request1.getHeader("Cache-Control")).isNull();
 
     server.enqueue(new MockResponse());
-    loader.load("/", true);
+    loader.load(URL, true);
     RecordedRequest request2 = server.takeRequest();
     assertThat(request2.getHeader("Cache-Control")).isEqualTo("only-if-cached");
   }
@@ -79,11 +82,11 @@ public class UrlConnectionLoaderTest {
   @Config(reportSdk = GINGERBREAD)
   @Test public void responseSourceHeaderSetsResponseValue() throws Exception {
     server.enqueue(new MockResponse());
-    Loader.Response response1 = loader.load("/", false);
+    Loader.Response response1 = loader.load(URL, false);
     assertThat(response1.cached).isFalse();
 
     server.enqueue(new MockResponse().addHeader(RESPONSE_SOURCE, "CACHE 200"));
-    Loader.Response response2 = loader.load("/", true);
+    Loader.Response response2 = loader.load(URL, true);
     assertThat(response2.cached).isTrue();
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -1,7 +1,7 @@
 package com.squareup.picasso;
 
+import android.net.Uri;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,32 +16,31 @@ import static org.mockito.Mockito.mock;
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class UtilsTest {
-  private static final String URL = "http://example.com/a.png";
-  private static final List<Transformation> NONE = Collections.emptyList();
+  private static final Uri URL = Uri.parse("http://example.com/a.png");
 
   private Picasso picasso = mock(Picasso.class);
 
   @Test public void matchingRequestsHaveSameKey() {
-    Request r1 = new Request(picasso, URL, 0, null, null, NONE, null, false, false, 0, null);
-    Request r2 = new Request(picasso, URL, 0, null, null, NONE, null, false, false, 0, null);
+    Request r1 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null);
+    Request r2 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null);
     assertThat(createKey(r1)).isEqualTo(createKey(r2));
 
     List<Transformation> t1 = new ArrayList<Transformation>();
     t1.add(new TestTransformation("foo", null));
-    Request single1 = new Request(picasso, URL, 0, null, null, t1, null, false, false, 0, null);
+    Request single1 = new Request(picasso, URL, 0, null, null, t1, false, false, 0, null);
     List<Transformation> t2 = new ArrayList<Transformation>();
     t2.add(new TestTransformation("foo", null));
-    Request single2 = new Request(picasso, URL, 0, null, null, t2, null, false, false, 0, null);
+    Request single2 = new Request(picasso, URL, 0, null, null, t2, false, false, 0, null);
     assertThat(createKey(single1)).isEqualTo(createKey(single2));
 
     List<Transformation> t3 = new ArrayList<Transformation>();
     t3.add(new TestTransformation("foo", null));
     t3.add(new TestTransformation("bar", null));
-    Request double1 = new Request(picasso, URL, 0, null, null, t3, null, false, false, 0, null);
+    Request double1 = new Request(picasso, URL, 0, null, null, t3, false, false, 0, null);
     List<Transformation> t4 = new ArrayList<Transformation>();
     t4.add(new TestTransformation("foo", null));
     t4.add(new TestTransformation("bar", null));
-    Request double2 = new Request(picasso, URL, 0, null, null, t4, null, false, false, 0, null);
+    Request double2 = new Request(picasso, URL, 0, null, null, t4, false, false, 0, null);
     assertThat(createKey(double1)).isEqualTo(createKey(double2));
 
     List<Transformation> t5 = new ArrayList<Transformation>();
@@ -51,8 +50,8 @@ public class UtilsTest {
     List<Transformation> t6 = new ArrayList<Transformation>();
     t6.add(new TestTransformation("bar", null));
     t6.add(new TestTransformation("foo", null));
-    Request order1 = new Request(picasso, URL, 0, null, null, t5, null, false, false, 0, null);
-    Request order2 = new Request(picasso, URL, 0, null, null, t6, null, false, false, 0, null);
+    Request order1 = new Request(picasso, URL, 0, null, null, t5, false, false, 0, null);
+    Request order2 = new Request(picasso, URL, 0, null, null, t6, false, false, 0, null);
     assertThat(createKey(order1)).isNotEqualTo(createKey(order2));
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.squareup.picasso</groupId>
   <artifactId>picasso-parent</artifactId>
-  <version>1.0.3-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Picasso (Parent)</name>


### PR DESCRIPTION
Nothing revolutionary but it kills the enum.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Picasso (Parent) .................................. SUCCESS [0.711s]
[INFO] Picasso ........................................... SUCCESS [10.222s]
[INFO] Picasso Sample .................................... SUCCESS [7.087s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 18.998s
[INFO] Finished at: Sat May 25 03:36:16 PDT 2013
[INFO] Final Memory: 36M/217M
[INFO] ------------------------------------------------------------------------
```
