### PR TITLE
Use onPreDrawListener instead. Add copyright sections.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Callback.java
+++ b/picasso/src/main/java/com/squareup/picasso/Callback.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 public interface Callback {

--- a/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import java.lang.ref.WeakReference;
 
-class DeferredRequestCreator implements ViewTreeObserver.OnGlobalLayoutListener {
+class DeferredRequestCreator implements ViewTreeObserver.OnPreDrawListener {
 
   final RequestCreator creator;
   final WeakReference<ImageView> target;
@@ -12,30 +27,30 @@ class DeferredRequestCreator implements ViewTreeObserver.OnGlobalLayoutListener 
   DeferredRequestCreator(RequestCreator creator, ImageView target) {
     this.creator = creator;
     this.target = new WeakReference<ImageView>(target);
-    target.getViewTreeObserver().addOnGlobalLayoutListener(this);
+    target.getViewTreeObserver().addOnPreDrawListener(this);
   }
 
-  @Override public void onGlobalLayout() {
+  @Override public boolean onPreDraw() {
     ImageView target = this.target.get();
     if (target == null) {
-      return;
+      return true;
     }
     ViewTreeObserver vto = target.getViewTreeObserver();
     if (!vto.isAlive()) {
-      return;
+      return true;
     }
 
     int width = target.getMeasuredWidth();
     int height = target.getMeasuredHeight();
 
     if (width <= 0 || height <= 0) {
-      return;
+      return true;
     }
 
-    //noinspection deprecation
-    vto.removeGlobalOnLayoutListener(this);
+    vto.removeOnPreDrawListener(this);
 
     this.creator.unfit().resize(width, height).into(target);
+    return true;
   }
 
   void cancel() {
@@ -47,7 +62,6 @@ class DeferredRequestCreator implements ViewTreeObserver.OnGlobalLayoutListener 
     if (!vto.isAlive()) {
       return;
     }
-    //noinspection deprecation
-    vto.removeGlobalOnLayoutListener(this);
+    vto.removeOnPreDrawListener(this);
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/FetchAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/FetchAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 import android.graphics.Bitmap;

--- a/picasso/src/main/java/com/squareup/picasso/GetAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/GetAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 import android.graphics.Bitmap;

--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 import android.content.Context;

--- a/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 import android.net.ConnectivityManager;

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 import android.net.Uri;

--- a/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
@@ -53,7 +53,7 @@ public class DeferredRequestCreatorTest {
     ImageView target = mockFitImageViewTarget(true);
     ViewTreeObserver observer = target.getViewTreeObserver();
     DeferredRequestCreator request = new DeferredRequestCreator(mock(RequestCreator.class), target);
-    verify(observer).addOnGlobalLayoutListener(request);
+    verify(observer).addOnPreDrawListener(request);
   }
 
   @Test public void cancelRemovesLayoutListener() throws Exception {
@@ -61,7 +61,7 @@ public class DeferredRequestCreatorTest {
     ViewTreeObserver observer = target.getViewTreeObserver();
     DeferredRequestCreator request = new DeferredRequestCreator(mock(RequestCreator.class), target);
     request.cancel();
-    verify(observer).removeGlobalOnLayoutListener(request);
+    verify(observer).removeOnPreDrawListener(request);
   }
 
   @Test public void onLayoutSkipsIfTargetIsNull() throws Exception {
@@ -70,9 +70,9 @@ public class DeferredRequestCreatorTest {
     DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
     ViewTreeObserver viewTreeObserver = target.getViewTreeObserver();
     request.target.clear();
-    request.onGlobalLayout();
+    request.onPreDraw();
     verifyZeroInteractions(creator);
-    verify(viewTreeObserver).addOnGlobalLayoutListener(request);
+    verify(viewTreeObserver).addOnPreDrawListener(request);
     verifyNoMoreInteractions(viewTreeObserver);
   }
 
@@ -81,8 +81,8 @@ public class DeferredRequestCreatorTest {
     RequestCreator creator = mock(RequestCreator.class);
     DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
     ViewTreeObserver viewTreeObserver = target.getViewTreeObserver();
-    request.onGlobalLayout();
-    verify(viewTreeObserver).addOnGlobalLayoutListener(request);
+    request.onPreDraw();
+    verify(viewTreeObserver).addOnPreDrawListener(request);
     verify(viewTreeObserver).isAlive();
     verifyNoMoreInteractions(viewTreeObserver);
     verifyZeroInteractions(creator);
@@ -94,8 +94,8 @@ public class DeferredRequestCreatorTest {
     when(target.getMeasuredHeight()).thenReturn(0);
     RequestCreator creator = mock(RequestCreator.class);
     DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
-    request.onGlobalLayout();
-    verify(target.getViewTreeObserver(), never()).removeGlobalOnLayoutListener(request);
+    request.onPreDraw();
+    verify(target.getViewTreeObserver(), never()).removeOnPreDrawListener(request);
     verifyZeroInteractions(creator);
   }
 
@@ -105,7 +105,7 @@ public class DeferredRequestCreatorTest {
     DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
     request.target.clear();
     request.cancel();
-    verify(target.getViewTreeObserver(), never()).removeGlobalOnLayoutListener(request);
+    verify(target.getViewTreeObserver(), never()).removeOnPreDrawListener(request);
   }
 
 
@@ -114,7 +114,7 @@ public class DeferredRequestCreatorTest {
     RequestCreator creator = mock(RequestCreator.class);
     DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
     request.cancel();
-    verify(target.getViewTreeObserver(), never()).removeGlobalOnLayoutListener(request);
+    verify(target.getViewTreeObserver(), never()).removeOnPreDrawListener(request);
   }
 
   @Test public void onGlobalLayoutSubmitsRequestAndCleansUp() throws Exception {
@@ -130,9 +130,9 @@ public class DeferredRequestCreatorTest {
     ViewTreeObserver observer = target.getViewTreeObserver();
 
     DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
-    request.onGlobalLayout();
+    request.onPreDraw();
 
-    verify(observer).removeGlobalOnLayoutListener(request);
+    verify(observer).removeOnPreDrawListener(request);
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
 
     Action value = actionCaptor.getValue();

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.picasso;
 
 import android.content.Context;

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -1,3 +1,18 @@
+/*
+* Copyright (C) 2013 Square, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package com.squareup.picasso;
 
 import android.graphics.Bitmap;


### PR DESCRIPTION
Apparently the `onGlobalLayoutListener` is not always called...weirdly enough a view in the gridview adapter is not measured, picasso registers a global layout listener which is never invoked.

Using `onPreDrawListener` does it and also appears to be invoked way fewer times than the layout one.
