### PR TITLE
Revert swap dimens

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -394,9 +394,8 @@ abstract class BitmapHunter implements Runnable {
   }
 
   static Bitmap transformResult(Request data, Bitmap result, int exifRotation) {
-    boolean swapDimens = exifRotation == 90 || exifRotation == 270;
-    int inWidth = swapDimens ? result.getHeight() : result.getWidth();
-    int inHeight = swapDimens ? result.getWidth() : result.getHeight();
+    int inWidth = result.getWidth();
+    int inHeight = result.getHeight();
 
     int drawX = 0;
     int drawY = 0;

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -20,6 +20,9 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.Uri;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.FutureTask;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,10 +31,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowBitmap;
 import org.robolectric.shadows.ShadowMatrix;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.concurrent.FutureTask;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static android.graphics.Bitmap.Config.RGB_565;
@@ -537,20 +536,6 @@ public class BitmapHunterTest {
     ShadowMatrix shadowMatrix = shadowOf(matrix);
 
     assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
-  }
-
-  @Test public void exif90SwapsDimensions() throws Exception {
-    Request data = new Request.Builder(URI_1).build();
-    Bitmap in = Bitmap.createBitmap(30, 40, null);
-    Bitmap out = transformResult(data, in, 90);
-    assertThat(out).hasWidth(40).hasHeight(30);
-  }
-
-  @Test public void exif270SwapsDimensions() throws Exception {
-    Request data = new Request.Builder(URI_1).build();
-    Bitmap in = Bitmap.createBitmap(30, 40, null);
-    Bitmap out = transformResult(data, in, 270);
-    assertThat(out).hasWidth(40).hasHeight(30);
   }
 
   @Test public void reusedBitmapIsNotRecycled() throws Exception {


### PR DESCRIPTION
I dont think this is needed. If it is we need to find the correct way to allocate the bitmap instead.

At the moment its breaking loading files from camera and until we find a proper fix we should at least revert it.

ref #539 
