### PR TITLE
Added possibility to specify Bitmap.Config for image decoding

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/AssetBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/AssetBitmapHunter.java
@@ -33,9 +33,8 @@ class AssetBitmapHunter extends BitmapHunter {
   }
 
   Bitmap decodeAsset(String filePath) throws IOException {
-    BitmapFactory.Options options = null;
+    BitmapFactory.Options options = createBitmapOptions(data);
     if (data.hasSize()) {
-      options = new BitmapFactory.Options();
       options.inJustDecodeBounds = true;
       InputStream is = null;
       try {

--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -216,6 +216,14 @@ abstract class BitmapHunter implements Runnable {
     }
   }
 
+  static BitmapFactory.Options createBitmapOptions(Request data) {
+    BitmapFactory.Options options = new BitmapFactory.Options();
+    if (data.config != null) {
+      options.inPreferredConfig = data.config;
+    }
+    return options;
+  }
+
   static void calculateInSampleSize(int reqWidth, int reqHeight, BitmapFactory.Options options) {
     calculateInSampleSize(reqWidth, reqHeight, options.outWidth, options.outHeight, options);
   }

--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
@@ -106,9 +106,8 @@ class ContactsPhotoBitmapHunter extends BitmapHunter {
     if (stream == null) {
       return null;
     }
-    BitmapFactory.Options options = null;
+    BitmapFactory.Options options = createBitmapOptions(data);
     if (data.hasSize()) {
-      options = new BitmapFactory.Options();
       options.inJustDecodeBounds = true;
       InputStream is = getInputStream();
       try {

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamBitmapHunter.java
@@ -44,9 +44,8 @@ class ContentStreamBitmapHunter extends BitmapHunter {
 
   protected Bitmap decodeContentStream(Request data) throws IOException {
     ContentResolver contentResolver = context.getContentResolver();
-    BitmapFactory.Options options = null;
+    BitmapFactory.Options options = createBitmapOptions(data);
     if (data.hasSize()) {
-      options = new BitmapFactory.Options();
       options.inJustDecodeBounds = true;
       InputStream is = null;
       try {

--- a/picasso/src/main/java/com/squareup/picasso/MediaStoreBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/MediaStoreBitmapHunter.java
@@ -55,7 +55,7 @@ class MediaStoreBitmapHunter extends ContentStreamBitmapHunter {
 
       long id = parseId(data.uri);
 
-      BitmapFactory.Options options = new BitmapFactory.Options();
+      BitmapFactory.Options options = createBitmapOptions(data);
       options.inJustDecodeBounds = true;
 
       calculateInSampleSize(data.targetWidth, data.targetHeight, picassoKind.width,

--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -87,9 +87,8 @@ class NetworkBitmapHunter extends BitmapHunter {
     // Decode byte array instead
     if (isWebPFile) {
       byte[] bytes = Utils.toByteArray(stream);
-      BitmapFactory.Options options = null;
+      BitmapFactory.Options options = createBitmapOptions(data);
       if (data.hasSize()) {
-        options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
 
         BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
@@ -97,9 +96,8 @@ class NetworkBitmapHunter extends BitmapHunter {
       }
       return BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
     } else {
-      BitmapFactory.Options options = null;
+      BitmapFactory.Options options = createBitmapOptions(data);
       if (data.hasSize()) {
-        options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
 
         BitmapFactory.decodeStream(stream, null, options);

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.picasso;
 
+import android.graphics.Bitmap;
 import android.net.Uri;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,10 +62,12 @@ public final class Request {
   public final float rotationPivotY;
   /** Whether or not {@link #rotationPivotX} and {@link #rotationPivotY} are set. */
   public final boolean hasRotationPivot;
+  /** Target image config for decoding. */
+  public final Bitmap.Config config;
 
   private Request(Uri uri, int resourceId, List<Transformation> transformations, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
-      float rotationPivotX, float rotationPivotY, boolean hasRotationPivot) {
+      float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config) {
     this.uri = uri;
     this.resourceId = resourceId;
     if (transformations == null) {
@@ -80,6 +83,7 @@ public final class Request {
     this.rotationPivotX = rotationPivotX;
     this.rotationPivotY = rotationPivotY;
     this.hasRotationPivot = hasRotationPivot;
+    this.config = config;
   }
 
   String getName() {
@@ -122,6 +126,7 @@ public final class Request {
     private float rotationPivotY;
     private boolean hasRotationPivot;
     private List<Transformation> transformations;
+    private Bitmap.Config config;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(Uri uri) {
@@ -152,6 +157,7 @@ public final class Request {
       if (request.transformations != null) {
         transformations = new ArrayList<Transformation>(request.transformations);
       }
+      config = request.config;
     }
 
     boolean hasImage() {
@@ -273,6 +279,12 @@ public final class Request {
       return this;
     }
 
+    /** Decode the image using the specified config. */
+    public Builder config(Bitmap.Config config) {
+      this.config = config;
+      return this;
+    }
+
     /**
      * Add a custom transformation to be applied to the image.
      * <p/>
@@ -301,7 +313,7 @@ public final class Request {
         throw new IllegalStateException("Center inside requires calling resize.");
       }
       return new Request(uri, resourceId, transformations, targetWidth, targetHeight, centerCrop,
-          centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot);
+          centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -20,8 +20,9 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.widget.ImageView;
-import java.io.IOException;
 import org.jetbrains.annotations.TestOnly;
+
+import java.io.IOException;
 
 import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
@@ -171,6 +172,12 @@ public class RequestCreator {
   /** Rotate the image by the specified degrees around a pivot point. */
   public RequestCreator rotate(float degrees, float pivotX, float pivotY) {
     data.rotate(degrees, pivotX, pivotY);
+    return this;
+  }
+
+  /** Decode the image using the specified config. */
+  public RequestCreator config(Bitmap.Config config) {
+    data.config(config);
     return this;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ResourceBitmapHunter.java
@@ -43,9 +43,8 @@ class ResourceBitmapHunter extends BitmapHunter {
   }
 
   private Bitmap decodeResource(Resources resources, int id, Request data) {
-    BitmapFactory.Options bitmapOptions = null;
+    BitmapFactory.Options bitmapOptions = createBitmapOptions(data);
     if (data.hasSize()) {
-      bitmapOptions = new BitmapFactory.Options();
       bitmapOptions.inJustDecodeBounds = true;
       BitmapFactory.decodeResource(resources, id, bitmapOptions);
       calculateInSampleSize(data.targetWidth, data.targetHeight, bitmapOptions);

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -32,6 +32,7 @@ import org.robolectric.shadows.ShadowBitmap;
 import org.robolectric.shadows.ShadowMatrix;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
+import static com.squareup.picasso.BitmapHunter.createBitmapOptions;
 import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.BitmapHunter.transformResult;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
@@ -326,6 +327,16 @@ public class BitmapHunterTest {
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
     assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 1.5");
+  }
+
+  @Test public void bitmapConfig() throws Exception {
+    for (Bitmap.Config config : Bitmap.Config.values()) {
+      Request data = new Request.Builder(URI_1).config(config).build();
+      Request copy = data.buildUpon().build();
+
+      assertThat(createBitmapOptions(data).inPreferredConfig).isSameAs(config);
+      assertThat(createBitmapOptions(copy).inPreferredConfig).isSameAs(config);
+    }
   }
 
   @Test public void centerCropTallTooSmall() throws Exception {


### PR DESCRIPTION
Hello.

I have to deal with very large images (`4096x2048` pixels) in my app, so using `Bitmap.Config.RGB_565` instead of `Bitmap.Config.ARGB_8888` is essential for me. Unfortunately, there is no way to change the config in `picasso`, so I have added it.
