### PR TITLE
Restore keeping track of desired drawable alpha

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -110,9 +110,9 @@ final class PicassoDrawable extends BitmapDrawable {
         }
 
         int partialAlpha = (int) (alpha * normalized);
-        setAlpha(partialAlpha);
+        super.setAlpha(partialAlpha);
         super.draw(canvas);
-        setAlpha(alpha);
+        super.setAlpha(alpha);
         if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
           invalidateSelf();
         }
@@ -125,6 +125,7 @@ final class PicassoDrawable extends BitmapDrawable {
   }
 
   @Override public void setAlpha(int alpha) {
+    this.alpha = alpha;
     if (placeholder != null) {
       placeholder.setAlpha(alpha);
     }


### PR DESCRIPTION
- Fix for re-appearance of https://github.com/square/picasso/issues/25 in 2.3.x
- 18c8427 broke alpha support on PicassoDrawable

Tested with SeriesGuide and works fine after these changes. However, I'm not sure if using the super classes `setAlpha()` (lines 113, 115) instead of the local one has any side effects.
