### PR TITLE
Changed WeakReference to RequestWeakReference to avoid a Class Cast Exce...

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
+++ b/picasso/src/main/java/com/squareup/picasso/TargetRequest.java
@@ -29,7 +29,7 @@ final class TargetRequest extends Request<Target> {
       String key) {
     super(picasso, uri, resourceId, null, bitmapOptions, transformations, skipCache, false, 0, null,
         key);
-    this.weakTarget = new WeakReference<Target>(target, picasso.referenceQueue);
+    this.weakTarget = new RequestWeakReference<Target>(this, target, picasso.referenceQueue);
   }
 
   @Override Target getTarget() {


### PR DESCRIPTION
...ption

I was receiving a Class Cast Exception in CleanupThread when it attempted to cast the result of referenceQueue.remove() to a RequestWeakReference<?>. I traced it back to TargetRequest generating a WeakReference instead of a RequestWeakReference (as Request does).
