### PR TITLE
Switch conditional to OR.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -345,7 +345,7 @@ public class RequestCreator {
       }
       int measuredWidth = target.getMeasuredWidth();
       int measuredHeight = target.getMeasuredHeight();
-      if (measuredWidth == 0 && measuredHeight == 0) {
+      if (measuredWidth == 0 || measuredHeight == 0) {
         PicassoDrawable.setPlaceholder(target, placeholderResId, placeholderDrawable);
         picasso.defer(target, new DeferredRequestCreator(this, target, callback));
         return;


### PR DESCRIPTION
`Request` will throw if `height` is zero which it previously could do on multi-pass layouts in adapters.
