### PR TITLE
Allow returning a Bitmap instance directly from the loader.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Downloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/Downloader.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.picasso;
 
+import android.graphics.Bitmap;
 import android.net.Uri;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,16 +28,32 @@ public interface Downloader {
    * @param uri Remote image URL.
    * @param localCacheOnly If {@code true} the URL should only be loaded if available in a local
    * disk cache.
-   * @return {@link InputStream} and {@code boolean} indicating whether or not the image is being
-   *         loaded from a local disk cache. <strong>Must not be {@code null}.</strong>
+   * @return {@link Response} containing either a {@link Bitmap} representation of the request or an
+   * {@link InputStream} for the image data. <strong>Must not be {@code null}.</strong>
    * @throws IOException if the requested URL cannot successfully be loaded.
    */
   Response load(Uri uri, boolean localCacheOnly) throws IOException;
 
-  /** Response stream and info. */
+  /** Response stream or bitmap and info. */
   class Response {
     final InputStream stream;
+    final Bitmap bitmap;
     final boolean cached;
+
+    /**
+     * Response image and info.
+     *
+     * @param bitmap Image.
+     * @param loadedFromCache {@code true} if the source of the image is from a local disk cache.
+     */
+    public Response(Bitmap bitmap, boolean loadedFromCache) {
+      if (bitmap == null) {
+        throw new IllegalArgumentException("Bitmap may not be null.");
+      }
+      this.stream = null;
+      this.bitmap = bitmap;
+      this.cached = loadedFromCache;
+    }
 
     /**
      * Response stream and info.
@@ -45,12 +62,30 @@ public interface Downloader {
      * @param loadedFromCache {@code true} if the source of the stream is from a local disk cache.
      */
     public Response(InputStream stream, boolean loadedFromCache) {
+      if (stream == null) {
+        throw new IllegalArgumentException("Stream may not be null.");
+      }
       this.stream = stream;
+      this.bitmap = null;
       this.cached = loadedFromCache;
     }
 
-    @SuppressWarnings("UnusedDeclaration") public InputStream getInputStream() {
+    /**
+     * Input stream containing image data.
+     * <p>
+     * If this returns {@code null}, image data will be available via {@link #getBitmap()}.
+     */
+    public InputStream getInputStream() {
       return stream;
+    }
+
+    /**
+     * Bitmap representing the image.
+     * <p>
+     * If this returns {@code null}, image data will be available via {@link #getInputStream()}.
+     */
+    public Bitmap getBitmap() {
+      return bitmap;
     }
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
@@ -16,7 +16,9 @@
 package com.squareup.picasso;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.net.Uri;
+import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,9 +26,11 @@ import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.mockRequest;
+import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.mock;
@@ -71,5 +75,20 @@ public class NetworkBitmapHunterTest {
         new NetworkBitmapHunter(picasso, dispatcher, cache, request, downloader, true);
     hunter.decode(request.getUri(), null, hunter.retryCount);
     verify(downloader).load(URI_1, true);
+  }
+
+  @Test public void downloaderCanReturnBitmapDirectly() throws Exception {
+    final Bitmap expected = Bitmap.createBitmap(10, 10, ARGB_8888);
+    Downloader bitmapDownloader = new Downloader() {
+      @Override public Response load(Uri uri, boolean localCacheOnly) throws IOException {
+        return new Response(expected, false);
+      }
+    };
+    Request request = mockRequest(URI_KEY_1, URI_1);
+    NetworkBitmapHunter hunter =
+        new NetworkBitmapHunter(picasso, dispatcher, cache, request, bitmapDownloader, false);
+
+    Bitmap actual = hunter.decode(request.getUri(), null, 2);
+    assertThat(actual).isSameAs(expected);
   }
 }


### PR DESCRIPTION
This support fun use-cases like allowing Base64-encoded images inside JSON or rendering a dynamic image based on the response data.
