### PR TITLE
Invoke callback when result in memory.

### DIFF
--- a/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.java
@@ -19,18 +19,6 @@ public class SampleGalleryActivity extends PicassoSampleActivity {
   private ViewAnimator animator;
   private String image;
 
-  private void loadImage() {
-    // Index 1 is the progress bar. Show it while we're loading the image.
-    animator.setDisplayedChild(1);
-
-    Picasso.with(this).load(image).into(imageView, new EmptyCallback() {
-      @Override public void onSuccess() {
-        // Index 0 is the image view.
-        animator.setDisplayedChild(0);
-      }
-    });
-  }
-
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
@@ -77,5 +65,17 @@ public class SampleGalleryActivity extends PicassoSampleActivity {
     } else {
       super.onActivityResult(requestCode, resultCode, data);
     }
+  }
+
+  private void loadImage() {
+    // Index 1 is the progress bar. Show it while we're loading the image.
+    animator.setDisplayedChild(1);
+
+    Picasso.with(this).load(image).into(imageView, new EmptyCallback() {
+      @Override public void onSuccess() {
+        // Index 0 is the image view.
+        animator.setDisplayedChild(0);
+      }
+    });
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -384,6 +384,11 @@ public class RequestBuilder {
     if (bitmap != null) {
       picasso.cancelRequest(target);
       PicassoDrawable.setBitmap(target, picasso.context, bitmap, MEMORY, noFade, picasso.debugging);
+
+      if (callback != null) {
+        callback.onSuccess();
+      }
+
       return;
     }
 


### PR DESCRIPTION
If bitmap is in memory and a callback is supplied it should be invoked.

I promise tests are coming for `RequestBuilder`.
