### PR TITLE
Better retrying.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
@@ -38,7 +38,7 @@ class ContactsPhotoBitmapHunter extends BitmapHunter {
     this.context = context;
   }
 
-  @Override Bitmap decode(Request data, int retryCount)
+  @Override Bitmap decode(Request data)
       throws IOException {
     InputStream is = null;
     try {

--- a/picasso/src/main/java/com/squareup/picasso/ContentProviderBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentProviderBitmapHunter.java
@@ -33,7 +33,7 @@ class ContentProviderBitmapHunter extends ContentStreamBitmapHunter {
     super(context, picasso, dispatcher, cache, stats, action);
   }
 
-  @Override Bitmap decode(Request data, int retryCount) throws IOException {
+  @Override Bitmap decode(Request data) throws IOException {
     setExifRotation(getContentProviderExifRotation(context.getContentResolver(), data.uri));
     return super.decodeContentStream(data);
   }

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
@@ -33,7 +33,7 @@ class ContentStreamBitmapHunter extends BitmapHunter {
     this.context = context;
   }
 
-  @Override Bitmap decode(Request data, int retryCount)
+  @Override Bitmap decode(Request data)
       throws IOException {
     return decodeContentStream(data);
   }

--- a/picasso/src/main/java/com/squareup/picasso/FileBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/FileBitmapHunter.java
@@ -34,10 +34,10 @@ class FileBitmapHunter extends ContentStreamBitmapHunter {
     super(context, picasso, dispatcher, cache, stats, action);
   }
 
-  @Override Bitmap decode(Request data, int retryCount)
+  @Override Bitmap decode(Request data)
       throws IOException {
     setExifRotation(getFileExifRotation(data.uri));
-    return super.decode(data, retryCount);
+    return super.decode(data);
   }
 
   static int getFileExifRotation(Uri uri) throws IOException {

--- a/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
@@ -22,6 +22,10 @@ class PicassoExecutorService extends ThreadPoolExecutor {
   }
 
   void adjustThreadCount(NetworkInfo info) {
+    if (info == null || !info.isConnectedOrConnecting()) {
+      setThreadCount(DEFAULT_THREAD_COUNT);
+      return;
+    }
     switch (info.getType()) {
       case ConnectivityManager.TYPE_WIFI:
       case ConnectivityManager.TYPE_WIMAX:

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -216,7 +216,7 @@ public class RequestCreator {
 
     Action action = new GetAction(picasso, finalData, skipMemoryCache, key);
     return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, picasso.stats,
-        action, picasso.dispatcher.downloader, Utils.isAirplaneModeOn(picasso.context)).hunt();
+        action, picasso.dispatcher.downloader).hunt();
   }
 
   /**

--- a/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
@@ -32,7 +32,7 @@ class ResourceBitmapHunter extends BitmapHunter {
     this.context = context;
   }
 
-  @Override Bitmap decode(Request data, int retryCount) throws IOException {
+  @Override Bitmap decode(Request data) throws IOException {
     return decodeResource(context.getResources(), data);
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -101,7 +101,7 @@ public class BitmapHunterTest {
         spy(new TestableBitmapHunter(picasso, dispatcher, cache, stats, action, BITMAP_1));
     Bitmap result = hunter.hunt();
     verify(cache).get(URI_KEY_1);
-    verify(hunter).decode(action.getData(), hunter.retryCount);
+    verify(hunter).decode(action.getData());
     assertThat(result).isEqualTo(BITMAP_1);
   }
 
@@ -112,7 +112,7 @@ public class BitmapHunterTest {
         spy(new TestableBitmapHunter(picasso, dispatcher, cache, stats, action, BITMAP_1));
     Bitmap result = hunter.hunt();
     verify(cache).get(URI_KEY_1);
-    verify(hunter, never()).decode(action.getData(), hunter.retryCount);
+    verify(hunter, never()).decode(action.getData());
     assertThat(result).isEqualTo(BITMAP_1);
   }
 
@@ -150,35 +150,35 @@ public class BitmapHunterTest {
   @Test public void forContentProviderRequest() throws Exception {
     Action action = mockAction(CONTENT_KEY_1, CONTENT_1_URL);
     BitmapHunter hunter =
-        forRequest(context, picasso, dispatcher, cache, stats, action, downloader, false);
+        forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
     assertThat(hunter).isInstanceOf(ContentProviderBitmapHunter.class);
   }
 
   @Test public void forContactsPhotoRequest() throws Exception {
     Action action = mockAction(CONTACT_KEY_1, CONTACT_URI_1);
     BitmapHunter hunter =
-        forRequest(context, picasso, dispatcher, cache, stats, action, downloader, false);
+        forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
     assertThat(hunter).isInstanceOf(ContactsPhotoBitmapHunter.class);
   }
 
   @Test public void forNetworkRequest() throws Exception {
     Action action = mockAction(URI_KEY_1, URI_1);
     BitmapHunter hunter =
-        forRequest(context, picasso, dispatcher, cache, stats, action, downloader, false);
+        forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
     assertThat(hunter).isInstanceOf(NetworkBitmapHunter.class);
   }
 
   @Test public void forFileWithAuthorityRequest() throws Exception {
     Action action = mockAction(FILE_KEY_1, FILE_1_URL);
     BitmapHunter hunter =
-        forRequest(context, picasso, dispatcher, cache, stats, action, downloader, false);
+        forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
     assertThat(hunter).isInstanceOf(FileBitmapHunter.class);
   }
 
   @Test public void forAndroidResourceRequest() throws Exception {
     Action action = mockAction(RESOURCE_ID_KEY_1, null, null, RESOURCE_ID_1);
     BitmapHunter hunter =
-        forRequest(context, picasso, dispatcher, cache, stats, action, downloader, false);
+        forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
     assertThat(hunter).isInstanceOf(ResourceBitmapHunter.class);
   }
 
@@ -408,7 +408,7 @@ public class BitmapHunterTest {
       this.throwException = throwException;
     }
 
-    @Override Bitmap decode(Request data, int retryCount) throws IOException {
+    @Override Bitmap decode(Request data) throws IOException {
       if (throwException) {
         throw new IOException("Failed.");
       }

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -175,17 +175,6 @@ public class DispatcherTest {
     assertThat(dispatcher.batch).isEmpty();
   }
 
-  @Test public void performRetryTwoTimesBeforeError() throws Exception {
-    BitmapHunter hunter = mockHunter(URI_KEY_1, BITMAP_1, false);
-    dispatcher.performRetry(hunter);
-    verify(service).submit(hunter);
-    dispatcher.performRetry(hunter);
-    verify(service, times(2)).submit(hunter);
-    dispatcher.performRetry(hunter);
-    verify(service, times(3)).isShutdown();
-    verifyNoMoreInteractions(service);
-  }
-
   @Test public void performRetrySkipsRetryIfCancelled() throws Exception {
     BitmapHunter hunter = mockHunter(URI_KEY_1, BITMAP_1, false);
     when(hunter.isCancelled()).thenReturn(true);

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -101,7 +101,6 @@ class TestUtils {
     when(hunter.getResult()).thenReturn(result);
     when(hunter.getData()).thenReturn(data);
     when(hunter.shouldSkipMemoryCache()).thenReturn(skipCache);
-    hunter.retryCount = BitmapHunter.DEFAULT_RETRY_COUNT;
     return hunter;
   }
 


### PR DESCRIPTION
- Moved retry logic with retry count into `NetworkBitmapHunter`, all other hunters need not to retry.
- Now taking into consideration `NetworkInfo`. If available we check `isConnectingOrConnected()`, if not available then always assume connected and retry.
- Turning on airplane mode returns `null` for `NetworkInfo` from the `ConnectivityManager`. The `PicassoExecutorService` now properly resets thread count when this scenario occurs. Before it would maintain the old thread count which was a bug.

Tested sample app with airplane mode ON and wifi connected. Images downloaded as expected.

Fixes #169 
