### PR TITLE
Bugfix. only-if-cached was invalid for okhttp

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
@@ -99,7 +99,7 @@ public class OkHttpDownloader implements Downloader {
     HttpURLConnection connection = openConnection(uri);
     connection.setUseCaches(true);
     if (localCacheOnly) {
-      connection.setRequestProperty("Cache-Control", "only-if-cached;max-age=" + Integer.MAX_VALUE);
+      connection.setRequestProperty("Cache-Control", "only-if-cached,max-age=" + Integer.MAX_VALUE);
     }
 
     int responseCode = connection.getResponseCode();

--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
@@ -58,7 +58,7 @@ public class UrlConnectionDownloader implements Downloader {
     HttpURLConnection connection = openConnection(uri);
     connection.setUseCaches(true);
     if (localCacheOnly) {
-      connection.setRequestProperty("Cache-Control", "only-if-cached;max-age=" + Integer.MAX_VALUE);
+      connection.setRequestProperty("Cache-Control", "only-if-cached,max-age=" + Integer.MAX_VALUE);
     }
 
     int responseCode = connection.getResponseCode();

--- a/picasso/src/test/java/com/squareup/picasso/OkHttpDownloaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/OkHttpDownloaderTest.java
@@ -78,7 +78,7 @@ public class OkHttpDownloaderTest {
     loader.load(URL, true);
     RecordedRequest request2 = server.takeRequest();
     assertThat(request2.getHeader("Cache-Control")) //
-        .isEqualTo("only-if-cached;max-age=" + Integer.MAX_VALUE);
+        .isEqualTo("only-if-cached,max-age=" + Integer.MAX_VALUE);
   }
 
   @Test public void responseSourceHeaderSetsResponseValue() throws Exception {

--- a/picasso/src/test/java/com/squareup/picasso/UrlConnectionDownloaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UrlConnectionDownloaderTest.java
@@ -104,7 +104,7 @@ public class UrlConnectionDownloaderTest {
     loader.load(URL, true);
     RecordedRequest request2 = server.takeRequest();
     assertThat(request2.getHeader("Cache-Control")) //
-        .isEqualTo("only-if-cached;max-age=" + Integer.MAX_VALUE);
+        .isEqualTo("only-if-cached,max-age=" + Integer.MAX_VALUE);
   }
 
   @Config(reportSdk = GINGERBREAD)


### PR DESCRIPTION
Okhttp use ',' to split directives.
Use ';' would make Okhttp's HeaderParser split directive as "only-if-cached;max-age", and make localCacheOnly load fail. 
