### PR TITLE
GetRequest should use the requestKey

### DIFF
--- a/picasso-sample/AndroidManifest.xml
+++ b/picasso-sample/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <activity android:name=".SampleContactsActivity"/>
     <activity android:name=".SampleGalleryActivity"/>
     <activity android:name=".SampleListDetailActivity"/>
+    <activity android:name=".GetSampleActivity"/>
 
   </application>
 </manifest>

--- a/picasso-sample/res/layout/picasso_sample_get_activity.xml
+++ b/picasso-sample/res/layout/picasso_sample_get_activity.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+    <ImageView android:id="@+id/picasso_sample_get_activity_imageview"
+           android:layout_width="wrap_content"
+           android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:src="@drawable/placeholder"/>
+
+</RelativeLayout>

--- a/picasso-sample/src/main/java/com/example/picasso/GetSampleActivity.java
+++ b/picasso-sample/src/main/java/com/example/picasso/GetSampleActivity.java
@@ -1,0 +1,51 @@
+package com.example.picasso;
+
+import android.app.Activity;
+import android.graphics.Bitmap;
+import android.os.AsyncTask;
+import android.os.Bundle;
+import android.widget.ImageView;
+import com.squareup.picasso.Picasso;
+
+import java.io.IOException;
+
+public class GetSampleActivity extends Activity {
+    private ImageView mImageView;
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.picasso_sample_get_activity);
+        mImageView = (ImageView) findViewById(R.id.picasso_sample_get_activity_imageview);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        new GetImageAsyncTask().execute();
+    }
+
+    private class GetImageAsyncTask extends AsyncTask<Void, Void, Bitmap> {
+
+        @Override
+        protected Bitmap  doInBackground(Void... params) {
+            Bitmap ret = null;
+            try {
+                ret = Picasso.with(GetSampleActivity.this).load(Data.URLS[0]).get();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            return ret;
+        }
+
+        @Override
+        protected void onPostExecute(Bitmap bitmap) {
+            super.onPostExecute(bitmap);
+
+            if ( bitmap != null ) {
+                mImageView.setImageBitmap(bitmap);
+            }
+
+        }
+    }
+}

--- a/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.java
@@ -14,7 +14,8 @@ final class PicassoSampleAdapter extends BaseAdapter {
     GRID_VIEW("Image Grid View", SampleGridViewActivity.class),
     GALLERY("Load from Gallery", SampleGalleryActivity.class),
     CONTACTS("Contact Photos", SampleContactsActivity.class),
-    LIST_DETAIL("List / Detail View", SampleListDetailActivity.class);
+    LIST_DETAIL("List / Detail View", SampleListDetailActivity.class),
+    GET_SAMPLE("Get sample", GetSampleActivity.class);
 
     private final Class<?> activityClass;
 

--- a/picasso/src/main/java/com/squareup/picasso/GetRequest.java
+++ b/picasso/src/main/java/com/squareup/picasso/GetRequest.java
@@ -7,9 +7,9 @@ import java.util.List;
 class GetRequest extends Request<Void> {
 
   GetRequest(Picasso picasso, Uri uri, int resourceId, PicassoBitmapOptions bitmapOptions,
-      List<Transformation> transformations, boolean skipCache) {
+      List<Transformation> transformations, boolean skipCache, String key) {
     super(picasso, uri, resourceId, null, bitmapOptions, transformations, skipCache, false, 0, null,
-        null);
+        key);
   }
 
   @Override void complete(Bitmap result, Picasso.LoadedFrom from) {

--- a/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestBuilder.java
@@ -301,8 +301,10 @@ public class RequestBuilder {
       return null;
     }
 
+    String requestKey = createKey(uri, resourceId, options, transformations);
     Request request =
-        new GetRequest(picasso, uri, resourceId, options, transformations, skipMemoryCache);
+        new GetRequest(picasso, uri, resourceId, options, transformations, skipMemoryCache,
+                requestKey);
     return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, request,
         picasso.dispatcher.downloader, Utils.isAirplaneModeOn(picasso.context)).hunt();
   }


### PR DESCRIPTION
I have been trying to do a request synchronously using `get()` but it failed because the `GetRequest` didn't have a `requestKey`.

This pull request also includes a sample activity to reproduce the issue.

Also check the `fetch()` method:

```
  public void fetch() {
    String requestKey = createKey(uri, resourceId, options, transformations);
    Request request =
        new FetchRequest(picasso, uri, resourceId, options, transformations, skipMemoryCache);
    picasso.enqueueAndSubmit(request);
  }
```

`requestKey` is created but never used.
