### PR TITLE
Reduce image target width and height by 2 recursively on OutOfMemmoryError

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -47,7 +47,7 @@ public class Picasso {
    */
   private static final Object DECODE_LOCK = new Object();
 
-    /** Callbacks for Picasso events. */
+  /** Callbacks for Picasso events. */
   public interface Listener {
     /**
      * Invoked when an image has failed to load. This is useful for reporting image failures to a
@@ -240,11 +240,17 @@ public class Picasso {
       try {
         bitmap = loadFromType(request);
       } catch (OutOfMemoryError e) {
-         if (request.options != null && request.options.targetHeight > DECODE_MINIMAL_SIZE && request.options.targetWidth > DECODE_MINIMAL_SIZE) {
-            request.options.targetHeight = request.options.targetHeight / 2;
-            request.options.targetWidth = request.options.targetWidth / 2;
-            request.options.inJustDecodeBounds = true;
+        PicassoBitmapOptions options = request.options;
+        if (options != null) {
+          int targetHeight = options.targetHeight;
+          int targetWidth = options.targetWidth;
+          if (targetHeight > DECODE_MINIMAL_SIZE && targetWidth > DECODE_MINIMAL_SIZE) {
+            options.targetHeight = targetHeight / 2;
+            options.targetWidth = targetWidth / 2;
+            options.inJustDecodeBounds = true;
+
             return resolveRequest(request);
+          }
          } else {
           throw new IOException("Failed to decode request: " + request, e);
         }


### PR DESCRIPTION
Discussion of problem here: https://plus.google.com/u/0/114377082157285747246/posts/cZFan3pLhiN
