### PR TITLE
fixed an NPE crash 

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
@@ -57,13 +57,13 @@ class ContactsPhotoBitmapHunter extends BitmapHunter {
   private InputStream getInputStream() throws IOException {
     ContentResolver contentResolver = context.getContentResolver();
     Uri uri = this.uri;
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-      if (uri.toString().startsWith(ContactsContract.Contacts.CONTENT_LOOKUP_URI.toString())) {
-        uri = ContactsContract.Contacts.lookupContact(contentResolver, uri);
-        if (uri == null) {
-          return null;
-        }
+    if (uri.toString().startsWith(ContactsContract.Contacts.CONTENT_LOOKUP_URI.toString())) {
+      uri = ContactsContract.Contacts.lookupContact(contentResolver, uri);
+      if (uri == null) {
+        return null;
       }
+    }
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
       return openContactPhotoInputStream(contentResolver, uri);
     } else {
       return ContactPhotoStreamIcs.get(contentResolver, uri);


### PR DESCRIPTION
fixed an NPE crash where the lookup uri of a deleted contact was used to fetch the contact photo.
This is a re-work of the previous fix. Same symptom (NPE), different cause.
Internally, openContactPhotoInputStream doesn't seem to cope well with stale lookup uris. If the referenced contact no longer exists, the method throws an NPE.
