### PR TITLE
Change file path to abstract representation.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -66,7 +66,7 @@
 
   Picasso.with(context).load(url).into(view);
 }</pre>
-  
+
             <h4>Image Transformations</h4>
             <p>Transform images to better fit into layouts and to reduce memory size.</p>
             <pre class="prettyprint">Picasso.with(context)
@@ -104,7 +104,7 @@
             <h4>Resource Loading</h4>
             <p>Resources, assets, files, content providers are all supported as image sources.</p>
             <pre class="prettyprint">Picasso.with(context).load(R.drawable.landing_screen).into(imageView1);
-Picasso.with(context).load(new File("/images/oprah_bees.gif")).into(imageView2);</pre>
+Picasso.with(context).load(new File(...)).into(imageView2);</pre>
 
             <h4>Debug Indicators</h4>
             <p>For development you can enable the display of a colored ribbon which indicates the image source. Call <code>setDebugging(true)</code> on the Picasso instance.</p>
@@ -176,7 +176,7 @@ limitations under the License.</pre>
 
         // Spy on scroll position for real-time updating of current section.
         $('body').scrollspy();
-        
+
         // Use smooth-scroll for internal links.
         $('a').smoothScroll();
 


### PR DESCRIPTION
The actual file passed is an implementation detail and using a real example would only serve to clutter showcasing the actual Picasso API.

We also don't want to give users the wrong idea in thinking that we support loading animated GIFs. Or humor.

Closes #380. @dnkoutso 
