### PR TITLE
Remove downloader from Picasso.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -82,7 +82,6 @@ public class Picasso {
   static Picasso singleton = null;
 
   final Context context;
-  final Downloader downloader;
   final Dispatcher dispatcher;
   final Cache cache;
   final Listener listener;
@@ -92,10 +91,9 @@ public class Picasso {
 
   boolean debugging;
 
-  Picasso(Context context, Downloader downloader, Dispatcher dispatcher, Cache cache,
-      Listener listener, Stats stats, boolean debugging) {
+  Picasso(Context context, Dispatcher dispatcher, Cache cache, Listener listener, Stats stats,
+      boolean debugging) {
     this.context = context;
-    this.downloader = downloader;
     this.dispatcher = dispatcher;
     this.cache = cache;
     this.listener = listener;
@@ -395,7 +393,7 @@ public class Picasso {
 
       Dispatcher dispatcher = new Dispatcher(context, service, HANDLER, downloader, cache);
 
-      return new Picasso(context, downloader, dispatcher, cache, listener, stats, debugging);
+      return new Picasso(context, dispatcher, cache, listener, stats, debugging);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -299,7 +299,7 @@ public class RequestBuilder {
 
     Request request = new GetRequest(picasso, uri, resourceId, options, transformations, skipCache);
     return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, request,
-        picasso.downloader).hunt();
+        picasso.dispatcher.downloader).hunt();
   }
 
   /**

--- a/picasso/src/test/java/com/squareup/picasso/ImageViewRequestTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/ImageViewRequestTest.java
@@ -49,7 +49,7 @@ public class ImageViewRequestTest {
   @Test
   public void invokesTargetAndCallbackSuccessIfTargetIsNotNull() throws Exception {
     Picasso picasso =
-        new Picasso(Robolectric.application, mock(Downloader.class), mock(Dispatcher.class),
+        new Picasso(Robolectric.application, mock(Dispatcher.class),
             Cache.NONE, null, mock(Stats.class), true);
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -64,7 +64,7 @@ public class PicassoTest {
 
   @Before public void setUp() {
     initMocks(this);
-    picasso = new Picasso(context, downloader, dispatcher, cache, listener, stats, false);
+    picasso = new Picasso(context, dispatcher, cache, listener, stats, false);
   }
 
   @Test public void submitWithNullTargetInvokesDispatcher() throws Exception {

--- a/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
@@ -242,7 +242,7 @@ public class RequestBuilderTest {
 
   @Test public void noImageWithPlaceholderDoesNotSubmitAndSetsPlaceholder() {
     Context context = Robolectric.application;
-    Picasso picasso = spy(new Picasso(context, null, null, null, null, null, false));
+    Picasso picasso = spy(new Picasso(context, null, null, null, null, false));
     ImageView target = mock(ImageView.class);
 
     new RequestBuilder(picasso, null, 0).placeholder(R.drawable.ic_dialog_map).into(target);


### PR DESCRIPTION
`Picasso` doesn't use it. `Dispatcher` does.
