### PR TITLE
Request replay finish off edge cases, fixes

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Action.java
+++ b/picasso/src/main/java/com/squareup/picasso/Action.java
@@ -39,6 +39,7 @@ abstract class Action<T> {
   final Drawable errorDrawable;
   final String key;
 
+  boolean willReplay;
   boolean cancelled;
 
   Action(Picasso picasso, T target, Request data, boolean skipCache, boolean noFade,
@@ -75,6 +76,10 @@ abstract class Action<T> {
 
   boolean isCancelled() {
     return cancelled;
+  }
+
+  boolean willReplay() {
+    return willReplay;
   }
 
   Picasso getPicasso() {

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -351,7 +351,9 @@ public class Picasso {
     if (action.isCancelled()) {
       return;
     }
-    targetToAction.remove(action.getTarget());
+    if (!action.willReplay()) {
+      targetToAction.remove(action.getTarget());
+    }
     if (result != null) {
       if (from == null) {
         throw new AssertionError("LoadedFrom cannot be null.");

--- a/picasso/src/main/java/com/squareup/picasso/RemoteViewsAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/RemoteViewsAction.java
@@ -24,13 +24,14 @@ import android.widget.RemoteViews;
 import static android.content.Context.NOTIFICATION_SERVICE;
 import static com.squareup.picasso.Utils.getService;
 
-abstract class RemoteViewsAction extends Action<Void> {
+abstract class RemoteViewsAction extends Action<RemoteViewsAction.RemoteViewsTarget> {
   final RemoteViews remoteViews;
   final int viewId;
 
   RemoteViewsAction(Picasso picasso, Request data, RemoteViews remoteViews, int viewId,
       int errorResId, boolean skipCache, String key) {
-    super(picasso, null, data, skipCache, false, errorResId, null, key);
+    super(picasso, new RemoteViewsTarget(remoteViews, viewId), data, skipCache, false, errorResId,
+        null, key);
     this.remoteViews = remoteViews;
     this.viewId = viewId;
   }
@@ -52,6 +53,28 @@ abstract class RemoteViewsAction extends Action<Void> {
   }
 
   abstract void update();
+
+  static class RemoteViewsTarget {
+    final RemoteViews remoteViews;
+    final int viewId;
+
+    RemoteViewsTarget(RemoteViews remoteViews, int viewId) {
+      this.remoteViews = remoteViews;
+      this.viewId = viewId;
+    }
+
+    @Override public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      RemoteViewsTarget remoteViewsTarget = (RemoteViewsTarget) o;
+      return viewId == remoteViewsTarget.viewId && remoteViews.equals(
+          remoteViewsTarget.remoteViews);
+    }
+
+    @Override public int hashCode() {
+      return 31 * remoteViews.hashCode() + viewId;
+    }
+  }
 
   static class AppWidgetAction extends RemoteViewsAction {
     private final int[] appWidgetIds;

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -133,6 +133,19 @@ public class PicassoTest {
     verify(action).complete(BITMAP_1, MEMORY);
   }
 
+  @Test public void completeWithReplayDoesNotRemove() throws Exception {
+    Action action = mockAction(URI_KEY_1, URI_1, mockImageViewTarget());
+    when(action.willReplay()).thenReturn(true);
+    BitmapHunter hunter = mockHunter(URI_KEY_1, BITMAP_1, false);
+    when(hunter.getLoadedFrom()).thenReturn(MEMORY);
+    when(hunter.getAction()).thenReturn(action);
+    picasso.enqueueAndSubmit(action);
+    assertThat(picasso.targetToAction).hasSize(1);
+    picasso.complete(hunter);
+    assertThat(picasso.targetToAction).hasSize(1);
+    verify(action).complete(BITMAP_1, MEMORY);
+  }
+
   @Test public void completeDeliversToSingleAndMultiple() throws Exception {
     Action action = mockAction(URI_KEY_1, URI_1, mockImageViewTarget());
     Action action2 = mockAction(URI_KEY_1, URI_1, mockImageViewTarget());


### PR DESCRIPTION
- When retrying we always ask for latest `NetworkInfo`. Having the value cached is bad because it might be out of date by the time we want to retry.
- Retry if we only have an open data connection (`isConnected()` instead of `isConnectingOrConnected()`)
- Scanning for network changes is no more limited to having an instance of `PicassoExecutorService`. It should have never been.
- Rewrote all performRetry tests
- `RemoteViewsAction` now properly provides a unique target.
- Treat `Bitmap.decodeStream() -> null` as a retryable case.

This makes request replay much more robust.
