### PR TITLE
Add RewindInputStream for inSampleSize decoding of HTTP.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RewindInputStream.java
+++ b/picasso/src/main/java/com/squareup/picasso/RewindInputStream.java
@@ -1,0 +1,154 @@
+package com.squareup.picasso;
+
+import android.util.Log;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.jetbrains.annotations.TestOnly;
+
+/**
+ * An {@link InputStream} wrapper which buffers all reads until {@link #rewind()} is called at
+ * which point it replays the data from the beginning.
+ */
+final class RewindInputStream extends InputStream {
+  private static final int DEFAULT_BUFFER_SIZE = 4096;
+  private static final boolean DEBUG = false;
+  private static final String TAG = "RewindInputStream";
+
+  /** A {@link ByteArrayOutputStream} which directly returns the underlying buffer. */
+  private static class CopyFreeByteArrayOutputStream extends ByteArrayOutputStream {
+    public CopyFreeByteArrayOutputStream(int bufferSize) {
+      super(bufferSize);
+    }
+
+    @Override public byte[] toByteArray() {
+      return buf;
+    }
+  }
+
+  private final ByteArrayOutputStream buffer;
+  private final InputStream original;
+  private boolean replaying;
+  byte[] bufferData;
+  int bufferLength;
+  int bufferPosition;
+
+  public RewindInputStream(InputStream original) {
+    this(original, DEFAULT_BUFFER_SIZE);
+  }
+
+  @TestOnly RewindInputStream(InputStream original, int bufferSize) {
+    this.original = original;
+    this.buffer = new CopyFreeByteArrayOutputStream(bufferSize);
+  }
+
+  /**
+   * Replay any buffered data on subsequent reads until exhausted and then fall back to the
+   * original stream.
+   */
+  public void rewind() {
+    if (replaying) {
+      throw new IllegalStateException("Rewind may only be called once.");
+    }
+    if (DEBUG) log("> rewind()");
+
+    replaying = true;
+    bufferData = buffer.toByteArray();
+    bufferLength = buffer.size();
+    bufferPosition = 0;
+
+    if (DEBUG) log("  bufferLength: %s", bufferLength);
+  }
+
+  @Override public int read() throws IOException {
+    final int bits;
+    if (replaying) {
+      if (bufferPosition < bufferLength) {
+        bits = bufferData[bufferPosition++];
+      } else {
+        bits = original.read();
+      }
+    } else {
+      bits = original.read();
+      buffer.write(bits);
+    }
+    return bits;
+  }
+
+  @Override public int read(byte[] b, int offset, int length) throws IOException {
+    if (DEBUG) log("> read(byte[], offset=%s, length=%s)", offset, length);
+    int given = 0;
+
+    if (replaying) {
+      // Number of bytes the buffer wants starting at offset.
+      int want = length - offset;
+      // Number of bytes the rewind buffer still has.
+      int have = bufferLength - bufferPosition;
+
+      if (DEBUG) log("  want=%s, have=%s", want, have);
+
+      if (have > 0) {
+        // Ensure we don't copy more than the buffer wants.
+        have = Math.min(have, want);
+
+        System.arraycopy(bufferData, bufferPosition, b, offset, have);
+        if (DEBUG) log("  Buffer at %s into %s for %s, got %s", bufferPosition, offset, have, have);
+
+        bufferPosition += have;
+        want -= have;
+        given += have;
+        if (DEBUG) log("    New: bufferPosition=%s, want=%s", bufferPosition, want);
+
+        // Adjust the view into the output buffer in case we try to fill from the original as well.
+        offset += have;
+        length -= have;
+        if (DEBUG) log("    New: offset=%s, length=%s", offset, length);
+      }
+
+      if (want > 0) {
+        given += original.read(b, offset, length);
+        if (DEBUG) log("  Real into %s for %s, got=%s", offset, length, (given - have));
+      }
+    } else {
+      given = original.read(b, offset, length);
+      if (DEBUG) log("  Real into %s for %s, got=%s", offset, length, given);
+
+      buffer.write(b, offset, given);
+      if (DEBUG) log("  Buffer write of %s to size=%s", (given - offset), buffer.size());
+    }
+
+    return given;
+  }
+
+  @Override public long skip(long count) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public int available() throws IOException {
+    int available = original.available();
+    if (replaying) {
+      available += (bufferLength - bufferPosition);
+    }
+    return available;
+  }
+
+  @Override public void close() throws IOException {
+    original.close();
+  }
+
+  @Override public synchronized void mark(int readLimit) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public synchronized void reset() throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override public boolean markSupported() {
+    return false;
+  }
+
+  private void log(String message, Object... args) {
+    Log.d(TAG, "{" + Integer.toHexString(hashCode()) + "} " + String.format(message, args));
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -48,6 +48,13 @@ final class Utils {
     // No instances.
   }
 
+  static void closeQuietly(InputStream stream) {
+    try {
+      stream.close();
+    } catch (IOException ignored) {
+    }
+  }
+
   static int getContentProviderExifRotation(ContentResolver contentResolver, Uri uri) {
     Cursor cursor = null;
     try {

--- a/picasso/src/test/java/com/squareup/picasso/RewindInputStreamTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RewindInputStreamTest.java
@@ -1,0 +1,95 @@
+package com.squareup.picasso;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.fest.assertions.api.StringAssert;
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+@SuppressWarnings("ResultOfMethodCallIgnored") //
+public class RewindInputStreamTest {
+  @Test public void oneReadBuffered() throws IOException {
+    ByteArrayInputStream in = new ByteArrayInputStream(bytes("FOO"));
+    RewindInputStream ris = new RewindInputStream(in, 10);
+    byte[] buffer = new byte[3];
+
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("FOO");
+
+    ris.rewind();
+
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("FOO");
+  }
+
+  @Test public void twoReadsBuffered() throws IOException {
+    ByteArrayInputStream in = new ByteArrayInputStream(bytes("FOOBAR"));
+    RewindInputStream ris = new RewindInputStream(in, 10);
+    byte[] buffer = new byte[3];
+
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("FOO");
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("BAR");
+
+    ris.rewind();
+
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("FOO");
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("BAR");
+  }
+
+  @Test public void multipleBufferedReads() throws IOException {
+    ByteArrayInputStream in = new ByteArrayInputStream(bytes("FOOBARBAZFIZ"));
+    RewindInputStream ris = new RewindInputStream(in, 20);
+    byte[] buffer = new byte[3];
+
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("FOO");
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("BAR");
+
+    ris.rewind();
+
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("FOO");
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("BAR");
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("BAZ");
+    ris.read(buffer);
+    assertBytes(buffer).isEqualTo("FIZ");
+  }
+
+  @Test public void bufferedReadCrossingBoundary() throws IOException {
+    ByteArrayInputStream in = new ByteArrayInputStream(bytes("FOOBARBAZFIZ"));
+    RewindInputStream ris = new RewindInputStream(in, 20);
+
+    byte[] buffer1 = new byte[3];
+    ris.read(buffer1);
+    assertBytes(buffer1).isEqualTo("FOO");
+    ris.read(buffer1);
+    assertBytes(buffer1).isEqualTo("BAR");
+
+    ris.rewind();
+
+    byte[] buffer2 = new byte[4];
+    ris.read(buffer2);
+    assertBytes(buffer2).isEqualTo("FOOB");
+    ris.read(buffer2);
+    assertBytes(buffer2).isEqualTo("ARBA");
+    ris.read(buffer2);
+    assertBytes(buffer2).isEqualTo("ZFIZ");
+  }
+
+  private static byte[] bytes(String data) {
+    return data.getBytes(Charset.forName("UTF-8"));
+  }
+
+  private static StringAssert assertBytes(byte[] bytes) {
+    return assertThat(new String(bytes, Charset.forName("UTF-8")));
+  }
+}


### PR DESCRIPTION
Since HTTP streams can only be read once we were previously unable to do inSampleSize decoding on them. This pulls introduces an input stream delegate which buffers the first read into memory. It can then be told to rewind so that the second read (doing the full decode) get the entire stream.

Closes #12.
