### PR TITLE
Let worker threads check cache instead of dispatcher.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
@@ -33,9 +33,9 @@ class ContactsPhotoBitmapHunter extends BitmapHunter {
 
   final Context context;
 
-  ContactsPhotoBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher,
+  ContactsPhotoBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
       Request request) {
-    super(picasso, dispatcher, request);
+    super(picasso, dispatcher, cache, request);
     this.context = context;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/ContentProviderBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentProviderBitmapHunter.java
@@ -28,9 +28,9 @@ class ContentProviderBitmapHunter extends ContentStreamBitmapHunter {
   private static final String[] CONTENT_ORIENTATION =
       new String[] {MediaStore.Images.ImageColumns.ORIENTATION};
 
-  ContentProviderBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher,
+  ContentProviderBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
       Request request) {
-    super(context, picasso, dispatcher, request);
+    super(context, picasso, dispatcher, cache, request);
   }
 
   @Override Bitmap decode(Uri uri, PicassoBitmapOptions options) throws IOException {

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
@@ -29,9 +29,9 @@ class ContentStreamBitmapHunter extends BitmapHunter {
 
   final Context context;
 
-  ContentStreamBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher,
+  ContentStreamBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
       Request request) {
-    super(picasso, dispatcher, request);
+    super(picasso, dispatcher, cache, request);
     this.context = context;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/FileBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/FileBitmapHunter.java
@@ -29,8 +29,9 @@ import static android.media.ExifInterface.TAG_ORIENTATION;
 
 class FileBitmapHunter extends ContentStreamBitmapHunter {
 
-  FileBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Request request) {
-    super(context, picasso, dispatcher, request);
+  FileBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
+      Request request) {
+    super(context, picasso, dispatcher, cache, request);
   }
 
   @Override Bitmap decode(Uri uri, PicassoBitmapOptions options) throws IOException {

--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -30,9 +30,9 @@ class NetworkBitmapHunter extends BitmapHunter {
   private final Downloader downloader;
   private LoadedFrom loadedFrom;
 
-  public NetworkBitmapHunter(Picasso picasso, Dispatcher dispatcher, Request request,
+  public NetworkBitmapHunter(Picasso picasso, Dispatcher dispatcher, Cache cache, Request request,
       Downloader downloader) {
-    super(picasso, dispatcher, request);
+    super(picasso, dispatcher, cache, request);
     this.downloader = downloader;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -24,7 +24,6 @@ import android.os.Message;
 import android.os.Process;
 import android.widget.ImageView;
 import java.io.File;
-import java.io.IOException;
 import java.lang.ref.ReferenceQueue;
 import java.util.List;
 import java.util.Map;
@@ -211,11 +210,6 @@ public class Picasso {
       targetToRequest.put(target, request);
     }
     dispatcher.dispatchSubmit(request);
-  }
-
-  // Used by get() requests.
-  Bitmap execute(Request request) throws IOException {
-    return BitmapHunter.forRequest(context, this, dispatcher, request, downloader).hunt();
   }
 
   Bitmap quickMemoryCacheCheck(String key) {

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.jetbrains.annotations.TestOnly;
 
+import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.Request.LoadedFrom.MEMORY;
 import static com.squareup.picasso.Utils.checkNotMain;
 import static com.squareup.picasso.Utils.createKey;
@@ -297,7 +298,8 @@ public class RequestBuilder {
     }
 
     Request request = new GetRequest(picasso, uri, resourceId, options, transformations, skipCache);
-    return picasso.execute(request);
+    return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, request,
+        picasso.downloader).hunt();
   }
 
   /**

--- a/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
@@ -28,8 +28,9 @@ class ResourceBitmapHunter extends BitmapHunter {
   private final int resourceId;
   private final Context context;
 
-  ResourceBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Request request) {
-    super(picasso, dispatcher, request);
+  ResourceBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
+      Request request) {
+    super(picasso, dispatcher, cache, request);
     this.context = context;
     this.resourceId = request.resourceId;
   }

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -68,15 +68,6 @@ public class DispatcherTest {
     verify(service).submit(any(BitmapHunter.class));
   }
 
-  @Test public void performSubmitWithCachedPerformsComplete() throws Exception {
-    Request request = mockRequest(URI_KEY_1, URI_1);
-    when(cache.get(request.getKey())).thenReturn(BITMAP_1);
-    dispatcher.performSubmit(request);
-    assertThat(dispatcher.hunterMap).isEmpty();
-    verifyZeroInteractions(service);
-    verify(mainThreadHandler).sendMessage(any(Message.class));
-  }
-
   @Test public void performCancelDetachesRequestAndCleansMap() throws Exception {
     Request request = mockRequest(URI_KEY_1, URI_1);
     BitmapHunter hunter = mockHunter(URI_KEY_1, BITMAP_1, false);


### PR DESCRIPTION
@JakeWharton 

This effectively makes the hunter responsible for checking the cache instead of the dispatcher.

When a `get()` request is executed now the logic for fetching the bitmap is exactly the same as if it was for an `into()` or `fetch()` request. 

Previously if you did a `get()` it wouldn't check the cache in the background thread.

The old code also used to make worker threads check the cache instead of the dispacher.
