### PR TITLE
Added a drawableFactory API to Picasso.

### DIFF
--- a/picasso-sample/AndroidManifest.xml
+++ b/picasso-sample/AndroidManifest.xml
@@ -34,6 +34,7 @@
       </intent-filter>
     </activity>
 
+    <activity android:name=".SampleGridViewWithEffectsActivity"/>
     <activity android:name=".SampleContactsActivity"/>
     <activity android:name=".SampleGalleryActivity"/>
     <activity android:name=".SampleListDetailActivity"/>

--- a/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.java
@@ -21,6 +21,7 @@ final class PicassoSampleAdapter extends BaseAdapter {
 
   enum Sample {
     GRID_VIEW("Image Grid View", SampleGridViewActivity.class),
+    GRID_VIEW_EFFECTS("Image Grid View With Effects", SampleGridViewWithEffectsActivity.class),
     GALLERY("Load from Gallery", SampleGalleryActivity.class),
     CONTACTS("Contact Photos", SampleContactsActivity.class),
     LIST_DETAIL("List / Detail View", SampleListDetailActivity.class),

--- a/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
@@ -1,10 +1,15 @@
 package com.example.picasso;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import com.squareup.picasso.Picasso;
+import com.squareup.picasso.RequestCreator;
+import com.squareup.picasso.TargetTransformation;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -14,9 +19,11 @@ import static android.widget.ImageView.ScaleType.CENTER_CROP;
 final class SampleGridViewAdapter extends BaseAdapter {
   private final Context context;
   private final List<String> urls = new ArrayList<String>();
+  private boolean useShaderEffects = false;
 
-  public SampleGridViewAdapter(Context context) {
+  public SampleGridViewAdapter(Context context, boolean useShaderEffects) {
     this.context = context;
+    this.useShaderEffects = useShaderEffects;
 
     // Ensure we get a different ordering of images on each run.
     Collections.addAll(urls, Data.URLS);
@@ -39,12 +46,20 @@ final class SampleGridViewAdapter extends BaseAdapter {
     String url = getItem(position);
 
     // Trigger the download of the URL asynchronously into the image view.
-    Picasso.with(context) //
-        .load(url) //
-        .placeholder(R.drawable.placeholder) //
-        .error(R.drawable.error) //
-        .fit() //
-        .into(view);
+    RequestCreator creator = Picasso.with(context) //
+            .load(url) //
+            .placeholder(R.drawable.placeholder) //
+            .error(R.drawable.error) //
+            .fit();
+    if (useShaderEffects) {
+      creator.transformTarget(new TargetTransformation() {
+            @Override
+            public Drawable transform(Bitmap source) {
+              return new ShaderEffectsDrawable(source);
+            }
+        });
+      }
+    creator.into(view);
 
     return view;
   }

--- a/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
@@ -6,9 +6,9 @@ import android.graphics.drawable.Drawable;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
+import com.squareup.picasso.DrawableFactory;
 import com.squareup.picasso.Picasso;
 import com.squareup.picasso.RequestCreator;
-import com.squareup.picasso.TargetTransformation;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -19,7 +19,8 @@ import static android.widget.ImageView.ScaleType.CENTER_CROP;
 final class SampleGridViewAdapter extends BaseAdapter {
   private final Context context;
   private final List<String> urls = new ArrayList<String>();
-  private boolean useShaderEffects = false;
+  private final boolean useShaderEffects;
+  private final DrawableFactory drawableFactory;
 
   public SampleGridViewAdapter(Context context, boolean useShaderEffects) {
     this.context = context;
@@ -33,6 +34,13 @@ final class SampleGridViewAdapter extends BaseAdapter {
     ArrayList<String> copy = new ArrayList<String>(urls);
     urls.addAll(copy);
     urls.addAll(copy);
+
+    drawableFactory = new DrawableFactory() {
+      @Override
+      public Drawable createDrawable(Bitmap source) {
+        return new ShaderEffectsDrawable(source);
+      }
+    };
   }
 
   @Override public View getView(int position, View convertView, ViewGroup parent) {
@@ -47,18 +55,13 @@ final class SampleGridViewAdapter extends BaseAdapter {
 
     // Trigger the download of the URL asynchronously into the image view.
     RequestCreator creator = Picasso.with(context) //
-            .load(url) //
-            .placeholder(R.drawable.placeholder) //
-            .error(R.drawable.error) //
-            .fit();
+        .load(url) //
+        .placeholder(R.drawable.placeholder) //
+        .error(R.drawable.error) //
+        .fit();
     if (useShaderEffects) {
-      creator.transformTarget(new TargetTransformation() {
-            @Override
-            public Drawable transform(Bitmap source) {
-              return new ShaderEffectsDrawable(source);
-            }
-        });
-      }
+      creator.drawableFactory(drawableFactory);
+    }
     creator.into(view);
 
     return view;

--- a/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
@@ -19,12 +19,10 @@ import static android.widget.ImageView.ScaleType.CENTER_CROP;
 final class SampleGridViewAdapter extends BaseAdapter {
   private final Context context;
   private final List<String> urls = new ArrayList<String>();
-  private final boolean useShaderEffects;
   private final DrawableFactory drawableFactory;
 
   public SampleGridViewAdapter(Context context, boolean useShaderEffects) {
     this.context = context;
-    this.useShaderEffects = useShaderEffects;
 
     // Ensure we get a different ordering of images on each run.
     Collections.addAll(urls, Data.URLS);
@@ -35,12 +33,16 @@ final class SampleGridViewAdapter extends BaseAdapter {
     urls.addAll(copy);
     urls.addAll(copy);
 
-    drawableFactory = new DrawableFactory() {
-      @Override
-      public Drawable createDrawable(Bitmap source) {
-        return new ShaderEffectsDrawable(source);
-      }
-    };
+    if (useShaderEffects) {
+      drawableFactory = new DrawableFactory() {
+        @Override
+        public Drawable createDrawable(Bitmap source) {
+          return new ShaderEffectsDrawable(source);
+        }
+      };
+    } else {
+      drawableFactory = null;
+    }
   }
 
   @Override public View getView(int position, View convertView, ViewGroup parent) {
@@ -59,7 +61,7 @@ final class SampleGridViewAdapter extends BaseAdapter {
         .placeholder(R.drawable.placeholder) //
         .error(R.drawable.error) //
         .fit();
-    if (useShaderEffects) {
+    if (drawableFactory != null) {
       creator.drawableFactory(drawableFactory);
     }
     creator.into(view);

--- a/picasso-sample/src/main/java/com/example/picasso/SampleGridViewWithEffectsActivity.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGridViewWithEffectsActivity.java
@@ -3,12 +3,12 @@ package com.example.picasso;
 import android.os.Bundle;
 import android.widget.GridView;
 
-public class SampleGridViewActivity extends PicassoSampleActivity {
+public class SampleGridViewWithEffectsActivity extends PicassoSampleActivity {
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.sample_gridview_activity);
 
     GridView gv = (GridView) findViewById(R.id.grid_view);
-    gv.setAdapter(new SampleGridViewAdapter(this, false));
+    gv.setAdapter(new SampleGridViewAdapter(this, true));
   }
 }

--- a/picasso-sample/src/main/java/com/example/picasso/ShaderEffectsDrawable.java
+++ b/picasso-sample/src/main/java/com/example/picasso/ShaderEffectsDrawable.java
@@ -1,0 +1,74 @@
+package com.example.picasso;
+
+import android.graphics.*;
+import android.graphics.drawable.Drawable;
+
+public class ShaderEffectsDrawable extends Drawable {
+
+  private Bitmap bitmap;
+  private Paint bitmapPaint;
+
+  public ShaderEffectsDrawable(Bitmap bitmap) {
+    this.bitmap = bitmap;
+
+    bitmapPaint = new Paint();
+    bitmapPaint.setAntiAlias(true);
+
+    int radius = bitmap.getWidth() / 2;
+
+    RadialGradient vignette = new RadialGradient( radius, radius, radius, new int[] { 0, 0, 0x7f000000 },
+            new float[] { 0.0f, 0.8f, 1.0f }, Shader.TileMode.CLAMP);
+    Matrix oval = new Matrix(); oval.setScale(1.0f, 0.8f); vignette.setLocalMatrix(oval);
+
+    // We can use shaders for adding effects
+    bitmapPaint.setShader(new ComposeShader(new BitmapShader(this.bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP), vignette, PorterDuff.Mode.SRC_OVER));
+
+    // We can add a little sepia effect to the Paint using color filters.
+    ColorMatrix m1 = new ColorMatrix();
+    ColorMatrix m2 = new ColorMatrix();
+    m1.setSaturation(0.1f);
+    m2.setScale(1f, 0.95f, 0.82f, 1.0f);
+    m1.setConcat(m2, m1);
+    bitmapPaint.setColorFilter(new ColorMatrixColorFilter(m1));
+  }
+
+  @Override
+  public void draw(Canvas canvas) {
+    final Rect bounds = getBounds();
+    canvas.translate(bounds.left, bounds.top);
+    final long centerX = bounds.width() / 2;
+    final long centerY = bounds.height() / 2;
+    final long radius = Math.min(bounds.width(), bounds.height()) / 2;
+
+    // Image
+    canvas.drawCircle(centerX, centerY, radius, bitmapPaint);
+  }
+
+  @Override
+  public void setAlpha(int alpha) {
+    bitmapPaint.setAlpha(alpha);
+  }
+
+  @Override
+  public void setColorFilter(ColorFilter cf) {
+    bitmapPaint.setColorFilter(cf);
+  }
+
+  @Override
+  public int getOpacity() {
+    Bitmap bm = bitmap;
+    return (bm == null || bm.hasAlpha() || bitmapPaint.getAlpha() < 255) ?
+            PixelFormat.TRANSLUCENT : PixelFormat.OPAQUE;
+  }
+
+  @Override
+  public int getIntrinsicHeight() {
+    return bitmap.getHeight();
+  }
+
+  @Override
+  public int getIntrinsicWidth() {
+    return bitmap.getWidth();
+  }
+
+}

--- a/picasso-sample/src/main/java/com/example/picasso/ShaderEffectsDrawable.java
+++ b/picasso-sample/src/main/java/com/example/picasso/ShaderEffectsDrawable.java
@@ -1,6 +1,19 @@
 package com.example.picasso;
 
-import android.graphics.*;
+import android.graphics.Bitmap;
+import android.graphics.Paint;
+import android.graphics.RadialGradient;
+import android.graphics.Shader;
+import android.graphics.Matrix;
+import android.graphics.ComposeShader;
+import android.graphics.BitmapShader;
+import android.graphics.PorterDuff;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.graphics.ColorFilter;
+import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
 
 public class ShaderEffectsDrawable extends Drawable {
@@ -16,12 +29,13 @@ public class ShaderEffectsDrawable extends Drawable {
 
     int radius = bitmap.getWidth() / 2;
 
-    RadialGradient vignette = new RadialGradient( radius, radius, radius, new int[] { 0, 0, 0x7f000000 },
-            new float[] { 0.0f, 0.8f, 1.0f }, Shader.TileMode.CLAMP);
+    RadialGradient vignette = new RadialGradient(radius, radius, radius,
+        new int[] {0, 0, 0x7f000000}, new float[] {0.0f, 0.8f, 1.0f}, Shader.TileMode.CLAMP);
     Matrix oval = new Matrix(); oval.setScale(1.0f, 0.8f); vignette.setLocalMatrix(oval);
 
     // We can use shaders for adding effects
-    bitmapPaint.setShader(new ComposeShader(new BitmapShader(this.bitmap, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP), vignette, PorterDuff.Mode.SRC_OVER));
+    bitmapPaint.setShader(new ComposeShader(new BitmapShader(this.bitmap, Shader.TileMode.CLAMP,
+        Shader.TileMode.CLAMP), vignette, PorterDuff.Mode.SRC_OVER));
 
     // We can add a little sepia effect to the Paint using color filters.
     ColorMatrix m1 = new ColorMatrix();
@@ -57,8 +71,8 @@ public class ShaderEffectsDrawable extends Drawable {
   @Override
   public int getOpacity() {
     Bitmap bm = bitmap;
-    return (bm == null || bm.hasAlpha() || bitmapPaint.getAlpha() < 255) ?
-            PixelFormat.TRANSLUCENT : PixelFormat.OPAQUE;
+    return (bm == null || bm.hasAlpha() || bitmapPaint.getAlpha() < 255)
+        ? PixelFormat.TRANSLUCENT : PixelFormat.OPAQUE;
   }
 
   @Override

--- a/picasso-sample/src/main/java/com/example/picasso/ShaderEffectsDrawable.java
+++ b/picasso-sample/src/main/java/com/example/picasso/ShaderEffectsDrawable.java
@@ -18,20 +18,23 @@ import android.graphics.drawable.Drawable;
 
 public class ShaderEffectsDrawable extends Drawable {
 
-  private Bitmap bitmap;
-  private Paint bitmapPaint;
+  private final Bitmap bitmap;
+  private final Paint bitmapPaint;
 
   public ShaderEffectsDrawable(Bitmap bitmap) {
     this.bitmap = bitmap;
+    if (bitmap == null) {
+      throw new NullPointerException("Bitmap cannot be null.");
+    }
 
-    bitmapPaint = new Paint();
-    bitmapPaint.setAntiAlias(true);
+    bitmapPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
     int radius = bitmap.getWidth() / 2;
-
     RadialGradient vignette = new RadialGradient(radius, radius, radius,
-        new int[] {0, 0, 0x7f000000}, new float[] {0.0f, 0.8f, 1.0f}, Shader.TileMode.CLAMP);
-    Matrix oval = new Matrix(); oval.setScale(1.0f, 0.8f); vignette.setLocalMatrix(oval);
+        new int[]{0, 0, 0x7f000000}, new float[]{0.0f, 0.8f, 1.0f}, Shader.TileMode.CLAMP);
+    Matrix oval = new Matrix();
+    oval.setScale(1.0f, 0.8f);
+    vignette.setLocalMatrix(oval);
 
     // We can use shaders for adding effects
     bitmapPaint.setShader(new ComposeShader(new BitmapShader(this.bitmap, Shader.TileMode.CLAMP,
@@ -46,42 +49,34 @@ public class ShaderEffectsDrawable extends Drawable {
     bitmapPaint.setColorFilter(new ColorMatrixColorFilter(m1));
   }
 
-  @Override
-  public void draw(Canvas canvas) {
+  @Override public void draw(Canvas canvas) {
     final Rect bounds = getBounds();
     canvas.translate(bounds.left, bounds.top);
     final long centerX = bounds.width() / 2;
     final long centerY = bounds.height() / 2;
     final long radius = Math.min(bounds.width(), bounds.height()) / 2;
-
-    // Image
     canvas.drawCircle(centerX, centerY, radius, bitmapPaint);
   }
 
-  @Override
-  public void setAlpha(int alpha) {
+  @Override public void setAlpha(int alpha) {
     bitmapPaint.setAlpha(alpha);
   }
 
-  @Override
-  public void setColorFilter(ColorFilter cf) {
-    bitmapPaint.setColorFilter(cf);
+  @Override public void setColorFilter(ColorFilter cf) {
+    throw new UnsupportedOperationException("Custom ColorFilters not supported");
   }
 
-  @Override
-  public int getOpacity() {
+  @Override public int getOpacity() {
     Bitmap bm = bitmap;
-    return (bm == null || bm.hasAlpha() || bitmapPaint.getAlpha() < 255)
+    return (bm.hasAlpha() || bitmapPaint.getAlpha() < 255)
         ? PixelFormat.TRANSLUCENT : PixelFormat.OPAQUE;
   }
 
-  @Override
-  public int getIntrinsicHeight() {
+  @Override public int getIntrinsicHeight() {
     return bitmap.getHeight();
   }
 
-  @Override
-  public int getIntrinsicWidth() {
+  @Override public int getIntrinsicWidth() {
     return bitmap.getWidth();
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/DrawableFactory.java
+++ b/picasso/src/main/java/com/squareup/picasso/DrawableFactory.java
@@ -18,12 +18,12 @@ package com.squareup.picasso;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 
-/** Target Drawable transformation. */
-public interface TargetTransformation {
+/** Factory for creating a custom Drawable the final bitmap will be wrapped into. . */
+public interface DrawableFactory {
 
   /**
-   * Transform the target drawable the bitmap will be wrapped into.
+   * Create a custom drawable the bitmap will be wrapped into.
    */
-  Drawable transform(Bitmap source);
+  Drawable createDrawable(Bitmap source);
 
 }

--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -43,7 +43,8 @@ class ImageViewAction extends Action<ImageView> {
 
     Context context = picasso.context;
     boolean debugging = picasso.debugging;
-    PicassoDrawable.setBitmap(target, context, result, from, noFade, debugging);
+    TargetTransformation targetTransformation = data == null ? null : data.targetTransformation;
+    PicassoDrawable.setBitmap(target, context, result, from, noFade, debugging, targetTransformation);
 
     if (callback != null) {
       callback.onSuccess();

--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -43,9 +43,9 @@ class ImageViewAction extends Action<ImageView> {
 
     Context context = picasso.context;
     boolean debugging = picasso.debugging;
-    TargetTransformation targetTransformation = data == null ? null : data.targetTransformation;
+    DrawableFactory drawableFactory = data == null ? null : data.drawableFactory;
     PicassoDrawable.setBitmap(target, context, result, from, noFade,
-          debugging, targetTransformation);
+          debugging, drawableFactory);
 
     if (callback != null) {
       callback.onSuccess();

--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -44,7 +44,8 @@ class ImageViewAction extends Action<ImageView> {
     Context context = picasso.context;
     boolean debugging = picasso.debugging;
     TargetTransformation targetTransformation = data == null ? null : data.targetTransformation;
-    PicassoDrawable.setBitmap(target, context, result, from, noFade, debugging, targetTransformation);
+    PicassoDrawable.setBitmap(target, context, result, from, noFade,
+          debugging, targetTransformation);
 
     if (callback != null) {
       callback.onSuccess();

--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -44,13 +44,13 @@ final class PicassoDrawable extends Drawable {
    * image.
    */
   static void setBitmap(ImageView target, Context context, Bitmap bitmap,
-      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging) {
+      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging, TargetTransformation targetTransformation) {
     Drawable placeholder = target.getDrawable();
     if (placeholder instanceof AnimationDrawable) {
       ((AnimationDrawable) placeholder).stop();
     }
     PicassoDrawable drawable =
-        new PicassoDrawable(context, placeholder, bitmap, loadedFrom, noFade, debugging);
+        new PicassoDrawable(context, placeholder, bitmap, loadedFrom, noFade, debugging, targetTransformation);
     target.setImageDrawable(drawable);
   }
 
@@ -72,7 +72,7 @@ final class PicassoDrawable extends Drawable {
   private final boolean debugging;
   private final float density;
   private final Picasso.LoadedFrom loadedFrom;
-  final BitmapDrawable image;
+  final Drawable image;
 
   Drawable placeholder;
 
@@ -81,7 +81,7 @@ final class PicassoDrawable extends Drawable {
   int alpha = 0xFF;
 
   PicassoDrawable(Context context, Drawable placeholder, Bitmap bitmap,
-      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging) {
+      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging, TargetTransformation targetTransformation) {
     Resources res = context.getResources();
 
     this.debugging = debugging;
@@ -89,7 +89,11 @@ final class PicassoDrawable extends Drawable {
 
     this.loadedFrom = loadedFrom;
 
-    this.image = new BitmapDrawable(res, bitmap);
+    if (targetTransformation == null) {
+        this.image = new BitmapDrawable(res, bitmap);
+    } else {
+        this.image = targetTransformation.transform(bitmap);
+    }
 
     boolean fade = loadedFrom != MEMORY && !noFade;
     if (fade) {

--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -44,13 +44,15 @@ final class PicassoDrawable extends Drawable {
    * image.
    */
   static void setBitmap(ImageView target, Context context, Bitmap bitmap,
-      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging, TargetTransformation targetTransformation) {
+      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging,
+      TargetTransformation targetTransformation) {
     Drawable placeholder = target.getDrawable();
     if (placeholder instanceof AnimationDrawable) {
       ((AnimationDrawable) placeholder).stop();
     }
     PicassoDrawable drawable =
-        new PicassoDrawable(context, placeholder, bitmap, loadedFrom, noFade, debugging, targetTransformation);
+        new PicassoDrawable(context, placeholder, bitmap, loadedFrom, noFade,
+              debugging, targetTransformation);
     target.setImageDrawable(drawable);
   }
 
@@ -81,7 +83,8 @@ final class PicassoDrawable extends Drawable {
   int alpha = 0xFF;
 
   PicassoDrawable(Context context, Drawable placeholder, Bitmap bitmap,
-      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging, TargetTransformation targetTransformation) {
+      Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging,
+      TargetTransformation targetTransformation) {
     Resources res = context.getResources();
 
     this.debugging = debugging;

--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -45,14 +45,14 @@ final class PicassoDrawable extends Drawable {
    */
   static void setBitmap(ImageView target, Context context, Bitmap bitmap,
       Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging,
-      TargetTransformation targetTransformation) {
+      DrawableFactory drawableFactory) {
     Drawable placeholder = target.getDrawable();
     if (placeholder instanceof AnimationDrawable) {
       ((AnimationDrawable) placeholder).stop();
     }
     PicassoDrawable drawable =
         new PicassoDrawable(context, placeholder, bitmap, loadedFrom, noFade,
-              debugging, targetTransformation);
+              debugging, drawableFactory);
     target.setImageDrawable(drawable);
   }
 
@@ -84,7 +84,7 @@ final class PicassoDrawable extends Drawable {
 
   PicassoDrawable(Context context, Drawable placeholder, Bitmap bitmap,
       Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging,
-      TargetTransformation targetTransformation) {
+      DrawableFactory drawableFactory) {
     Resources res = context.getResources();
 
     this.debugging = debugging;
@@ -92,10 +92,10 @@ final class PicassoDrawable extends Drawable {
 
     this.loadedFrom = loadedFrom;
 
-    if (targetTransformation == null) {
-        this.image = new BitmapDrawable(res, bitmap);
+    if (drawableFactory != null) {
+      this.image = drawableFactory.createDrawable(bitmap);
     } else {
-        this.image = targetTransformation.transform(bitmap);
+      this.image = new BitmapDrawable(res, bitmap);
     }
 
     boolean fade = loadedFrom != MEMORY && !noFade;

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -38,6 +38,7 @@ public final class Request {
   public final int resourceId;
   /** List of custom transformations to be applied after the built-in transformations. */
   public final List<Transformation> transformations;
+  public final TargetTransformation targetTransformation;
   /** Target image width for resizing. */
   public final int targetWidth;
   /** Target image height for resizing. */
@@ -65,7 +66,7 @@ public final class Request {
   /** Target image config for decoding. */
   public final Bitmap.Config config;
 
-  private Request(Uri uri, int resourceId, List<Transformation> transformations, int targetWidth,
+  private Request(Uri uri, int resourceId, List<Transformation> transformations, TargetTransformation targetTransformation, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
       float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config) {
     this.uri = uri;
@@ -75,6 +76,7 @@ public final class Request {
     } else {
       this.transformations = unmodifiableList(transformations);
     }
+    this.targetTransformation = targetTransformation;
     this.targetWidth = targetWidth;
     this.targetHeight = targetHeight;
     this.centerCrop = centerCrop;
@@ -127,6 +129,7 @@ public final class Request {
     private boolean hasRotationPivot;
     private List<Transformation> transformations;
     private Bitmap.Config config;
+    private TargetTransformation targetTransformation;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(Uri uri) {
@@ -154,6 +157,7 @@ public final class Request {
       rotationPivotX = request.rotationPivotX;
       rotationPivotY = request.rotationPivotY;
       hasRotationPivot = request.hasRotationPivot;
+      targetTransformation = request.targetTransformation;
       if (request.transformations != null) {
         transformations = new ArrayList<Transformation>(request.transformations);
       }
@@ -261,6 +265,18 @@ public final class Request {
       return this;
     }
 
+    /**
+     * Transform the target Drawable the final bitmap will be wrapped into. This allows modifying
+     * underlying drawable and creating more advanced effect without need to create another bitmap.
+     */
+    public Builder targetTransform(TargetTransformation targetTransformation) {
+      if (targetTransformation == null) {
+          throw new IllegalArgumentException("TargetTransformation must not be null.");
+      }
+      this.targetTransformation = targetTransformation;
+      return this;
+    }
+
     /** Rotate the image by the specified degrees around a pivot point. */
     public Builder rotate(float degrees, float pivotX, float pivotY) {
       rotationDegrees = degrees;
@@ -312,7 +328,7 @@ public final class Request {
       if (centerInside && targetWidth == 0) {
         throw new IllegalStateException("Center inside requires calling resize.");
       }
-      return new Request(uri, resourceId, transformations, targetWidth, targetHeight, centerCrop,
+      return new Request(uri, resourceId, transformations, targetTransformation, targetWidth, targetHeight, centerCrop,
           centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config);
     }
   }

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -66,7 +66,8 @@ public final class Request {
   /** Target image config for decoding. */
   public final Bitmap.Config config;
 
-  private Request(Uri uri, int resourceId, List<Transformation> transformations, TargetTransformation targetTransformation, int targetWidth,
+  private Request(Uri uri, int resourceId, List<Transformation> transformations,
+      TargetTransformation targetTransformation, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
       float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config) {
     this.uri = uri;
@@ -328,8 +329,9 @@ public final class Request {
       if (centerInside && targetWidth == 0) {
         throw new IllegalStateException("Center inside requires calling resize.");
       }
-      return new Request(uri, resourceId, transformations, targetTransformation, targetWidth, targetHeight, centerCrop,
-          centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config);
+      return new Request(uri, resourceId, transformations, targetTransformation, targetWidth,
+          targetHeight, centerCrop, centerInside, rotationDegrees, rotationPivotX,
+          rotationPivotY, hasRotationPivot, config);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -38,7 +38,7 @@ public final class Request {
   public final int resourceId;
   /** List of custom transformations to be applied after the built-in transformations. */
   public final List<Transformation> transformations;
-  public final TargetTransformation targetTransformation;
+  public final DrawableFactory drawableFactory;
   /** Target image width for resizing. */
   public final int targetWidth;
   /** Target image height for resizing. */
@@ -67,7 +67,7 @@ public final class Request {
   public final Bitmap.Config config;
 
   private Request(Uri uri, int resourceId, List<Transformation> transformations,
-      TargetTransformation targetTransformation, int targetWidth,
+      DrawableFactory drawableFactory, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
       float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config) {
     this.uri = uri;
@@ -77,7 +77,7 @@ public final class Request {
     } else {
       this.transformations = unmodifiableList(transformations);
     }
-    this.targetTransformation = targetTransformation;
+    this.drawableFactory = drawableFactory;
     this.targetWidth = targetWidth;
     this.targetHeight = targetHeight;
     this.centerCrop = centerCrop;
@@ -130,7 +130,7 @@ public final class Request {
     private boolean hasRotationPivot;
     private List<Transformation> transformations;
     private Bitmap.Config config;
-    private TargetTransformation targetTransformation;
+    private DrawableFactory drawableFactory;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(Uri uri) {
@@ -158,7 +158,7 @@ public final class Request {
       rotationPivotX = request.rotationPivotX;
       rotationPivotY = request.rotationPivotY;
       hasRotationPivot = request.hasRotationPivot;
-      targetTransformation = request.targetTransformation;
+      drawableFactory = request.drawableFactory;
       if (request.transformations != null) {
         transformations = new ArrayList<Transformation>(request.transformations);
       }
@@ -267,14 +267,15 @@ public final class Request {
     }
 
     /**
-     * Transform the target Drawable the final bitmap will be wrapped into. This allows modifying
-     * underlying drawable and creating more advanced effect without need to create another bitmap.
+     * Factory for creating a custom Drawable the final bitmap will be wrapped into.
+     * This allows modifying underlying drawable and creating more advanced effects
+     * without need to create another bitmap.
      */
-    public Builder targetTransform(TargetTransformation targetTransformation) {
-      if (targetTransformation == null) {
-          throw new IllegalArgumentException("TargetTransformation must not be null.");
+    public Builder drawableFactory(DrawableFactory drawableFactory) {
+      if (drawableFactory == null) {
+        throw new IllegalArgumentException("DrawableFactory must not be null.");
       }
-      this.targetTransformation = targetTransformation;
+      this.drawableFactory = drawableFactory;
       return this;
     }
 
@@ -329,7 +330,7 @@ public final class Request {
       if (centerInside && targetWidth == 0) {
         throw new IllegalStateException("Center inside requires calling resize.");
       }
-      return new Request(uri, resourceId, transformations, targetTransformation, targetWidth,
+      return new Request(uri, resourceId, transformations, drawableFactory, targetWidth,
           targetHeight, centerCrop, centerInside, rotationDegrees, rotationPivotX,
           rotationPivotY, hasRotationPivot, config);
     }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -202,11 +202,12 @@ public class RequestCreator {
   }
 
   /**
-   * Transform the target Drawable the final bitmap will be wrapped into. This allows modifying
-   * underlying drawable and creating more advanced effect without need to create another bitmap.
+   * Factory for creating a custom Drawable the final bitmap will be wrapped into.
+   * This allows modifying underlying drawable and creating more advanced effects
+   * without need to create another bitmap.
    */
-  public RequestCreator transformTarget(TargetTransformation targetTransformation) {
-    data.targetTransform(targetTransformation);
+  public RequestCreator drawableFactory(DrawableFactory drawableFactory) {
+    data.drawableFactory(drawableFactory);
     return this;
   }
 
@@ -453,7 +454,7 @@ public class RequestCreator {
       if (bitmap != null) {
         picasso.cancelRequest(target);
         PicassoDrawable.setBitmap(target, picasso.context, bitmap, MEMORY, noFade,
-            picasso.debugging, finalData.targetTransformation);
+            picasso.debugging, finalData.drawableFactory);
         if (callback != null) {
           callback.onSuccess();
         }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -202,6 +202,15 @@ public class RequestCreator {
   }
 
   /**
+   * Transform the target Drawable the final bitmap will be wrapped into. This allows modifying
+   * underlying drawable and creating more advanced effect without need to create another bitmap.
+   */
+  public RequestCreator transformTarget(TargetTransformation targetTransformation) {
+    data.targetTransform(targetTransformation);
+    return this;
+  }
+
+  /**
    * Indicate that this action should not use the memory cache for attempting to load or save the
    * image. This can be useful when you know an image will only ever be used once (e.g., loading
    * an image from the filesystem and uploading to a remote server).
@@ -444,7 +453,7 @@ public class RequestCreator {
       if (bitmap != null) {
         picasso.cancelRequest(target);
         PicassoDrawable.setBitmap(target, picasso.context, bitmap, MEMORY, noFade,
-            picasso.debugging);
+            picasso.debugging, finalData.targetTransformation);
         if (callback != null) {
           callback.onSuccess();
         }

--- a/picasso/src/main/java/com/squareup/picasso/TargetTransformation.java
+++ b/picasso/src/main/java/com/squareup/picasso/TargetTransformation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso;
+
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+
+/** Target Drawable transformation. */
+public interface TargetTransformation {
+
+  /**
+   * Transform the target drawable the bitmap will be wrapped into.
+   */
+  Drawable transform(Bitmap source);
+
+}

--- a/picasso/src/main/java/com/squareup/picasso/TargetTransformation.java
+++ b/picasso/src/main/java/com/squareup/picasso/TargetTransformation.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.picasso;
 
-import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 

--- a/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
@@ -26,7 +26,6 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import static android.graphics.Bitmap.Config.ARGB_8888;
 import static android.graphics.Color.RED;
 import static com.squareup.picasso.Picasso.LoadedFrom.DISK;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
@@ -60,17 +59,16 @@ public class PicassoDrawableTest {
     assertThat(pd.animating).isFalse();
   }
 
-  @Test public void createWithTargetTransformerDrawable() {
+  @Test public void createWithDrawableFactory() {
     final BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), BITMAP_1);
 
-    TargetTransformation targetTransformation = new TargetTransformation() {
-        @Override
-        public Drawable transform(Bitmap source) {
-            return bitmapDrawable;
-        }
+    DrawableFactory drawableFactory = new DrawableFactory() {
+      @Override public Drawable createDrawable(Bitmap source) {
+        return bitmapDrawable;
+      }
     };
 
-    PicassoDrawable pd = new PicassoDrawable(context, null, BITMAP_1, DISK, false, false, targetTransformation);
+    PicassoDrawable pd = new PicassoDrawable(context, null, BITMAP_1, DISK, false, false, drawableFactory);
     assertThat(pd.image).isSameAs(bitmapDrawable);
     assertThat(((BitmapDrawable) pd.image).getBitmap()).isSameAs(BITMAP_1);
     assertThat(pd.placeholder).isNull();

--- a/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import org.junit.Test;
@@ -39,23 +40,41 @@ public class PicassoDrawableTest {
   private final Drawable placeholder = new ColorDrawable(RED);
 
   @Test public void createWithNoPlaceholderAnimation() {
-    PicassoDrawable pd = new PicassoDrawable(context, null, BITMAP_1, DISK, false, false);
-    assertThat(pd.image.getBitmap()).isSameAs(BITMAP_1);
+    PicassoDrawable pd = new PicassoDrawable(context, null, BITMAP_1, DISK, false, false, null);
+    assertThat(((BitmapDrawable) pd.image).getBitmap()).isSameAs(BITMAP_1);
     assertThat(pd.placeholder).isNull();
     assertThat(pd.animating).isTrue();
   }
 
   @Test public void createWithPlaceholderAnimation() {
-    PicassoDrawable pd = new PicassoDrawable(context, placeholder, BITMAP_1, DISK, false, false);
-    assertThat(pd.image.getBitmap()).isSameAs(BITMAP_1);
+    PicassoDrawable pd = new PicassoDrawable(context, placeholder, BITMAP_1, DISK, false, false, null);
+    assertThat(((BitmapDrawable) pd.image).getBitmap()).isSameAs(BITMAP_1);
     assertThat(pd.placeholder).isSameAs(placeholder);
     assertThat(pd.animating).isTrue();
   }
 
   @Test public void createWithBitmapCacheHit() {
-    PicassoDrawable pd = new PicassoDrawable(context, placeholder, BITMAP_1, MEMORY, false, false);
-    assertThat(pd.image.getBitmap()).isSameAs(BITMAP_1);
+    PicassoDrawable pd = new PicassoDrawable(context, placeholder, BITMAP_1, MEMORY, false, false, null);
+    assertThat(((BitmapDrawable) pd.image).getBitmap()).isSameAs(BITMAP_1);
     assertThat(pd.placeholder).isNull();
     assertThat(pd.animating).isFalse();
   }
+
+  @Test public void createWithTargetTransformerDrawable() {
+    final BitmapDrawable bitmapDrawable = new BitmapDrawable(context.getResources(), BITMAP_1);
+
+    TargetTransformation targetTransformation = new TargetTransformation() {
+        @Override
+        public Drawable transform(Bitmap source) {
+            return bitmapDrawable;
+        }
+    };
+
+    PicassoDrawable pd = new PicassoDrawable(context, null, BITMAP_1, DISK, false, false, targetTransformation);
+    assertThat(pd.image).isSameAs(bitmapDrawable);
+    assertThat(((BitmapDrawable) pd.image).getBitmap()).isSameAs(BITMAP_1);
+    assertThat(pd.placeholder).isNull();
+    assertThat(pd.animating).isTrue();
+  }
+
 }

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -479,9 +479,12 @@ public class RequestCreatorTest {
     new RequestCreator().transform(null);
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void nullTargetTransformationInvalid() throws Exception {
-      new RequestCreator().transformTarget(null);
+  @Test public void nullTargetTransformationInvalid() throws Exception {
+    try {
+      new RequestCreator().drawableFactory(null);
+      fail("Null DrawableFactory should throw exception");
+    } catch (IllegalArgumentException e) {
+    }
   }
 
   @Test public void nullTargetsInvalid() throws Exception {

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -479,6 +479,11 @@ public class RequestCreatorTest {
     new RequestCreator().transform(null);
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void nullTargetTransformationInvalid() throws Exception {
+      new RequestCreator().transformTarget(null);
+  }
+
   @Test public void nullTargetsInvalid() throws Exception {
     try {
       new RequestCreator().into((ImageView) null);


### PR DESCRIPTION
API allows injecting a custom Drawable implementation into PicassoDrawable instead of BitmapDrawable. This allows developers to have direct access to bitmap and use it as a BitmapShader or apply effects to it without any need to create temporary or extra bitmaps.

As one possible use case we can draw bitmap as a BitmapShader on any shape, e.g. circle.

I have added a sample that demonstrates adding circles, sepia effect and gradient overlay over bitmaps without any extra bitmaps whatsoever.
![device-2014-01-09-171025](https://f.cloud.github.com/assets/1816227/1879943/77aaba78-7951-11e3-903c-b036cb956e5a.png)
