### PR TITLE
Use new string builder for fetch() requests

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -250,7 +250,7 @@ public class RequestCreator {
     }
     if (data.hasImage()) {
       Request finalData = picasso.transformRequest(data.build());
-      String key = createKey(finalData);
+      String key = createKey(finalData, new StringBuilder());
 
       Action action = new FetchAction(picasso, finalData, skipMemoryCache, key);
       picasso.enqueueAndSubmit(action);


### PR DESCRIPTION
Calls to `fetch()` from outside main thread can lead to fatal crashes during key creation as StringBuilder is not thread safe. This is likely to happen when key creation is also taking place from other threads (for example: `into()` from the main thread).
