### PR TITLE
Fix loaded from NPE.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -93,8 +93,6 @@ abstract class BitmapHunter implements Runnable {
 
   abstract Bitmap decode(Request data) throws IOException;
 
-  abstract Picasso.LoadedFrom getLoadedFrom();
-
   Bitmap hunt() throws IOException {
     Bitmap bitmap;
 
@@ -169,6 +167,10 @@ abstract class BitmapHunter implements Runnable {
 
   Exception getException() {
     return exception;
+  }
+
+  Picasso.LoadedFrom getLoadedFrom() {
+    return loadedFrom;
   }
 
   static BitmapHunter forRequest(Context context, Picasso picasso, Dispatcher dispatcher,

--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -30,7 +30,6 @@ class NetworkBitmapHunter extends BitmapHunter {
 
   private final Downloader downloader;
 
-  private Picasso.LoadedFrom loadedFrom;
   int retryCount;
 
   public NetworkBitmapHunter(Picasso picasso, Dispatcher dispatcher, Cache cache, Stats stats,
@@ -58,10 +57,6 @@ class NetworkBitmapHunter extends BitmapHunter {
     } finally {
       Utils.closeQuietly(is);
     }
-  }
-
-  @Override Picasso.LoadedFrom getLoadedFrom() {
-    return loadedFrom;
   }
 
   @Override boolean shouldRetry(boolean airplaneMode, NetworkInfo info) {

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -301,6 +301,9 @@ public class Picasso {
       }
       targetToAction.remove(join.getTarget());
       if (result != null) {
+        if (from == null) {
+          throw new AssertionError("LoadedFrom cannot be null.");
+        }
         join.complete(result, from);
       } else {
         join.error();


### PR DESCRIPTION
After more thought loadedFrom should never be null, if it is it will still crash. No need to check for null or throw an AssertionError. Its just never null.

Credit also to @dallasgutauckis 

Issue: #183 
