### PR TITLE
Set thread name when hunting.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -74,6 +74,8 @@ abstract class BitmapHunter implements Runnable {
 
   @Override public void run() {
     try {
+      Thread.currentThread().setName(Utils.THREAD_PREFIX + getName());
+
       result = hunt();
 
       if (result == null) {
@@ -84,6 +86,8 @@ abstract class BitmapHunter implements Runnable {
     } catch (IOException e) {
       exception = e;
       dispatcher.dispatchRetry(this);
+    } finally {
+      Thread.currentThread().setName(Utils.THREAD_IDLE_NAME);
     }
   }
 
@@ -144,6 +148,10 @@ abstract class BitmapHunter implements Runnable {
 
   String getKey() {
     return key;
+  }
+
+  String getName() {
+    return uri.getPath();
   }
 
   static BitmapHunter forRequest(Context context, Picasso picasso, Dispatcher dispatcher,

--- a/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
@@ -44,6 +44,10 @@ class ResourceBitmapHunter extends BitmapHunter {
     return DISK;
   }
 
+  @Override String getName() {
+    return Integer.toString(resourceId);
+  }
+
   private Bitmap decodeResource(Resources resources, int resourceId,
       PicassoBitmapOptions bitmapOptions) {
     if (bitmapOptions != null && bitmapOptions.inJustDecodeBounds) {


### PR DESCRIPTION
This was missed during upgrade to 2.0.
