### PR TITLE
Loading contact photos - Bug fixes

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -234,11 +234,10 @@ final class Utils {
 
   public static InputStream getContactPhotoStream(ContentResolver contentResolver, Uri uri) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-      final Uri contactUri = uri.toString().startsWith(
-          ContactsContract.Contacts.CONTENT_LOOKUP_URI.toString())
-        ? ContactsContract.Contacts.lookupContact(contentResolver, uri)
-        : uri;
-      return openContactPhotoInputStream(contentResolver, contactUri);
+      if (uri.toString().startsWith(ContactsContract.Contacts.CONTENT_LOOKUP_URI.toString()))
+        uri = ContactsContract.Contacts.lookupContact(contentResolver, uri);
+
+      return openContactPhotoInputStream(contentResolver, uri);
     } else {
       return ContactPhotoStreamIcs.get(contentResolver, uri);
     }


### PR DESCRIPTION
I was experiencing a crash on Gingerbread devices. Turns out the GB version of the  openContactPhotoInputStream method does not like lookup style Uris. If the incoming Uri is a lookup Uri, I'm converting it to an actual contact uri before processing.
This is a blocking process, so I've left the de-referencing in Utils.getContactPhotoStream.
