### PR TITLE
Picasso.with() should be synchronized

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -466,7 +466,7 @@ public class Picasso {
    * If these settings do not meet the requirements of your application you can construct your own
    * instance with full control over the configuration by using {@link Picasso.Builder}.
    */
-  public static Picasso with(Context context) {
+  public static synchronized Picasso with(Context context) {
     if (singleton == null) {
       singleton = new Builder(context).build();
     }


### PR DESCRIPTION
I was using Picasso `2.2.0` with OkHttp `1.3.0` and everything was working fine.
I updated OkHttp to `1.5.4` and I started seeing instances of https://github.com/square/okhttp/issues/680

After researching a bit I noticed that I had two Picasso instances in my app generated by a race condition in the method that generates the Picasso singleton. I am using Picasso from the main thread but also from a background service to prefetch images.

Apparently I had this bug before but, as @swankjesse explains in https://github.com/square/okhttp/pull/650, the exception was masked by the fact that the cleanup callable was being run with a `Future`.
