### PR TITLE
Thread safe key creation.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -233,7 +233,7 @@ public class RequestCreator {
     }
 
     Request finalData = picasso.transformRequest(data.build());
-    String key = createKey(finalData, new StringBuilder());
+    String key = createKey(finalData);
 
     Action action = new GetAction(picasso, finalData, skipMemoryCache, key);
     return forRequest(picasso.context, picasso, picasso.dispatcher, picasso.cache, picasso.stats,

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -52,8 +52,7 @@ final class Utils {
   private static final int MIN_DISK_CACHE_SIZE = 5 * 1024 * 1024; // 5MB
   private static final int MAX_DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
 
-  /** Thread confined to main thread for key creation. */
-  static final StringBuilder MAIN_THREAD_KEY_BUILDER = new StringBuilder();
+  static final StringBuilder KEY_BUILDER = new StringBuilder();
 
   /* WebP file header
      0                   1                   2                   3
@@ -93,13 +92,9 @@ final class Utils {
     }
   }
 
-  static String createKey(Request data) {
-    String result = createKey(data, MAIN_THREAD_KEY_BUILDER);
-    MAIN_THREAD_KEY_BUILDER.setLength(0);
-    return result;
-  }
+  static synchronized String createKey(Request data) {
+    StringBuilder builder = KEY_BUILDER;
 
-  static String createKey(Request data, StringBuilder builder) {
     if (data.uri != null) {
       String path = data.uri.toString();
       builder.ensureCapacity(path.length() + KEY_PADDING);
@@ -135,7 +130,9 @@ final class Utils {
       }
     }
 
-    return builder.toString();
+    String result =  builder.toString();
+    builder.setLength(0);
+    return result;
   }
 
   static void closeQuietly(InputStream is) {

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -98,9 +98,9 @@ public class UtilsTest {
     Request request1 = new Request.Builder(RESOURCE_ID_URI).build();
     Request request2 = new Request.Builder(URI_1).build();
     Utils.createKey(request1);
-    assertThat(Utils.MAIN_THREAD_KEY_BUILDER.length()).isEqualTo(0);
+    assertThat(Utils.KEY_BUILDER.length()).isEqualTo(0);
     Utils.createKey(request2);
-    assertThat(Utils.MAIN_THREAD_KEY_BUILDER.length()).isEqualTo(0);
+    assertThat(Utils.KEY_BUILDER.length()).isEqualTo(0);
   }
 
   @Test public void getResourceById() throws IOException {


### PR DESCRIPTION
In some cases StringBuilder will lead to fatal crashes (ArrayIndexOutOfBoundsException) when multiple threads are trying to create a key at the same time.

This is more likely to happen when an app makes calls to fetch() from a background service while also using into() from the main thread.

The solution I'm proposing here is to rename the misleading static final variable and synchronise the key creation method. This will keep the reuse of StringBuilder to reduce GC as introduced with d8f134b .
