### PR TITLE
Change PicassoDrawable to respect bounds given by its container

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -48,8 +48,9 @@ final class PicassoDrawable extends Drawable {
     if (picassoDrawable != null) {
       picassoDrawable.setBitmap(bitmap, loadedFrom, noFade);
     } else {
-      target.setImageDrawable(new PicassoDrawable(context, bitmap, loadedFrom, noFade, debugging));
+      picassoDrawable = new PicassoDrawable(context, bitmap, loadedFrom, noFade, debugging);
     }
+    target.setImageDrawable(picassoDrawable);
   }
 
   /**
@@ -62,9 +63,9 @@ final class PicassoDrawable extends Drawable {
     if (picassoDrawable != null) {
       picassoDrawable.setPlaceholder(placeholderResId, placeholderDrawable);
     } else {
-      target.setImageDrawable(
-          new PicassoDrawable(context, placeholderResId, placeholderDrawable, debugging));
+      picassoDrawable = new PicassoDrawable(context, placeholderResId, placeholderDrawable, debugging);
     }
+    target.setImageDrawable(picassoDrawable);
   }
 
   /**


### PR DESCRIPTION
This series fixes issues with PicassoDrawable that cause, among other things, the ScaleType attribute of the containing ImageView to not function properly.

This should fix issues #73 and #103.

You may have other plans for fixing/changing PicassoDrawable, but this series might at least be helpful to anyone who needs  a temporary fix before the final 2.0 release.
