### PR TITLE
Drop the decode lock on stream handling.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -268,9 +268,7 @@ public class Picasso {
       // Ensure we are not doing only a bounds decode.
       bitmapOptions.inJustDecodeBounds = false;
     }
-    synchronized (DECODE_LOCK) {
-      return BitmapFactory.decodeStream(stream, null, bitmapOptions);
-    }
+    return BitmapFactory.decodeStream(stream, null, bitmapOptions);
   }
 
   Bitmap decodeContentStream(Uri path, PicassoBitmapOptions bitmapOptions) throws IOException {
@@ -279,9 +277,7 @@ public class Picasso {
       BitmapFactory.decodeStream(contentResolver.openInputStream(path), null, bitmapOptions);
       calculateInSampleSize(bitmapOptions);
     }
-    synchronized (DECODE_LOCK) {
-      return BitmapFactory.decodeStream(contentResolver.openInputStream(path), null, bitmapOptions);
-    }
+    return BitmapFactory.decodeStream(contentResolver.openInputStream(path), null, bitmapOptions);
   }
 
   Bitmap decodeResource(Resources resources, int resourceId, PicassoBitmapOptions bitmapOptions) {
@@ -289,9 +285,7 @@ public class Picasso {
       BitmapFactory.decodeResource(resources, resourceId, bitmapOptions);
       calculateInSampleSize(bitmapOptions);
     }
-    synchronized (DECODE_LOCK) {
-      return BitmapFactory.decodeResource(resources, resourceId, bitmapOptions);
-    }
+    return BitmapFactory.decodeResource(resources, resourceId, bitmapOptions);
   }
 
   private void cancelExistingRequest(Object target, Uri uri) {


### PR DESCRIPTION
This lock was actually detremental to the speed since we piped streams directly to the Bitmap decoder rather than through an intermediary byte array. Thus we potentially blocked all bitmap decoding while waiting on a single stream.

Only lock decoding from Bitmap to Bitmap since that is where the real potential to OOM exists.

Closes #49.
