### PR TITLE
Cleanup upon OOM from bitmap decode.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -87,9 +87,9 @@ abstract class BitmapHunter implements Runnable {
         dispatcher.dispatchComplete(this);
       }
     } catch (OutOfMemoryError e) {
-	result = null;
-        dispatcher.dispatchFailed(this);
-        throw(e);
+      result = null;
+      dispatcher.dispatchFailed(this);
+      throw e;
     } catch (IOException e) {
       exception = e;
       dispatcher.dispatchRetry(this);


### PR DESCRIPTION
If an OutOfMemoryError is encountered when decoding a received bitmap
then actions remain attached to it and will thus never be retried for a
new request. Catch the OutOfMemoryError and fail the request before
rethrowing the OOM.
