### PR TITLE
Add null check for Intent

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
+++ b/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
@@ -290,6 +290,11 @@ class Dispatcher {
     }
 
     @Override public void onReceive(Context context, Intent intent) {
+      // On some versions of Android this may be called with a null Intent
+      if (null == intent) {
+        return;
+      }
+
       String action = intent.getAction();
       Bundle extras = intent.getExtras();
 


### PR DESCRIPTION
We got the following in one of our Crashlytics logs, on a Dell Venue 8
3830 running Android 4.2.2:

java.lang.RuntimeException: Error receiving broadcast Intent {
act=android.intent.action.AIRPLANE_MODE flg=0x10 } in
com.squareup.picasso.Dispatcher$NetworkBroadcastReceiver@210e9298
       at
android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:768)
       at android.os.Handler.handleCallback(Handler.java:725)
       at android.os.Handler.dispatchMessage(Handler.java:92)
       at android.os.Looper.loop(Looper.java:152)
       at android.app.ActivityThread.main(ActivityThread.java:5132)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:511)
       at
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.ja
va:793)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:560)
       at dalvik.system.NativeStart.main(NativeStart.java)
Caused by: java.lang.NullPointerException
       at
com.squareup.picasso.Dispatcher$NetworkBroadcastReceiver.onReceive(Dispa
tcher.java:291)
       at
android.app.LoadedApk$ReceiverDispatcher$Args.run(LoadedApk.java:758)
       at android.os.Handler.handleCallback(Handler.java:725)
       at android.os.Handler.dispatchMessage(Handler.java:92)
       at android.os.Looper.loop(Looper.java:152)
       at android.app.ActivityThread.main(ActivityThread.java:5132)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:511)
       at
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.ja
va:793)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:560)
       at dalvik.system.NativeStart.main(NativeStart.java)
