### PR TITLE
fix bug which do not transform bitmap with exif rotation on default setting

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -115,7 +115,7 @@ abstract class BitmapHunter implements Runnable {
 
     if (bitmap != null) {
       stats.dispatchBitmapDecoded(bitmap);
-      if (data.needsTransformation()) {
+      if (data.needsTransformation() || exifRotation != 0) {
         synchronized (DECODE_LOCK) {
           if (data.needsMatrixTransform() || exifRotation != 0) {
             bitmap = transformResult(data, bitmap, exifRotation);


### PR DESCRIPTION
`BitmapHunter` should transform bitmap automatically with rotation information on EXIF when `exifRotation` is not 0. But in original `BitmapHunter`, don't executes transform operation if `data.needsTransformation()` is `false`, even if `exifRotation` is not 0. So condition of the if statement should `data.needsTransformation() || exifRotation != 0`, not `data.needsTransformation()` only.
