### PR TITLE
Update NetworkBitmapHunter.java

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -104,10 +104,7 @@ class NetworkBitmapHunter extends BitmapHunter {
       return BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
     } else {
       if (calculateSize) {
-        BitmapFactory.decodeStream(stream, null, options);
         calculateInSampleSize(data.targetWidth, data.targetHeight, options);
-
-        markStream.reset(mark);
       }
       return BitmapFactory.decodeStream(stream, null, options);
     }


### PR DESCRIPTION
Don't know why those 2 lines codes placed there. From my understanding those 2 lines are useless and the 2nd time reset MarkableInputStream cause "can not reset" IOException.

https://github.com/square/picasso/issues/465
