### PR TITLE
Custom Transformations take precedence over default behavior

### DIFF
--- a/picasso-sample/src/main/java/com/example/picasso/GrayscaleTransformation.java
+++ b/picasso-sample/src/main/java/com/example/picasso/GrayscaleTransformation.java
@@ -24,6 +24,7 @@ import android.graphics.Paint;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import com.squareup.picasso.Picasso;
+import com.squareup.picasso.Request;
 import com.squareup.picasso.Transformation;
 import java.io.IOException;
 
@@ -39,7 +40,7 @@ public class GrayscaleTransformation implements Transformation {
     this.picasso = picasso;
   }
 
-  @Override public Bitmap transform(Bitmap source) {
+  @Override public Bitmap transform(Request data, Bitmap source, int exifRotation) {
     Bitmap result = createBitmap(source.getWidth(), source.getHeight(), source.getConfig());
     Bitmap noise;
     try {

--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -132,11 +132,10 @@ abstract class BitmapHunter implements Runnable {
       stats.dispatchBitmapDecoded(bitmap);
       if (data.needsTransformation() || exifRotation != 0) {
         synchronized (DECODE_LOCK) {
-          if (data.needsMatrixTransform() || exifRotation != 0) {
-            bitmap = transformResult(data, bitmap, exifRotation);
-          }
           if (data.hasCustomTransformations()) {
-            bitmap = applyCustomTransformations(data.transformations, bitmap);
+            bitmap = applyCustomTransformations(data, bitmap, exifRotation);
+          } else if (data.needsMatrixTransform() || exifRotation != 0) {
+            bitmap = transformResult(data, bitmap, exifRotation);
           }
         }
         if (bitmap != null) {
@@ -290,10 +289,11 @@ abstract class BitmapHunter implements Runnable {
     options.inJustDecodeBounds = false;
   }
 
-  static Bitmap applyCustomTransformations(List<Transformation> transformations, Bitmap result) {
+  static Bitmap applyCustomTransformations(Request data, Bitmap result, int exifRotation) {
+    final List<Transformation> transformations = data.transformations;
     for (int i = 0, count = transformations.size(); i < count; i++) {
       final Transformation transformation = transformations.get(i);
-      Bitmap newResult = transformation.transform(result);
+      Bitmap newResult = transformation.transform(data, result, exifRotation);
 
       if (newResult == null) {
         final StringBuilder builder = new StringBuilder() //

--- a/picasso/src/main/java/com/squareup/picasso/Transformation.java
+++ b/picasso/src/main/java/com/squareup/picasso/Transformation.java
@@ -24,7 +24,7 @@ public interface Transformation {
    * call {@link android.graphics.Bitmap#recycle()} on {@code source}. You may return the original
    * if no transformation is required.
    */
-  Bitmap transform(Bitmap source);
+  Bitmap transform(Request data, Bitmap source, int exifRotation);
 
   /**
    * Returns a unique key for the transformation, used for caching purposes. If the transformation

--- a/picasso/src/test/java/com/squareup/picasso/TestTransformation.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestTransformation.java
@@ -30,7 +30,7 @@ class TestTransformation implements Transformation {
     this.result = result;
   }
 
-  @Override public Bitmap transform(Bitmap source) {
+  @Override public Bitmap transform(Request data, Bitmap source, int exifRotation) {
     source.recycle();
     return result;
   }


### PR DESCRIPTION
Custom transformations should take precedence over default resizing behavior

When loading large photos, the width and height passed in to the resize() function are used to set the sample rate. However, if want to apply custom transformations, they are currently applied only after the default transformations have been performed. This prohibits transformations that require knowledge of the original dimensions and rotation of the image. It also means that custom transformations must be applied instead of the default behavior when provided.

This does require changing the signature of Transformation.transform() to match that of BitmapHunter.transformResult(), which admittedly is not ideal. 
