### PR TITLE
Allow preferHighRes config

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -393,7 +393,8 @@ public class Picasso {
         ContentResolver contentResolver = context.getContentResolver();
         if (Contacts.CONTENT_URI.getHost().equals(uri.getHost()) //
             && !uri.getPathSegments().contains(Contacts.Photo.CONTENT_DIRECTORY)) {
-          InputStream contactStream = Utils.getContactPhotoStream(contentResolver, uri);
+          InputStream contactStream = Utils.getContactPhotoStream(contentResolver, uri,
+              request.preferHighRes);
           result = decodeStream(contactStream, options);
         } else {
           exifRotation = Utils.getContentProviderExifRotation(contentResolver, uri);

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -63,6 +63,7 @@ class Request implements Runnable {
   final int errorResId;
   final Drawable errorDrawable;
   final String key;
+  final boolean preferHighRes;
 
   Future<?> future;
   Bitmap result;
@@ -72,7 +73,7 @@ class Request implements Runnable {
 
   Request(Picasso picasso, Uri uri, int resourceId, ImageView imageView,
       PicassoBitmapOptions options, List<Transformation> transformations, boolean skipCache,
-      boolean noFade, int errorResId, Drawable errorDrawable) {
+      boolean noFade, int errorResId, Drawable errorDrawable, boolean preferHighRes) {
     this.picasso = picasso;
     this.uri = uri;
     this.resourceId = resourceId;
@@ -85,6 +86,7 @@ class Request implements Runnable {
     this.errorDrawable = errorDrawable;
     this.retryCount = DEFAULT_RETRY_COUNT;
     this.key = createKey(this);
+    this.preferHighRes = preferHighRes;
   }
 
   Object getTarget() {

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -45,17 +45,20 @@ public class RequestBuilder {
   private Drawable placeholderDrawable;
   private int errorResId;
   private Drawable errorDrawable;
+  private boolean preferHighRes;
 
   RequestBuilder(Picasso picasso, Uri uri, int resourceId) {
     this.picasso = picasso;
     this.uri = uri;
     this.resourceId = resourceId;
+    this.preferHighRes = true;
   }
 
   @TestOnly RequestBuilder() {
     this.picasso = null;
     this.uri = null;
     this.resourceId = 0;
+    this.preferHighRes = true;
   }
 
   private PicassoBitmapOptions getOptions() {
@@ -288,6 +291,15 @@ public class RequestBuilder {
     return this;
   }
 
+  /**
+   * This request should fetch a contact thumbnail instead of a high resolution picture whenever
+   * possible.
+   */
+  public RequestBuilder preferThumbnail() {
+    preferHighRes = false;
+    return this;
+  }
+
   /** Synchronously fulfill this request. Must not be called from the main thread. */
   public Bitmap get() throws IOException {
     checkNotMain();
@@ -298,7 +310,7 @@ public class RequestBuilder {
 
     Request request =
         new Request(picasso, uri, resourceId, null, options, transformations, skipCache, false, 0,
-            null);
+            null, preferHighRes);
     return picasso.resolveRequest(request);
   }
 
@@ -355,7 +367,7 @@ public class RequestBuilder {
     if (hasItemToLoad) {
       Request request =
           new Request(picasso, uri, resourceId, target, options, transformations, skipCache, noFade,
-              errorResId, errorDrawable);
+              errorResId, errorDrawable, preferHighRes);
       picasso.submit(request);
     } else {
       picasso.cancelRequest(target);
@@ -380,7 +392,7 @@ public class RequestBuilder {
 
     Request request =
         new TargetRequest(picasso, uri, resourceId, target, strong, options, transformations,
-            skipCache);
+            skipCache, preferHighRes);
     picasso.submit(request);
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
+++ b/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
@@ -25,9 +25,10 @@ final class TargetRequest extends Request {
   private final Target strongTarget;
 
   TargetRequest(Picasso picasso, Uri uri, int resourceId, Target target, boolean strong,
-      PicassoBitmapOptions bitmapOptions, List<Transformation> transformations, boolean skipCache) {
+      PicassoBitmapOptions bitmapOptions, List<Transformation> transformations, boolean skipCache,
+      boolean preferHighRes) {
     super(picasso, uri, resourceId, null, bitmapOptions, transformations, skipCache, false, 0,
-        null);
+        null, preferHighRes);
     this.weakTarget =
         strong ? null : new WeakReference<Target>(target, picasso.referenceQueue);
     this.strongTarget = strong ? target : null;

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -256,7 +256,8 @@ final class Utils {
     return Math.min(size, MAX_MEM_CACHE_SIZE);
   }
 
-  public static InputStream getContactPhotoStream(ContentResolver contentResolver, Uri uri) {
+  public static InputStream getContactPhotoStream(ContentResolver contentResolver, Uri uri,
+      boolean preferHighRes) {
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
       if (uri.toString().startsWith(ContactsContract.Contacts.CONTENT_LOOKUP_URI.toString())) {
         uri = ContactsContract.Contacts.lookupContact(contentResolver, uri);
@@ -266,7 +267,7 @@ final class Utils {
       }
       return openContactPhotoInputStream(contentResolver, uri);
     } else {
-      return ContactPhotoStreamIcs.get(contentResolver, uri);
+      return ContactPhotoStreamIcs.get(contentResolver, uri, preferHighRes);
     }
   }
 
@@ -304,8 +305,8 @@ final class Utils {
 
   @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
   private static class ContactPhotoStreamIcs {
-    static InputStream get(ContentResolver contentResolver, Uri uri) {
-      return openContactPhotoInputStream(contentResolver, uri, true);
+    static InputStream get(ContentResolver contentResolver, Uri uri, boolean preferHighRes) {
+      return openContactPhotoInputStream(contentResolver, uri, preferHighRes);
     }
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -411,7 +411,7 @@ public class PicassoTest {
 
     Picasso picasso = create(LOADER_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable, false);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -427,7 +427,7 @@ public class PicassoTest {
 
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, FILE_1_URL, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, FILE_1_URL, 0, target, null, null, false, false, 0, errorDrawable, false);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -443,7 +443,7 @@ public class PicassoTest {
 
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Request request =
-        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, errorDrawable, false);
     request = spy(request);
     picasso.submit(request);
     executor.flush();
@@ -458,7 +458,7 @@ public class PicassoTest {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
 
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null, false);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -472,7 +472,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, Uri.fromFile(FILE_1), 0, target, null, null, false, false, 0, null);
+        new Request(picasso, Uri.fromFile(FILE_1), 0, target, null, null, false, false, 0, null, false);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -488,7 +488,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, null);
+        new Request(picasso, CONTENT_1_URL, 0, target, null, null, false, false, 0, null, false);
     request = spy(request);
 
     retryRequest(picasso, request);
@@ -503,7 +503,7 @@ public class PicassoTest {
     ImageView target = mock(ImageView.class);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable);
+        new Request(picasso, URI_1, 0, target, null, null, false, false, 0, errorDrawable, false);
 
     retryRequest(picasso, request);
     verify(target).setImageDrawable(errorDrawable);
@@ -515,7 +515,7 @@ public class PicassoTest {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
 
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null, false);
 
     retryRequest(picasso, request);
     assertThat(picasso.targetsToRequests).isEmpty();
@@ -554,7 +554,7 @@ public class PicassoTest {
 
   @Test public void whenTargetRequestFailsCleansUpTargetMap() throws Exception {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, BITMAP1_ANSWER);
-    Request request = new TargetRequest(picasso, URI_1, 0, null, false, null, null, false);
+    Request request = new TargetRequest(picasso, URI_1, 0, null, false, null, null, false, false);
 
     retryRequest(picasso, request);
     assertThat(picasso.targetsToRequests).isEmpty();
@@ -689,7 +689,7 @@ public class PicassoTest {
     transformations.add(resize);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null);
+        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null, false);
     picasso.submit(request);
 
     executor.flush();
@@ -740,7 +740,7 @@ public class PicassoTest {
     transformations.add(resize);
 
     Request request =
-        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null);
+        new Request(picasso, URI_1, 0, target, null, transformations, false, false, 0, null, false);
     picasso.submit(request);
 
     executor.flush();
@@ -877,7 +877,7 @@ public class PicassoTest {
   @Test public void cancelRequestBeforeExecution() throws Exception {
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null, false);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -890,7 +890,7 @@ public class PicassoTest {
   @Test public void cancelTargetRequestBeforeExecution() throws Exception {
     Picasso picasso = create(NULL_ANSWER, NULL_ANSWER);
     Target target = mock(Target.class);
-    Request request = new TargetRequest(picasso, URI_1, 0, target, true, null, null, false);
+    Request request = new TargetRequest(picasso, URI_1, 0, target, true, null, null, false, false);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -903,7 +903,7 @@ public class PicassoTest {
   @Test public void cancelRequestBetweenRetries() throws Exception {
     Picasso picasso = create(IO_EXCEPTION_ANSWER, NULL_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null, false);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     assertThat(request.future.isCancelled()).isFalse();
@@ -920,7 +920,7 @@ public class PicassoTest {
   @Test public void cancelRequestAfterResult() throws Exception {
     Picasso picasso = create(LOADER_ANSWER, BITMAP1_ANSWER);
     ImageView target = mock(ImageView.class);
-    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null);
+    Request request = new Request(picasso, URI_1, 0, target, null, null, false, false, 0, null, false);
     picasso.submit(request);
     assertThat(picasso.targetsToRequests).hasSize(1);
     pauseMainLooper();

--- a/picasso/src/test/java/com/squareup/picasso/TargetRequestTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/TargetRequestTest.java
@@ -41,7 +41,7 @@ public class TargetRequestTest {
       }
     };
     Picasso picasso = mock(Picasso.class);
-    TargetRequest tr = new TargetRequest(picasso, URL, 0, recycler, false, null, null, false);
+    TargetRequest tr = new TargetRequest(picasso, URL, 0, recycler, false, null, null, false, false);
     tr.result = Bitmap.createBitmap(10, 10, null);
     try {
       tr.complete();

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -36,26 +36,26 @@ public class UtilsTest {
   private Picasso picasso = mock(Picasso.class);
 
   @Test public void matchingRequestsHaveSameKey() {
-    Request r1 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null);
-    Request r2 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null);
+    Request r1 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null, false);
+    Request r2 = new Request(picasso, URL, 0, null, null, null, false, false, 0, null, false);
     assertThat(createKey(r1)).isEqualTo(createKey(r2));
 
     List<Transformation> t1 = new ArrayList<Transformation>();
     t1.add(new TestTransformation("foo", null));
-    Request single1 = new Request(picasso, URL, 0, null, null, t1, false, false, 0, null);
+    Request single1 = new Request(picasso, URL, 0, null, null, t1, false, false, 0, null, false);
     List<Transformation> t2 = new ArrayList<Transformation>();
     t2.add(new TestTransformation("foo", null));
-    Request single2 = new Request(picasso, URL, 0, null, null, t2, false, false, 0, null);
+    Request single2 = new Request(picasso, URL, 0, null, null, t2, false, false, 0, null, false);
     assertThat(createKey(single1)).isEqualTo(createKey(single2));
 
     List<Transformation> t3 = new ArrayList<Transformation>();
     t3.add(new TestTransformation("foo", null));
     t3.add(new TestTransformation("bar", null));
-    Request double1 = new Request(picasso, URL, 0, null, null, t3, false, false, 0, null);
+    Request double1 = new Request(picasso, URL, 0, null, null, t3, false, false, 0, null, false);
     List<Transformation> t4 = new ArrayList<Transformation>();
     t4.add(new TestTransformation("foo", null));
     t4.add(new TestTransformation("bar", null));
-    Request double2 = new Request(picasso, URL, 0, null, null, t4, false, false, 0, null);
+    Request double2 = new Request(picasso, URL, 0, null, null, t4, false, false, 0, null, false);
     assertThat(createKey(double1)).isEqualTo(createKey(double2));
 
     List<Transformation> t5 = new ArrayList<Transformation>();
@@ -65,8 +65,8 @@ public class UtilsTest {
     List<Transformation> t6 = new ArrayList<Transformation>();
     t6.add(new TestTransformation("bar", null));
     t6.add(new TestTransformation("foo", null));
-    Request order1 = new Request(picasso, URL, 0, null, null, t5, false, false, 0, null);
-    Request order2 = new Request(picasso, URL, 0, null, null, t6, false, false, 0, null);
+    Request order1 = new Request(picasso, URL, 0, null, null, t5, false, false, 0, null, false);
+    Request order2 = new Request(picasso, URL, 0, null, null, t6, false, false, 0, null, false);
     assertThat(createKey(order1)).isNotEqualTo(createKey(order2));
   }
 


### PR DESCRIPTION
High resolution contact pictures are not suitable to use as thumbnails, for example in contact lists. But, when API > 14, Picasso returns always a high res picture if possible. This PR features a new RequestBuilder method that allows user to fetch only contact thumbnails.
