### PR TITLE
Fixed blinking when using Picasso for displaying changing previews

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -452,7 +452,8 @@ public class RequestCreator {
       }
     }
 
-    PicassoDrawable.setPlaceholder(target, placeholderResId, placeholderDrawable);
+    if (!(placeholderDrawable == null && data.hasImage() && skipMemoryCache))
+        PicassoDrawable.setPlaceholder(target, placeholderResId, placeholderDrawable);
 
     Action action =
         new ImageViewAction(picasso, target, finalData, skipMemoryCache, noFade, errorResId,


### PR DESCRIPTION
Fixed unnecessary cleaning of ImageView before actually loading bitmap when we have no placeholder available - it disables blinking when using Picasso for stream previews when we are not caching images
