### PR TITLE
Fixed StatFs bug occurring on some devices.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -235,14 +235,14 @@ final class Utils {
   }
 
   static int calculateDiskCacheSize(File dir) {
-  int size = 0;
+    int size = 0;
 
     try {
       StatFs statFs = new StatFs(dir.getAbsolutePath());
       int available = statFs.getBlockCount() * statFs.getBlockSize();
       // Target 2% of the total space.
       size = available / 50;
-    } catch(IllegalArgumentException e) {
+    } catch (IllegalArgumentException e) {
       // If can't access dir, assume min size.  
       size = MIN_DISK_CACHE_SIZE;
     }


### PR DESCRIPTION
Fixes IllegalArgumentException occurring on some devices.

`````` java.lang.IllegalArgumentException
at android.os.StatFs.native_setup(Native Method)
at android.os.StatFs.(StatFs.java:32)
at com.squareup.picasso.Utils.int calculateDiskCacheSize(java.io.File)(Unknown Source)```
``````
