### PR TITLE
Correct for skia decoding problem during underflow.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
+++ b/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
@@ -102,6 +102,13 @@ final class MarkableInputStream extends InputStream {
   private void skip(long current, long target) throws IOException {
     while (current < target) {
       long skipped = in.skip(target - current);
+      if (skipped == 0) {
+        if (read() == -1) {
+          break; // EOF
+        } else {
+          skipped = 1;
+        }
+      }
       current += skipped;
     }
   }


### PR DESCRIPTION
Adapted from http://b.android.com/6066#c12

Closes #281.
