### PR TITLE
Setting BitmapFactory.Options.inMutable to true when available

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -21,6 +21,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.NetworkInfo;
 import android.net.Uri;
+import android.os.Build;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -217,6 +218,9 @@ abstract class BitmapHunter implements Runnable {
 
     options.inSampleSize = sampleSize;
     options.inJustDecodeBounds = false;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
+      options.inMutable = true;
+    }
   }
 
   static Bitmap applyCustomTransformations(List<Transformation> transformations, Bitmap result) {


### PR DESCRIPTION
I ran into a situation where the `Bitmap` supplied to my `Transformation` was immutable.  From Honeycomb we can set inMutable for all decodes to guarantee that the bitmaps will be mutable.  I don't believe this has any negative effects, even if the bitmap is never mutated.

Admittedly, `calculateInSampleSize` is probably not a great place for this, but it served as a nice centralised location for a PoC.  Ultimately this should probably be implemented in a more independent manner, since `calculateInSampleSize` won't always necessarily be called.
