### PR TITLE
Bump save position to 4096.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -84,7 +84,7 @@ class NetworkBitmapHunter extends BitmapHunter {
       MarkableInputStream markStream = new MarkableInputStream(stream);
       stream = markStream;
 
-      long mark = markStream.savePosition(1024); // Mirrors BitmapFactory.cpp value.
+      long mark = markStream.savePosition(4096);
       BitmapFactory.decodeStream(stream, null, options);
       calculateInSampleSize(data.targetWidth, data.targetHeight, options);
 


### PR DESCRIPTION
#234

Temporary fix. `MarkableInputStream` should be updated to support expandable buffer.
