### PR TITLE
Placeholder to use full bounds

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -149,34 +149,7 @@ final class PicassoDrawable extends Drawable {
 
     image.setBounds(bounds);
     if (placeholder != null) {
-      // Center placeholder inside the image bounds
-      setBounds(placeholder);
-    }
-  }
-
-  private void setBounds(Drawable drawable) {
-    Rect bounds = getBounds();
-
-    final int width = bounds.width();
-    final int height = bounds.height();
-    final float ratio = (float) width / height;
-
-    final int drawableWidth = drawable.getIntrinsicWidth();
-    final int drawableHeight = drawable.getIntrinsicHeight();
-    final float drawableRatio = (float) drawableWidth / drawableHeight;
-
-    if (drawableRatio < ratio) {
-      final float scale = (float) height / drawableHeight;
-      final int scaledDrawableWidth = (int) (drawableWidth * scale);
-      final int drawableLeft = bounds.left - (scaledDrawableWidth - width) / 2;
-      final int drawableRight = drawableLeft + scaledDrawableWidth;
-      drawable.setBounds(drawableLeft, bounds.top, drawableRight, bounds.bottom);
-    } else {
-      final float scale = (float) width / drawableWidth;
-      final int scaledDrawableHeight = (int) (drawableHeight * scale);
-      final int drawableTop = bounds.top - (scaledDrawableHeight - height) / 2;
-      final int drawableBottom = drawableTop + scaledDrawableHeight;
-      drawable.setBounds(bounds.left, drawableTop, bounds.right, drawableBottom);
+      placeholder.setBounds(bounds);
     }
   }
 


### PR DESCRIPTION
Fixes #221

Current behavior causes placeholder to first
use full bounds at `setPlaceholder`, then use centered bounds at `onBoundsChange`, causing a broken fade in:

![http://i.imgur.com/d4yMhrf.gif](http://i.imgur.com/d4yMhrf.gif)

This reverts to previous behavior of using full bounds for placeholder:

![http://i.imgur.com/weWxfME.gif](http://i.imgur.com/weWxfME.gif)
