### PR TITLE
Transformation Override made available

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -132,7 +132,9 @@ abstract class BitmapHunter implements Runnable {
       stats.dispatchBitmapDecoded(bitmap);
       if (data.needsTransformation() || exifRotation != 0) {
         synchronized (DECODE_LOCK) {
-          if (data.needsMatrixTransform() || exifRotation != 0) {
+          if (data.hasTransformationOverride()) {
+            bitmap = data.transformationOverride.transform(data, bitmap, exifRotation);
+          } else if (data.needsMatrixTransform() || exifRotation != 0) {
             bitmap = transformResult(data, bitmap, exifRotation);
           }
           if (data.hasCustomTransformations()) {

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -202,6 +202,18 @@ public class RequestCreator {
   }
 
   /**
+   * Override default transformations. Parameters passed to {@link #resize(int, int)}
+   * are available but setting {@link #centerCrop()} or {@link #centerInside()} is illegal.
+   * <p>
+   * Will be run instead of the default transformation.
+   * Custom transformations, if provided, will be run afterwards.
+   */
+  public RequestCreator overrideTransform(TransformationOverride transformationOverride) {
+    data.overrideTransform(transformationOverride);
+    return this;
+  }
+
+  /**
    * Indicate that this action should not use the memory cache for attempting to load or save the
    * image. This can be useful when you know an image will only ever be used once (e.g., loading
    * an image from the filesystem and uploading to a remote server).

--- a/picasso/src/main/java/com/squareup/picasso/TransformationOverride.java
+++ b/picasso/src/main/java/com/squareup/picasso/TransformationOverride.java
@@ -1,0 +1,21 @@
+package com.squareup.picasso;
+
+import android.graphics.Bitmap;
+
+/** Image transformation Override */
+public interface TransformationOverride {
+
+  /**
+   * Transform the source bitmap into a new bitmap. If you create a new bitmap instance, you must
+   * call {@link android.graphics.Bitmap#recycle()} on {@code source}. You may return the original
+   * if no transformation is required.
+   */
+  Bitmap transform(Request data, Bitmap bitmap, int exifRotation);
+
+  /**
+   * Returns a unique key for the transformation, used for caching purposes. If the transformation
+   * has parameters (e.g. size, scale factor, etc) then these should be part of the key.
+   */
+  String key();
+
+}

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -142,6 +142,17 @@ public class BitmapHunterTest {
     verify(dispatcher).dispatchRetry(hunter);
   }
 
+  @Test public void transformationOverrideTakesPrecedence() throws Exception {
+    Bitmap transformed =  Bitmap.createBitmap(3, 2, ARGB_8888);
+    TransformationOverride override = new TestTransformationOverride("override", transformed);
+    Request request = new Request.Builder(URI_1).resize(50, 50).overrideTransform(override).build();
+    Action action = mockAction(URI_KEY_1, request);
+    BitmapHunter hunter =
+        spy(new TestableBitmapHunter(picasso, dispatcher, cache, stats, action, BITMAP_1));
+    Bitmap result = hunter.hunt();
+    assertThat(result).isSameAs(transformed);
+  }
+
   @Test public void huntDecodesWhenNotInCache() throws Exception {
     Action action = mockAction(URI_KEY_1, URI_1, mockImageViewTarget());
     BitmapHunter hunter =

--- a/picasso/src/test/java/com/squareup/picasso/TestTransformationOverride.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestTransformationOverride.java
@@ -1,0 +1,23 @@
+package com.squareup.picasso;
+
+import android.graphics.Bitmap;
+
+/**
+ * Sample Transformation Override
+ * <p>
+ * If the image is larger than the size provided by
+ * {@link com.squareup.picasso.Request#targetWidth} or {@link com.squareup.picasso.Request#targetHeight},
+ * it crops the image from the top center. Otherwise, it returns the original image.
+ */
+public class TestTransformationOverride extends TestTransformation implements TransformationOverride {
+
+  TestTransformationOverride(String key, Bitmap result) {
+    super(key, result);
+  }
+
+  @Override
+  public Bitmap transform(Request data, Bitmap source, int exifRotation) {
+    return super.transform(source);
+  }
+
+}


### PR DESCRIPTION
Ability to override default transformations _without breaking the existing API_

From previous pull request, which was rejected for breaking the API:
When loading large photos, the width and height passed in to the resize() function are used to set the sample rate. However, if want to apply custom transformations, they are currently applied only after the default transformations have been performed. This prohibits transformations that require knowledge of the original dimensions and rotation of the image. It also means that custom transformations must be applied instead of the default behavior when provided.

Improvement: This version doesn't break the API!
