### PR TITLE
Enable resource loading from android.resource URI.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
@@ -33,22 +33,23 @@ class ResourceBitmapHunter extends BitmapHunter {
   }
 
   @Override Bitmap decode(Request data) throws IOException {
-    return decodeResource(context.getResources(), data);
+    Resources res = Utils.getResources(context, data);
+    int id = Utils.getResourceId(res, data);
+    return decodeResource(res, id, data);
   }
 
   @Override Picasso.LoadedFrom getLoadedFrom() {
     return DISK;
   }
 
-  private Bitmap decodeResource(Resources resources, Request data) {
-    int resourceId = data.resourceId;
+  private Bitmap decodeResource(Resources resources, int id, Request data) {
     BitmapFactory.Options bitmapOptions = null;
     if (data.hasSize()) {
       bitmapOptions = new BitmapFactory.Options();
       bitmapOptions.inJustDecodeBounds = true;
-      BitmapFactory.decodeResource(resources, resourceId, bitmapOptions);
+      BitmapFactory.decodeResource(resources, id, bitmapOptions);
       calculateInSampleSize(data.targetWidth, data.targetHeight, bitmapOptions);
     }
-    return BitmapFactory.decodeResource(resources, resourceId, bitmapOptions);
+    return BitmapFactory.decodeResource(resources, id, bitmapOptions);
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -48,6 +48,10 @@ import static com.squareup.picasso.TestUtils.MEDIA_STORE_CONTENT_1_URL;
 import static com.squareup.picasso.TestUtils.MEDIA_STORE_CONTENT_KEY_1;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_KEY_1;
+import static com.squareup.picasso.TestUtils.RESOURCE_ID_URI;
+import static com.squareup.picasso.TestUtils.RESOURCE_TYPE_URI;
+import static com.squareup.picasso.TestUtils.RESOURCE_ID_URI_KEY;
+import static com.squareup.picasso.TestUtils.RESOURCE_TYPE_URI_KEY;
 import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.mockAction;
@@ -222,6 +226,20 @@ public class BitmapHunterTest {
 
   @Test public void forAndroidResourceRequest() throws Exception {
     Action action = mockAction(RESOURCE_ID_KEY_1, null, null, RESOURCE_ID_1);
+    BitmapHunter hunter =
+        forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
+    assertThat(hunter).isInstanceOf(ResourceBitmapHunter.class);
+  }
+
+  @Test public void forAndroidResourceUriWithId() throws Exception {
+    Action action = mockAction(RESOURCE_ID_URI_KEY, RESOURCE_ID_URI);
+    BitmapHunter hunter =
+        forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
+    assertThat(hunter).isInstanceOf(ResourceBitmapHunter.class);
+  }
+
+  @Test public void forAndroidResourceUriWithType() throws Exception {
+    Action action = mockAction(RESOURCE_TYPE_URI_KEY, RESOURCE_TYPE_URI);
     BitmapHunter hunter =
         forRequest(context, picasso, dispatcher, cache, stats, action, downloader);
     assertThat(hunter).isInstanceOf(ResourceBitmapHunter.class);

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -15,6 +15,9 @@
 */
 package com.squareup.picasso;
 
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -24,9 +27,11 @@ import java.io.File;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import static android.content.ContentResolver.SCHEME_ANDROID_RESOURCE;
 import static android.provider.ContactsContract.Contacts.CONTENT_URI;
 import static android.provider.ContactsContract.Contacts.Photo.CONTENT_DIRECTORY;
 import static com.squareup.picasso.Utils.createKey;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -55,11 +60,42 @@ class TestUtils {
   static final String CONTACT_KEY_1 = createKey(new Request.Builder(CONTACT_URI_1).build());
   static final Uri CONTACT_PHOTO_URI_1 =
       CONTENT_URI.buildUpon().path("1234").path(CONTENT_DIRECTORY).build();
-  static final String CONTACT_PHOTO_KEY_1 = createKey(new Request.Builder(CONTACT_PHOTO_URI_1).build());
+  static final String CONTACT_PHOTO_KEY_1 =
+      createKey(new Request.Builder(CONTACT_PHOTO_URI_1).build());
   static final int RESOURCE_ID_1 = 1;
   static final String RESOURCE_ID_KEY_1 = createKey(new Request.Builder(RESOURCE_ID_1).build());
   static final Uri ASSET_URI_1 = Uri.parse("file:///android_asset/foo/bar.png");
   static final String ASSET_KEY_1 = createKey(new Request.Builder(ASSET_URI_1).build());
+  static final String RESOURCE_PACKAGE = "com.squareup.picasso";
+  static final String RESOURCE_TYPE = "drawable";
+  static final String RESOURCE_NAME = "foo";
+  static final Uri RESOURCE_ID_URI = new Uri.Builder().scheme(SCHEME_ANDROID_RESOURCE)
+      .authority(RESOURCE_PACKAGE)
+      .appendPath(Integer.toString(RESOURCE_ID_1))
+      .build();
+  static final String RESOURCE_ID_URI_KEY = createKey(new Request.Builder(RESOURCE_ID_URI).build());
+  static final Uri RESOURCE_TYPE_URI = new Uri.Builder().scheme(SCHEME_ANDROID_RESOURCE)
+      .authority(RESOURCE_PACKAGE)
+      .appendPath(RESOURCE_TYPE)
+      .appendPath(RESOURCE_NAME)
+      .build();
+  static final String RESOURCE_TYPE_URI_KEY =
+      createKey(new Request.Builder(RESOURCE_TYPE_URI).build());
+
+  static Context mockPackageResourceContext() {
+    Context context = mock(Context.class);
+    PackageManager pm = mock(PackageManager.class);
+    Resources res = mock(Resources.class);
+
+    doReturn(pm).when(context).getPackageManager();
+    try {
+      doReturn(res).when(pm).getResourcesForApplication(RESOURCE_PACKAGE);
+    } catch (PackageManager.NameNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    doReturn(RESOURCE_ID_1).when(res).getIdentifier(RESOURCE_NAME, RESOURCE_TYPE, RESOURCE_PACKAGE);
+    return context;
+  }
 
   static Action mockAction(String key, Uri uri) {
     return mockAction(key, uri, null, 0);

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -15,13 +15,20 @@
  */
 package com.squareup.picasso;
 
+import java.io.IOException;
+
+import android.content.res.Resources;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import java.io.ByteArrayInputStream;
 
+import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
+import static com.squareup.picasso.TestUtils.RESOURCE_ID_URI;
+import static com.squareup.picasso.TestUtils.RESOURCE_TYPE_URI;
 import static com.squareup.picasso.TestUtils.URI_1;
+import static com.squareup.picasso.TestUtils.mockPackageResourceContext;
 import static com.squareup.picasso.Utils.createKey;
 import static com.squareup.picasso.Utils.isWebPFile;
 import static com.squareup.picasso.Utils.parseResponseSourceHeader;
@@ -86,5 +93,19 @@ public class UtilsTest {
     assertThat(isWebPFile(new ByteArrayInputStream("ABCDxxxxWEBP".getBytes("US-ASCII")))).isFalse();
     assertThat(isWebPFile(new ByteArrayInputStream("RIFFxxxxABCD".getBytes("US-ASCII")))).isFalse();
     assertThat(isWebPFile(new ByteArrayInputStream("RIFFxxWEBP".getBytes("US-ASCII")))).isFalse();
+  }
+
+  @Test public void getResourceById() throws IOException {
+    Request request = new Request.Builder(RESOURCE_ID_URI).build();
+    Resources resources = Utils.getResources(mockPackageResourceContext(), request);
+    int id = Utils.getResourceId(resources, request);
+    assertThat(id).isEqualTo(RESOURCE_ID_1);
+  }
+
+  @Test public void getResourceByTypeAndName() throws IOException {
+    Request request = new Request.Builder(RESOURCE_TYPE_URI).build();
+    Resources resources = Utils.getResources(mockPackageResourceContext(), request);
+    int id = Utils.getResourceId(resources, request);
+    assertThat(id).isEqualTo(RESOURCE_ID_1);
   }
 }


### PR DESCRIPTION
Added full support for the android.resource style URI as outlined at the link below.

http://developer.android.com/reference/android/content/ContentResolver.html#openAssetFileDescriptor(android.net.Uri, java.lang.String)
