### PR TITLE
Catch all exceptions and dispatch fail.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -89,6 +89,9 @@ abstract class BitmapHunter implements Runnable {
     } catch (IOException e) {
       exception = e;
       dispatcher.dispatchRetry(this);
+    } catch (Exception e) {
+      exception = e;
+      dispatcher.dispatchFailed(this);
     } finally {
       Thread.currentThread().setName(Utils.THREAD_IDLE_NAME);
     }


### PR DESCRIPTION
This should catch hidden exceptions (such as missing NETWORK permission that throws `SecurityException`) and show the error drawable.
