### PR TITLE
Update comments to reflect that memory cache isn't capped anymore.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -375,7 +375,7 @@ public class Picasso {
    * This instance is automatically initialized with defaults that are suitable to most
    * implementations.
    * <ul>
-   * <li>LRU memory cache of 15% the available application RAM up to 20MB</li>
+   * <li>LRU memory cache of 15% the available application RAM</li>
    * <li>Disk cache of 2% storage space up to 50MB but no less than 5MB. (Note: this is only
    * available on API 14+ <em>or</em> if you are using a standalone library that provides a disk
    * cache on all API levels like OkHttp)</li>


### PR DESCRIPTION
A previous change https://github.com/square/picasso/commit/f79dd0af3274b511c6d9521aa9e5cf3b2ee7d704 removed the cap on the memory cache.
