### PR TITLE
Add download stats.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Downloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/Downloader.java
@@ -47,20 +47,18 @@ public interface Downloader {
     final InputStream stream;
     final Bitmap bitmap;
     final boolean cached;
+    final long contentLength;
 
     /**
      * Response image and info.
      *
      * @param bitmap Image.
      * @param loadedFromCache {@code true} if the source of the image is from a local disk cache.
+     * @deprecated Use {@link Response#Response(android.graphics.Bitmap, boolean, long)} instead.
      */
+    @Deprecated @SuppressWarnings("UnusedDeclaration")
     public Response(Bitmap bitmap, boolean loadedFromCache) {
-      if (bitmap == null) {
-        throw new IllegalArgumentException("Bitmap may not be null.");
-      }
-      this.stream = null;
-      this.bitmap = bitmap;
-      this.cached = loadedFromCache;
+      this(bitmap, loadedFromCache, 0);
     }
 
     /**
@@ -68,14 +66,47 @@ public interface Downloader {
      *
      * @param stream Image data stream.
      * @param loadedFromCache {@code true} if the source of the stream is from a local disk cache.
+     * @deprecated Use {@link Response#Response(java.io.InputStream, boolean, long)} instead.
      */
+    @Deprecated @SuppressWarnings("UnusedDeclaration")
     public Response(InputStream stream, boolean loadedFromCache) {
+      this(stream, loadedFromCache, 0);
+    }
+
+    /**
+     * Response image and info.
+     *
+     * @param bitmap Image.
+     * @param loadedFromCache {@code true} if the source of the image is from a local disk cache.
+     * @param contentLength The content length of the response, typically derived by the
+     * {@code Content-Length} HTTP header.
+     */
+    public Response(Bitmap bitmap, boolean loadedFromCache, long contentLength) {
+      if (bitmap == null) {
+        throw new IllegalArgumentException("Bitmap may not be null.");
+      }
+      this.stream = null;
+      this.bitmap = bitmap;
+      this.cached = loadedFromCache;
+      this.contentLength = contentLength;
+    }
+
+    /**
+     * Response stream and info.
+     *
+     * @param stream Image data stream.
+     * @param loadedFromCache {@code true} if the source of the stream is from a local disk cache.
+     * @param contentLength The content length of the response, typically derived by the
+     * {@code Content-Length} HTTP header.
+     */
+    public Response(InputStream stream, boolean loadedFromCache, long contentLength) {
       if (stream == null) {
         throw new IllegalArgumentException("Stream may not be null.");
       }
       this.stream = stream;
       this.bitmap = null;
       this.cached = loadedFromCache;
+      this.contentLength = contentLength;
     }
 
     /**
@@ -94,6 +125,11 @@ public interface Downloader {
      */
     public Bitmap getBitmap() {
       return bitmap;
+    }
+
+    /** Content length of the response. */
+    public long getContentLength() {
+      return contentLength;
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -56,6 +56,12 @@ class NetworkBitmapHunter extends BitmapHunter {
     }
 
     InputStream is = response.getInputStream();
+    if (is == null) {
+      return null;
+    }
+    if (loadedFrom == NETWORK && response.getContentLength() > 0) {
+      stats.dispatchDownloadFinished(response.getContentLength());
+    }
     try {
       return decodeStream(is, data);
     } finally {
@@ -73,9 +79,6 @@ class NetworkBitmapHunter extends BitmapHunter {
   }
 
   private Bitmap decodeStream(InputStream stream, Request data) throws IOException {
-    if (stream == null) {
-      return null;
-    }
     MarkableInputStream markStream = new MarkableInputStream(stream);
     stream = markStream;
 

--- a/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
@@ -112,8 +112,10 @@ public class OkHttpDownloader implements Downloader {
     if (responseSource == null) {
       responseSource = connection.getHeaderField(RESPONSE_SOURCE_ANDROID);
     }
+
+    long contentLength = connection.getHeaderFieldInt("Content-Length", 0);
     boolean fromCache = parseResponseSourceHeader(responseSource);
 
-    return new Response(connection.getInputStream(), fromCache);
+    return new Response(connection.getInputStream(), fromCache, contentLength);
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -227,7 +227,11 @@ public class Picasso {
     this.debugging = debugging;
   }
 
-  /** Creates a {@link StatsSnapshot} of the current stats for this instance. */
+  /**
+   * Creates a {@link StatsSnapshot} of the current stats for this instance.
+   * <b>NOTE:</b> The snapshot may not always be completely up-to-date if requests are still in
+   * progress.
+   */
   @SuppressWarnings("UnusedDeclaration") public StatsSnapshot getSnapshot() {
     return stats.createSnapshot();
   }

--- a/picasso/src/main/java/com/squareup/picasso/StatsSnapshot.java
+++ b/picasso/src/main/java/com/squareup/picasso/StatsSnapshot.java
@@ -27,34 +27,40 @@ public class StatsSnapshot {
   public final int size;
   public final long cacheHits;
   public final long cacheMisses;
+  public final long totalDownloadSize;
   public final long totalOriginalBitmapSize;
   public final long totalTransformedBitmapSize;
+  public final long averageDownloadSize;
   public final long averageOriginalBitmapSize;
   public final long averageTransformedBitmapSize;
+  public final int downloadCount;
   public final int originalBitmapCount;
   public final int transformedBitmapCount;
 
   public final long timeStamp;
 
   public StatsSnapshot(int maxSize, int size, long cacheHits, long cacheMisses,
-      long totalOriginalBitmapSize, long totalTransformedBitmapSize, long averageOriginalBitmapSize,
-      long averageTransformedBitmapSize, int originalBitmapCount, int transformedBitmapCount,
-      long timeStamp) {
+      long totalDownloadSize, long totalOriginalBitmapSize, long totalTransformedBitmapSize,
+      long averageDownloadSize, long averageOriginalBitmapSize, long averageTransformedBitmapSize,
+      int downloadCount, int originalBitmapCount, int transformedBitmapCount, long timeStamp) {
     this.maxSize = maxSize;
     this.size = size;
     this.cacheHits = cacheHits;
     this.cacheMisses = cacheMisses;
+    this.totalDownloadSize = totalDownloadSize;
     this.totalOriginalBitmapSize = totalOriginalBitmapSize;
     this.totalTransformedBitmapSize = totalTransformedBitmapSize;
+    this.averageDownloadSize = averageDownloadSize;
     this.averageOriginalBitmapSize = averageOriginalBitmapSize;
     this.averageTransformedBitmapSize = averageTransformedBitmapSize;
+    this.downloadCount = downloadCount;
     this.originalBitmapCount = originalBitmapCount;
     this.transformedBitmapCount = transformedBitmapCount;
     this.timeStamp = timeStamp;
   }
 
   /** Prints out this {@link StatsSnapshot} into log. */
-  public void dump() {
+  @SuppressWarnings("UnusedDeclaration") public void dump() {
     StringWriter logWriter = new StringWriter();
     dump(new PrintWriter(logWriter));
     Log.i(TAG, logWriter.toString());
@@ -74,6 +80,13 @@ public class StatsSnapshot {
     writer.println(cacheHits);
     writer.print("  Cache Misses: ");
     writer.println(cacheMisses);
+    writer.println("Network Stats");
+    writer.print("  Download Count: ");
+    writer.println(downloadCount);
+    writer.print("  Total Download Size: ");
+    writer.println(totalDownloadSize);
+    writer.print("  Average Download Size: ");
+    writer.println(averageDownloadSize);
     writer.println("Bitmap Stats");
     writer.print("  Total Bitmaps Decoded: ");
     writer.println(originalBitmapCount);
@@ -101,6 +114,12 @@ public class StatsSnapshot {
         + cacheHits
         + ", cacheMisses="
         + cacheMisses
+        + ", downloadCount="
+        + downloadCount
+        + ", totalDownloadSize="
+        + totalDownloadSize
+        + ", averageDownloadSize="
+        + averageDownloadSize
         + ", totalOriginalBitmapSize="
         + totalOriginalBitmapSize
         + ", totalTransformedBitmapSize="

--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
@@ -67,9 +67,10 @@ public class UrlConnectionDownloader implements Downloader {
       throw new ResponseException(responseCode + " " + connection.getResponseMessage());
     }
 
+    long contentLength = connection.getHeaderFieldInt("Content-Length", 0);
     boolean fromCache = parseResponseSourceHeader(connection.getHeaderField(RESPONSE_SOURCE));
 
-    return new Response(connection.getInputStream(), fromCache);
+    return new Response(connection.getInputStream(), fromCache, contentLength);
   }
 
   private static void installCacheIfNeeded(Context context) {

--- a/picasso/src/test/java/com/squareup/picasso/OkHttpDownloaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/OkHttpDownloaderTest.java
@@ -86,6 +86,12 @@ public class OkHttpDownloaderTest {
     assertThat(response3.cached).isTrue();
   }
 
+  @Test public void readsContentLengthHeader() throws Exception {
+    server.enqueue(new MockResponse().addHeader("Content-Length", 1024));
+    Downloader.Response response = loader.load(URL, true);
+    assertThat(response.contentLength).isEqualTo(1024);
+  }
+
   @Test public void throwsResponseException() throws Exception {
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 401 Not Authorized"));
     try {

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -24,6 +24,8 @@ import android.net.Uri;
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -148,6 +150,10 @@ class TestUtils {
 
   static NetworkInfo mockNetworkInfo() {
     return mock(NetworkInfo.class);
+  }
+
+  static InputStream mockInputStream() throws IOException {
+    return mock(InputStream.class);
   }
 
   static BitmapHunter mockHunter(String key, Bitmap result, boolean skipCache) {

--- a/picasso/src/test/java/com/squareup/picasso/UrlConnectionDownloaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UrlConnectionDownloaderTest.java
@@ -109,6 +109,12 @@ public class UrlConnectionDownloaderTest {
     assertThat(response2.cached).isTrue();
   }
 
+  @Test public void readsContentLengthHeader() throws Exception {
+    server.enqueue(new MockResponse().addHeader("Content-Length", 1024));
+    Downloader.Response response = loader.load(URL, true);
+    assertThat(response.contentLength).isEqualTo(1024);
+  }
+
   @Test public void throwsResponseException() throws Exception {
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 401 Not Authorized"));
     try {

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -15,14 +15,13 @@
  */
 package com.squareup.picasso;
 
-import java.io.IOException;
-
 import android.content.res.Resources;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import java.io.ByteArrayInputStream;
 
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_URI;


### PR DESCRIPTION
@JakeWharton 
@loganj 
- Count number of downloads and actual compressed total size and average size.
- Remove `synchronized` from `createSnapshot()`. We talked with @loganj and said its OK if some of the data is not completely up-to-date. It only does a read on the stats.

I am also not sure if `available()` here is the right call. Can `Content-Length` provide the number here instead?

Couple of questions marked as TODOs in the code. 

Review only for now.
