### PR TITLE
Catch a more general exception when checking for rotation from content resolver

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -71,7 +71,7 @@ final class Utils {
         return 0;
       }
       return cursor.getInt(0);
-    } catch (IllegalArgumentException ignored) {
+    } catch (RuntimeException ignored) {
       // If the orientation column doesn't exist, assume no rotation.
       return 0;
     } finally {


### PR DESCRIPTION
The behaviour of a content provider when it is queried for a column that does
not exist is not well defined. Content providers can throw any one of the
exceptions defined in Parcel as well as a number SQLiteExceptions via
DatabaseUtils.readException()/.writeException(). The native Android content
provider will throw an SQLiteException if the orientation column is not found.

Fix for issue #88

Look, I know catching such a general exception is not ideal... but at the moment catching an IllegalArgumentException just does not work at all. What I would suggest in the future is adding a "noAutoRotate(boolean)" or something like that to requests. There are cases where the user knows that the file/uri does not need rotating and specifying that could save an extra IO operation.
