### PR TITLE
Add ability to query the local cache only

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -349,7 +349,7 @@ public class Picasso {
       } else {
         Response response = null;
         try {
-          response = loader.load(uri, request.retryCount == 0);
+          response = loader.load(uri, request.retryCount == 0 || request.localCacheOnly);
           if (response == null) {
             return null;
           }

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -34,6 +34,7 @@ class Request implements Runnable {
   final PicassoBitmapOptions options;
   final List<Transformation> transformations;
   final boolean skipCache;
+  final boolean localCacheOnly;
   final boolean noFade;
   final int errorResId;
   final Drawable errorDrawable;
@@ -46,8 +47,8 @@ class Request implements Runnable {
   boolean retryCancelled;
 
   Request(Picasso picasso, Uri uri, int resourceId, ImageView imageView,
-      PicassoBitmapOptions options, List<Transformation> transformations, boolean skipCache,
-      boolean noFade, int errorResId, Drawable errorDrawable) {
+          PicassoBitmapOptions options, List<Transformation> transformations, boolean skipCache,
+          boolean localCacheOnly, boolean noFade, int errorResId, Drawable errorDrawable) {
     this.picasso = picasso;
     this.uri = uri;
     this.resourceId = resourceId;
@@ -55,6 +56,7 @@ class Request implements Runnable {
     this.options = options;
     this.transformations = transformations;
     this.skipCache = skipCache;
+    this.localCacheOnly = localCacheOnly;
     this.noFade = noFade;
     this.errorResId = errorResId;
     this.errorDrawable = errorDrawable;

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -24,6 +24,7 @@ public class RequestBuilder {
   PicassoBitmapOptions options;
   private List<Transformation> transformations;
   private boolean skipCache;
+  private boolean localCacheOnly;
   private boolean noFade;
   private boolean hasNullPlaceholder;
   private int placeholderResId;
@@ -263,7 +264,24 @@ public class RequestBuilder {
    * an image from the filesystem and uploading to a remote server).
    */
   public RequestBuilder skipCache() {
+    if (localCacheOnly) {
+      throw new IllegalStateException("Cannot skip the cache for requests against the local cache only.");
+    }
+
     skipCache = true;
+    return this;
+  }
+
+  /**
+   * For network loads indicates that this request should only try to load from the local memory
+   * and disk caches and not initiate any network requests.
+   */
+  public RequestBuilder localCacheOnly() {
+    if (skipCache) {
+      throw new IllegalStateException("Cannot specify local cache only for requests specified to skip cache.");
+    }
+
+    localCacheOnly = true;
     return this;
   }
 
@@ -277,8 +295,8 @@ public class RequestBuilder {
   public Bitmap get() throws IOException {
     checkNotMain();
     Request request =
-        new Request(picasso, uri, resourceId, null, options, transformations, skipCache, false, 0,
-            null);
+        new Request(picasso, uri, resourceId, null, options, transformations, skipCache, localCacheOnly,
+          false, 0, null);
     return picasso.resolveRequest(request);
   }
 
@@ -328,8 +346,8 @@ public class RequestBuilder {
     }
 
     Request request =
-        new Request(picasso, uri, resourceId, target, options, transformations, skipCache, noFade,
-            errorResId, errorDrawable);
+        new Request(picasso, uri, resourceId, target, options, transformations, skipCache, localCacheOnly,
+          noFade, errorResId, errorDrawable);
     picasso.submit(request);
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
+++ b/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
@@ -11,7 +11,7 @@ final class TargetRequest extends Request {
 
   TargetRequest(Picasso picasso, Uri uri, int resourceId, Target target, boolean strong,
       PicassoBitmapOptions bitmapOptions, List<Transformation> transformations, boolean skipCache) {
-    super(picasso, uri, resourceId, null, bitmapOptions, transformations, skipCache, false, 0,
+    super(picasso, uri, resourceId, null, bitmapOptions, transformations, skipCache, false, false, 0,
         null);
     this.weakTarget = strong ? null : new WeakReference<Target>(target);
     this.strongTarget = strong ? target : null;

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -422,7 +422,7 @@ public class PicassoTest {
 
     Picasso picasso = create(LOADER_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, URI_1, 0, target, null, null, false, false, false, 0, errorDrawable);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -438,7 +438,7 @@ public class PicassoTest {
 
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, FILE_1_URL, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, FILE_1_URL, 0, target, null, null, false, false, false, 0, errorDrawable);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -454,7 +454,7 @@ public class PicassoTest {
 
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, false, 0, errorDrawable);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -469,7 +469,7 @@ public class PicassoTest {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
 
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, false, 0, null);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -483,7 +483,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, Uri.fromFile(FILE_1), 0, target, null, null, false, false, 0, null);
+        new Request(picasso, Uri.fromFile(FILE_1), 0, target, null, null, false, false, false, 0, null);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -499,7 +499,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, null);
+        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, false, 0, null);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -514,7 +514,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, URI_1, 0, target, null, null, false, false, false, 0, errorDrawable);
 
     retryRequest(picasso, request);
     verify(target).setImageDrawable(errorDrawable);
@@ -526,7 +526,7 @@ public class PicassoTest {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
 
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, false, 0, null);
 
     retryRequest(picasso, request);
     assertThat(picasso.targetsToRequests).isEmpty();
@@ -700,7 +700,7 @@ public class PicassoTest {
     transformations.add(resize);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null);
+        new Request(picasso, URI_1, 0, target, null, transformations, false, false, false, 0, null);
     picasso.submit(request);
 
     executor.flush();
@@ -751,7 +751,7 @@ public class PicassoTest {
     transformations.add(resize);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null);
+        new Request(picasso, URI_1, 0, target, null, transformations, false, false, false, 0, null);
     picasso.submit(request);
 
     executor.flush();
@@ -762,6 +762,17 @@ public class PicassoTest {
     inOrder.verify(resize).transform(any(Bitmap.class));
 
     assertThat(picasso.targetsToRequests).isEmpty();
+  }
+
+  @Test public void verifyLocalCacheOnlyCorrectLoaderCall() throws Exception {
+    ImageView target = mock(ImageView.class);
+
+    Picasso picasso = create(LOADER_ANSWER, BITMAP1_ANSWER);
+    picasso.load(URI_1).localCacheOnly().into(target);
+    executor.flush();
+
+    verify(loader).load(URI_1, true);
+    verifyNoMoreInteractions(loader);
   }
 
   @Test public void whenRequestSkipsCacheDoesNotCache() throws Exception {
@@ -888,7 +899,7 @@ public class PicassoTest {
   @Test public void cancelRequestBeforeExecution() throws Exception {
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, false, 0, null);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -914,7 +925,7 @@ public class PicassoTest {
   @Test public void cancelRequestBetweenRetries() throws Exception {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, NULL_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, false, 0, null);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -931,7 +942,7 @@ public class PicassoTest {
   @Test public void cancelRequestAfterResult() throws Exception {
     Picasso picasso = create(LOADER_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, false, 0, null);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     pauseMainLooper();

--- a/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
@@ -168,4 +168,20 @@ public class RequestBuilderTest {
     } catch (IllegalArgumentException expected) {
     }
   }
+
+  @Test public void invalidCacheCombination() {
+    try {
+      new RequestBuilder().localCacheOnly().skipCache();
+      fail("Skip cache after local cache only should throw exception.");
+    }
+    catch (IllegalStateException expected) {
+    }
+
+    try {
+      new RequestBuilder().skipCache().localCacheOnly();
+      fail("Local cache only after skip cache should throw exception.");
+    }
+    catch (IllegalStateException expected) {
+    }
+  }
 }

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -21,26 +21,26 @@ public class UtilsTest {
   private Picasso picasso = mock(Picasso.class);
 
   @Test public void matchingRequestsHaveSameKey() {
-    Request r1 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null);
-    Request r2 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null);
+    Request r1 = new Request(picasso, URL, 0, null, null, null, false, false, false, 0, null);
+    Request r2 = new Request(picasso, URL, 0, null, null, null, false, false, false, 0, null);
     assertThat(createKey(r1)).isEqualTo(createKey(r2));
 
     List<Transformation> t1 = new ArrayList<Transformation>();
     t1.add(new TestTransformation("foo", null));
-    Request single1 = new Request(picasso, URL, 0, null, null, t1, false, false, 0, null);
+    Request single1 = new Request(picasso, URL, 0, null, null, t1, false, false, false, 0, null);
     List<Transformation> t2 = new ArrayList<Transformation>();
     t2.add(new TestTransformation("foo", null));
-    Request single2 = new Request(picasso, URL, 0, null, null, t2, false, false, 0, null);
+    Request single2 = new Request(picasso, URL, 0, null, null, t2, false, false, false, 0, null);
     assertThat(createKey(single1)).isEqualTo(createKey(single2));
 
     List<Transformation> t3 = new ArrayList<Transformation>();
     t3.add(new TestTransformation("foo", null));
     t3.add(new TestTransformation("bar", null));
-    Request double1 = new Request(picasso, URL, 0, null, null, t3, false, false, 0, null);
+    Request double1 = new Request(picasso, URL, 0, null, null, t3, false, false, false, 0, null);
     List<Transformation> t4 = new ArrayList<Transformation>();
     t4.add(new TestTransformation("foo", null));
     t4.add(new TestTransformation("bar", null));
-    Request double2 = new Request(picasso, URL, 0, null, null, t4, false, false, 0, null);
+    Request double2 = new Request(picasso, URL, 0, null, null, t4, false, false, false, 0, null);
     assertThat(createKey(double1)).isEqualTo(createKey(double2));
 
     List<Transformation> t5 = new ArrayList<Transformation>();
@@ -50,8 +50,8 @@ public class UtilsTest {
     List<Transformation> t6 = new ArrayList<Transformation>();
     t6.add(new TestTransformation("bar", null));
     t6.add(new TestTransformation("foo", null));
-    Request order1 = new Request(picasso, URL, 0, null, null, t5, false, false, 0, null);
-    Request order2 = new Request(picasso, URL, 0, null, null, t6, false, false, 0, null);
+    Request order1 = new Request(picasso, URL, 0, null, null, t5, false, false, false, 0, null);
+    Request order2 = new Request(picasso, URL, 0, null, null, t6, false, false, false, 0, null);
     assertThat(createKey(order1)).isNotEqualTo(createKey(order2));
   }
 


### PR DESCRIPTION
This resolves #80 by adding `localCacheOnly` as an option which is passed down to the loader.
