### PR TITLE
Update Utils.java

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -173,18 +173,18 @@ final class Utils {
   }
 
   static int calculateDiskCacheSize(File dir) {
-    int size = MIN_DISK_CACHE_SIZE;
+    long size = MIN_DISK_CACHE_SIZE;
 
     try {
       StatFs statFs = new StatFs(dir.getAbsolutePath());
-      int available = statFs.getBlockCount() * statFs.getBlockSize();
+      long available = ((long)statFs.getBlockCount()) * statFs.getBlockSize();
       // Target 2% of the total space.
       size = available / 50;
     } catch (IllegalArgumentException ignored) {
     }
 
     // Bound inside min/max size for disk cache.
-    return Math.max(Math.min(size, MAX_DISK_CACHE_SIZE), MIN_DISK_CACHE_SIZE);
+    return (int)Math.max(Math.min(size, MAX_DISK_CACHE_SIZE), MIN_DISK_CACHE_SIZE);
   }
 
   static int calculateMemoryCacheSize(Context context) {


### PR DESCRIPTION
Fixed an integer overflow when calculating disk cache size on a disk greater than MAX_INT bytes. Otherwise, it can have wrong (even negative) values on any filesystem over 2 GB.
