### PR TITLE
update disk cache size in javadoc

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
@@ -28,7 +28,7 @@ import static com.squareup.picasso.Utils.parseResponseSourceHeader;
 
 /**
  * A {@link Downloader} which uses {@link HttpURLConnection} to download images. A disk cache of
- * 10MB will automatically be installed in the application's cache directory, when available.
+ * 50MB will automatically be installed in the application's cache directory, when available.
  */
 public class UrlConnectionDownloader implements Downloader {
   static final String RESPONSE_SOURCE = "X-Android-Response-Source";


### PR DESCRIPTION
Fix a misleading javadoc as the disk cache max size had been increase to 50MB in Picasso 1.0.2
