### PR TITLE
Return -1 as default value for missing or malformed content-length header

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
@@ -113,7 +113,7 @@ public class OkHttpDownloader implements Downloader {
       responseSource = connection.getHeaderField(RESPONSE_SOURCE_ANDROID);
     }
 
-    long contentLength = connection.getHeaderFieldInt("Content-Length", 0);
+    long contentLength = connection.getHeaderFieldInt("Content-Length", -1);
     boolean fromCache = parseResponseSourceHeader(responseSource);
 
     return new Response(connection.getInputStream(), fromCache, contentLength);

--- a/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/UrlConnectionDownloader.java
@@ -67,7 +67,7 @@ public class UrlConnectionDownloader implements Downloader {
       throw new ResponseException(responseCode + " " + connection.getResponseMessage());
     }
 
-    long contentLength = connection.getHeaderFieldInt("Content-Length", 0);
+    long contentLength = connection.getHeaderFieldInt("Content-Length", -1);
     boolean fromCache = parseResponseSourceHeader(connection.getHeaderField(RESPONSE_SOURCE));
 
     return new Response(connection.getInputStream(), fromCache, contentLength);

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -232,14 +232,14 @@ final class Utils {
     try {
       Class.forName("com.squareup.okhttp.OkUrlFactory");
       okUrlFactory = true;
-    } catch (ClassNotFoundException e) {
+    } catch (ClassNotFoundException ignored) {
     }
 
     boolean okHttpClient = false;
     try {
       Class.forName("com.squareup.okhttp.OkHttpClient");
       okHttpClient = true;
-    } catch (ClassNotFoundException e) {
+    } catch (ClassNotFoundException ignored) {
     }
 
     if (okHttpClient != okUrlFactory) {


### PR DESCRIPTION
If `content-length` is missing attempt to decode the stream. If we fail we will retry anyways. 

Edge case is when the `content-length` comes back as 0 on request replaying which we retry the request.

closes #523 #530  #501 
