### PR TITLE
Hook up stats again.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
@@ -34,8 +34,8 @@ class ContactsPhotoBitmapHunter extends BitmapHunter {
   final Context context;
 
   ContactsPhotoBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
-      Request request) {
-    super(picasso, dispatcher, cache, request);
+      Stats stats, Request request) {
+    super(picasso, dispatcher, cache, stats, request);
     this.context = context;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/ContentProviderBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentProviderBitmapHunter.java
@@ -29,8 +29,8 @@ class ContentProviderBitmapHunter extends ContentStreamBitmapHunter {
       new String[] {MediaStore.Images.ImageColumns.ORIENTATION};
 
   ContentProviderBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
-      Request request) {
-    super(context, picasso, dispatcher, cache, request);
+      Stats stats, Request request) {
+    super(context, picasso, dispatcher, cache, stats, request);
   }
 
   @Override Bitmap decode(Uri uri, PicassoBitmapOptions options, int retryCount)

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
@@ -30,8 +30,8 @@ class ContentStreamBitmapHunter extends BitmapHunter {
   final Context context;
 
   ContentStreamBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
-      Request request) {
-    super(picasso, dispatcher, cache, request);
+      Stats stats, Request request) {
+    super(picasso, dispatcher, cache, stats, request);
     this.context = context;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
+++ b/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
@@ -66,12 +66,13 @@ class Dispatcher {
   final Handler handler;
   final Handler mainThreadHandler;
   final Cache cache;
+  final Stats stats;
   final List<BitmapHunter> batch;
 
   boolean airplaneMode;
 
   Dispatcher(Context context, ExecutorService service, Handler mainThreadHandler,
-      Downloader downloader, Cache cache) {
+      Downloader downloader, Cache cache, Stats stats) {
     this.dispatcherThread = new DispatcherThread();
     this.dispatcherThread.start();
     this.context = context;
@@ -81,6 +82,7 @@ class Dispatcher {
     this.downloader = downloader;
     this.mainThreadHandler = mainThreadHandler;
     this.cache = cache;
+    this.stats = stats;
     this.batch = new ArrayList<BitmapHunter>(4);
     this.airplaneMode = Utils.isAirplaneModeOn(this.context);
     NetworkBroadcastReceiver receiver = new NetworkBroadcastReceiver(this.context);
@@ -132,8 +134,8 @@ class Dispatcher {
       return;
     }
 
-    hunter =
-        forRequest(context, request.getPicasso(), this, cache, request, downloader, airplaneMode);
+    hunter = forRequest(context, request.getPicasso(), this, cache, stats, request, downloader,
+        airplaneMode);
     hunter.future = service.submit(hunter);
     hunterMap.put(request.getKey(), hunter);
   }

--- a/picasso/src/main/java/com/squareup/picasso/FileBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/FileBitmapHunter.java
@@ -30,8 +30,8 @@ import static android.media.ExifInterface.TAG_ORIENTATION;
 class FileBitmapHunter extends ContentStreamBitmapHunter {
 
   FileBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
-      Request request) {
-    super(context, picasso, dispatcher, cache, request);
+      Stats stats, Request request) {
+    super(context, picasso, dispatcher, cache, stats, request);
   }
 
   @Override Bitmap decode(Uri uri, PicassoBitmapOptions options, int retryCount)

--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -30,9 +30,10 @@ class NetworkBitmapHunter extends BitmapHunter {
   private final boolean airplaneMode;
   private Picasso.LoadedFrom loadedFrom;
 
-  public NetworkBitmapHunter(Picasso picasso, Dispatcher dispatcher, Cache cache, Request request,
+  public NetworkBitmapHunter(Picasso picasso, Dispatcher dispatcher, Cache cache, Stats stats,
+      Request request,
       Downloader downloader, boolean airplaneMode) {
-    super(picasso, dispatcher, cache, request);
+    super(picasso, dispatcher, cache, stats, request);
     this.downloader = downloader;
     this.airplaneMode = airplaneMode;
   }

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -233,7 +233,7 @@ public class Picasso {
   Bitmap quickMemoryCacheCheck(String key) {
     Bitmap cached = cache.get(key);
     if (cached != null) {
-      stats.cacheHit();
+      stats.dispatchCacheHit();
     }
     return cached;
   }
@@ -424,7 +424,7 @@ public class Picasso {
 
       Stats stats = new Stats(cache);
 
-      Dispatcher dispatcher = new Dispatcher(context, service, HANDLER, downloader, cache);
+      Dispatcher dispatcher = new Dispatcher(context, service, HANDLER, downloader, cache, stats);
 
       return new Picasso(context, dispatcher, cache, listener, stats, debugging);
     }

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -49,8 +49,8 @@ public class RequestBuilder {
 
   RequestBuilder(Picasso picasso, Uri uri, int resourceId) {
     if (picasso.shutdown) {
-      throw new IllegalStateException("Picasso instance already shut down. "
-          + "Cannot submit new requests.");
+      throw new IllegalStateException(
+          "Picasso instance already shut down. " + "Cannot submit new requests.");
     }
     this.picasso = picasso;
     this.uri = uri;
@@ -136,7 +136,7 @@ public class RequestBuilder {
     PicassoBitmapOptions options = getOptions();
 
     if (options.targetWidth != 0 || options.targetHeight != 0) {
-     throw new IllegalStateException("Fit cannot be used with resize.");
+      throw new IllegalStateException("Fit cannot be used with resize.");
     }
 
     deferred = true;
@@ -302,8 +302,8 @@ public class RequestBuilder {
     }
 
     Request request = new GetRequest(picasso, uri, resourceId, options, transformations, skipCache);
-    return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, request,
-        picasso.dispatcher.downloader, Utils.isAirplaneModeOn(picasso.context)).hunt();
+    return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, picasso.stats,
+        request, picasso.dispatcher.downloader, Utils.isAirplaneModeOn(picasso.context)).hunt();
   }
 
   /**

--- a/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
@@ -29,8 +29,8 @@ class ResourceBitmapHunter extends BitmapHunter {
   private final Context context;
 
   ResourceBitmapHunter(Context context, Picasso picasso, Dispatcher dispatcher, Cache cache,
-      Request request) {
-    super(picasso, dispatcher, cache, request);
+      Stats stats, Request request) {
+    super(picasso, dispatcher, cache, stats, request);
     this.context = context;
     this.resourceId = request.resourceId;
   }

--- a/picasso/src/main/java/com/squareup/picasso/Stats.java
+++ b/picasso/src/main/java/com/squareup/picasso/Stats.java
@@ -52,24 +52,45 @@ class Stats {
     this.handler = new StatsHandler(statsThread.getLooper());
   }
 
-  void bitmapDecoded(Bitmap bitmap) {
+  void dispatchBitmapDecoded(Bitmap bitmap) {
     processBitmap(bitmap, BITMAP_DECODE_FINISHED);
   }
 
-  void bitmapTransformed(Bitmap bitmap) {
+  void dispatchBitmapTransformed(Bitmap bitmap) {
     processBitmap(bitmap, BITMAP_TRANSFORMED_FINISHED);
   }
 
-  void cacheHit() {
+  void dispatchCacheHit() {
     handler.sendEmptyMessage(CACHE_HIT);
   }
 
-  void cacheMiss() {
+  void dispatchCacheMiss() {
     handler.sendEmptyMessage(CACHE_MISS);
   }
 
   void shutdown() {
     statsThread.quit();
+  }
+
+  void performCacheHit() {
+    cacheHits++;
+  }
+
+  void performCacheMiss() {
+    cacheMisses++;
+  }
+
+  void performBitmapDecoded(long size) {
+    originalBitmapCount++;
+    totalOriginalBitmapSize += size;
+    averageOriginalBitmapSize = getAverage(originalBitmapCount, totalOriginalBitmapSize);
+  }
+
+  void performBitmapTransformed(long size) {
+    transformedBitmapCount++;
+    totalTransformedBitmapSize += size;
+    averageTransformedBitmapSize =
+        getAverage(originalBitmapCount, totalTransformedBitmapSize);
   }
 
   synchronized StatsSnapshot createSnapshot() {
@@ -99,21 +120,16 @@ class Stats {
       synchronized (Stats.this) {
         switch (msg.what) {
           case CACHE_HIT:
-            cacheHits++;
+            performCacheHit();
             break;
           case CACHE_MISS:
-            cacheMisses++;
+            performCacheMiss();
             break;
           case BITMAP_DECODE_FINISHED:
-            originalBitmapCount++;
-            totalOriginalBitmapSize += msg.arg1;
-            averageOriginalBitmapSize = getAverage(originalBitmapCount, totalOriginalBitmapSize);
+            performBitmapDecoded(msg.arg1);
             break;
           case BITMAP_TRANSFORMED_FINISHED:
-            transformedBitmapCount++;
-            totalTransformedBitmapSize += msg.arg1;
-            averageTransformedBitmapSize =
-                getAverage(originalBitmapCount, totalTransformedBitmapSize);
+            performBitmapTransformed(msg.arg1);
             break;
           case REQUESTED_COMPLETED:
             break;

--- a/picasso/src/main/java/com/squareup/picasso/StatsSnapshot.java
+++ b/picasso/src/main/java/com/squareup/picasso/StatsSnapshot.java
@@ -68,12 +68,14 @@ public class StatsSnapshot {
     writer.println(maxSize);
     writer.print("  Cache Size: ");
     writer.println(size);
+    writer.print("  Cache % Full: ");
+    writer.println((int) Math.ceil((float) size / maxSize * 100));
     writer.print("  Cache Hits: ");
     writer.println(cacheHits);
     writer.print("  Cache Misses: ");
     writer.println(cacheMisses);
     writer.println("Bitmap Stats");
-    writer.print("  Total Bitmaps: ");
+    writer.print("  Total Bitmaps Decoded: ");
     writer.println(originalBitmapCount);
     writer.print("  Total Bitmap Size: ");
     writer.println(totalOriginalBitmapSize);

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -40,11 +40,12 @@ public class DispatcherTest {
   @Mock Handler mainThreadHandler;
   @Mock Downloader downloader;
   @Mock Cache cache;
+  @Mock Stats stats;
   private Dispatcher dispatcher;
 
   @Before public void setUp() throws Exception {
     initMocks(this);
-    dispatcher = new Dispatcher(context, service, mainThreadHandler, downloader, cache);
+    dispatcher = new Dispatcher(context, service, mainThreadHandler, downloader, cache, stats);
   }
 
   @Test public void shutdownStopsService() throws Exception {
@@ -232,7 +233,8 @@ public class DispatcherTest {
   public void performNetworkStateChangeWithConnectedInfoAndPicassoExecutorServiceAdjustsThreads()
       throws Exception {
     PicassoExecutorService service = mock(PicassoExecutorService.class);
-    Dispatcher dispatcher = new Dispatcher(context, service, mainThreadHandler, downloader, cache);
+    Dispatcher dispatcher =
+        new Dispatcher(context, service, mainThreadHandler, downloader, cache, stats);
     NetworkInfo info = mockNetworkInfo();
     when(info.isConnectedOrConnecting()).thenReturn(true);
     dispatcher.performNetworkStateChange(info);

--- a/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
@@ -41,6 +41,7 @@ public class NetworkBitmapHunterTest {
   @Mock Context context;
   @Mock Picasso picasso;
   @Mock Cache cache;
+  @Mock Stats stats;
   @Mock Dispatcher dispatcher;
   @Mock Downloader downloader;
 
@@ -52,7 +53,7 @@ public class NetworkBitmapHunterTest {
   @Test public void doesNotForceLocalCacheOnlyWithAirplaneModeOffAndRetryCount() throws Exception {
     Request request = mockRequest(URI_KEY_1, URI_1);
     NetworkBitmapHunter hunter =
-        new NetworkBitmapHunter(picasso, dispatcher, cache, request, downloader, false);
+        new NetworkBitmapHunter(picasso, dispatcher, cache, stats, request, downloader, false);
     hunter.decode(request.getUri(), null, 2);
     verify(downloader).load(URI_1, false);
   }
@@ -60,7 +61,7 @@ public class NetworkBitmapHunterTest {
   @Test public void withZeroRetryCountForcesLocalCacheOnly() throws Exception {
     Request request = mockRequest(URI_KEY_1, URI_1);
     NetworkBitmapHunter hunter =
-        new NetworkBitmapHunter(picasso, dispatcher, cache, request, downloader, false);
+        new NetworkBitmapHunter(picasso, dispatcher, cache, stats, request, downloader, false);
     hunter.decode(request.getUri(), null, 0);
     verify(downloader).load(URI_1, true);
   }
@@ -68,7 +69,7 @@ public class NetworkBitmapHunterTest {
   @Test public void airplaneModeForcesLocalCacheOnly() throws Exception {
     Request request = mockRequest(URI_KEY_1, URI_1);
     NetworkBitmapHunter hunter =
-        new NetworkBitmapHunter(picasso, dispatcher, cache, request, downloader, true);
+        new NetworkBitmapHunter(picasso, dispatcher, cache, stats, request, downloader, true);
     hunter.decode(request.getUri(), null, hunter.retryCount);
     verify(downloader).load(URI_1, true);
   }

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -85,13 +85,7 @@ public class PicassoTest {
     when(cache.get(URI_KEY_1)).thenReturn(BITMAP_1);
     Bitmap cached = picasso.quickMemoryCacheCheck(URI_KEY_1);
     assertThat(cached).isEqualTo(BITMAP_1);
-    verify(stats).cacheHit();
-  }
-
-  @Test public void quickMemoryCheckReturnsNullIfNotInCache() throws Exception {
-    Bitmap cached = picasso.quickMemoryCacheCheck(URI_KEY_1);
-    assertThat(cached).isNull();
-    verifyZeroInteractions(stats);
+    verify(stats).dispatchCacheHit();
   }
 
   @Test public void completeInvokesSuccessOnAllSuccessfulRequests() throws Exception {

--- a/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestBuilderTest.java
@@ -165,7 +165,7 @@ public class RequestBuilderTest {
   public void intoImageViewWithQuickMemoryCacheCheckDoesNotSubmit() throws Exception {
     Picasso picasso =
         spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null,
-            mock(Stats.class), true));
+            new Stats(Cache.NONE), true));
     when(picasso.quickMemoryCacheCheck(URI_KEY_1)).thenReturn(BITMAP_1);
     ImageView target = mockImageViewTarget();
     new RequestBuilder(picasso, URI_1, 0).into(target);


### PR DESCRIPTION
- Renamed stats methods to match similar method names as `Dispatcher`.
- Turns out we don't update stats when a bitmap is evicted from the cache. This might be intentional or not but I updated the text to to be clearer.
