### PR TITLE
Handle actual photo uris

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoBitmapHunter.java
@@ -104,7 +104,7 @@ class ContactsPhotoBitmapHunter extends BitmapHunter {
       case ID_DISPLAY_PHOTO:
         return contentResolver.openInputStream(uri);
       default:
-        throw new IllegalStateException ("Invalid uri: " + uri);
+        throw new IllegalStateException("Invalid uri: " + uri);
     }
   }
 


### PR DESCRIPTION
Addressing the StackOverflow question (http://stackoverflow.com/questions/21157630/picasso-loads-photo-thumbnail-uri-but-not-photo-uri/21214524) where Picasso would not be able to deal with direct high-res photo uris. Picasso can fetch these if a contact or lookup uri is used, but fails if the uri points directly AT the contact's high resolution photo and not the contact.
