### PR TITLE
Use the StatsHandler

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Stats.java
+++ b/picasso/src/main/java/com/squareup/picasso/Stats.java
@@ -33,7 +33,7 @@ class Stats {
     this.cache = cache;
     HandlerThread statsThread = new HandlerThread(STATS_THREAD_NAME, THREAD_PRIORITY_BACKGROUND);
     statsThread.start();
-    handler = new Handler(statsThread.getLooper());
+    handler = new StatsHandler(statsThread.getLooper());
   }
 
   void bitmapDecoded(Bitmap bitmap) {


### PR DESCRIPTION
It doesn't look like you're using the `StatsHandler` class anywhere. This has the effect that cache hits and misses aren't counted. Sizes are still incremented, which is maybe why it was overlooked.
