### PR TITLE
Add single redirection support to picasso

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
@@ -60,6 +60,24 @@ public class UrlConnectionDownloader implements Downloader {
     if (localCacheOnly) {
       connection.setRequestProperty("Cache-Control", "only-if-cached,max-age=" + Integer.MAX_VALUE);
     }
+    
+     // Handle HTTP redirections by reconnecting to the new URL (currently we follow only a single redirection)
+    if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP
+			|| responseCode == HttpURLConnection.HTTP_MOVED_PERM
+				|| responseCode == HttpURLConnection.HTTP_SEE_OTHER) {
+    	// Disconnect previous connection
+    	connection.disconnect();
+    	
+    	String newUrl = connection.getHeaderField("Location");
+    	if(newUrl!=null){
+	    	connection = openConnection(Uri.parse(newUrl));
+	    	connection.setUseCaches(true);
+	    	responseCode = connection.getResponseCode();
+	      if (localCacheOnly) {
+	            connection.setRequestProperty("Cache-Control", "only-if-cached,max-age=" + Integer.MAX_VALUE);
+	      }
+    	}
+    }
 
     int responseCode = connection.getResponseCode();
     if (responseCode >= 300) {


### PR DESCRIPTION
We've been very happy using Picasso with our product.
One of our main usages is loading facebook friends profile pictures which unfortunately stopped working.

The reason was a redirection facebook added to the original profile image URL which prevented picasso from loading the images.(Since it doesn't follow redirections).

We've added support for the most basic use-case of a single redirection.

Please review and let us know if you have any comments.

Thank you,
Nati Dykstein.
Rounds Entertainment Inc.
