### PR TITLE
Reuse string builder for key creation.

### DIFF
--- a/picasso-sample/src/main/java/com/example/picasso/SampleContactsAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleContactsAdapter.java
@@ -42,21 +42,20 @@ class SampleContactsAdapter extends CursorAdapter {
     View itemLayout = inflater.inflate(R.layout.sample_contacts_activity_item, viewGroup, false);
 
     ViewHolder holder = new ViewHolder();
-    itemLayout.setTag(holder);
-
     holder.text1 = (TextView) itemLayout.findViewById(android.R.id.text1);
     holder.icon = (QuickContactBadge) itemLayout.findViewById(android.R.id.icon);
+
+    itemLayout.setTag(holder);
 
     return itemLayout;
   }
 
   @Override public void bindView(View view, Context context, Cursor cursor) {
-    ViewHolder holder = (ViewHolder) view.getTag();
-
-    holder.text1.setText(cursor.getString(ContactsQuery.DISPLAY_NAME));
-
     Uri contactUri = Contacts.getLookupUri(cursor.getLong(ContactsQuery.ID),
         cursor.getString(ContactsQuery.LOOKUP_KEY));
+
+    ViewHolder holder = (ViewHolder) view.getTag();
+    holder.text1.setText(cursor.getString(ContactsQuery.DISPLAY_NAME));
     holder.icon.assignContactUri(contactUri);
 
     Picasso.with(context)

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -219,7 +219,7 @@ public class RequestCreator {
     }
 
     Request finalData = picasso.transformRequest(data.build());
-    String key = createKey(finalData);
+    String key = createKey(finalData, new StringBuilder());
 
     Action action = new GetAction(picasso, finalData, skipMemoryCache, key);
     return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, picasso.stats,

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -95,6 +95,15 @@ public class UtilsTest {
     assertThat(isWebPFile(new ByteArrayInputStream("RIFFxxWEBP".getBytes("US-ASCII")))).isFalse();
   }
 
+  @Test public void ensureBuilderIsCleared() throws Exception {
+    Request request1 = new Request.Builder(RESOURCE_ID_URI).build();
+    Request request2 = new Request.Builder(URI_1).build();
+    Utils.createKey(request1);
+    assertThat(Utils.MAIN_THREAD_KEY_BUILDER.length()).isEqualTo(0);
+    Utils.createKey(request2);
+    assertThat(Utils.MAIN_THREAD_KEY_BUILDER.length()).isEqualTo(0);
+  }
+
   @Test public void getResourceById() throws IOException {
     Request request = new Request.Builder(RESOURCE_ID_URI).build();
     Resources resources = Utils.getResources(mockPackageResourceContext(), request);


### PR DESCRIPTION
@JakeWharton 

Reduces a lot of GC on main thread and object allocation for a new StringBuilder each time.
