### PR TITLE
Fix deferred loading for complex measurements

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
@@ -47,8 +47,8 @@ class DeferredRequestCreator implements ViewTreeObserver.OnPreDrawListener {
       return true;
     }
 
-    int width = target.getMeasuredWidth();
-    int height = target.getMeasuredHeight();
+    int width = target.getWidth();
+    int height = target.getHeight();
 
     if (width <= 0 || height <= 0) {
       return true;

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -157,7 +157,7 @@ public class RequestCreator {
 
   /**
    * Attempt to resize the image to fit exactly into the target {@link ImageView}'s bounds. This
-   * will result in delayed execution of the request until the {@link ImageView} has been measured.
+   * will result in delayed execution of the request until the {@link ImageView} has been laid out.
    * <p>
    * <em>Note:</em> This method works only when your target is an {@link ImageView}.
    */
@@ -489,14 +489,14 @@ public class RequestCreator {
       if (data.hasSize()) {
         throw new IllegalStateException("Fit cannot be used with resize.");
       }
-      int measuredWidth = target.getMeasuredWidth();
-      int measuredHeight = target.getMeasuredHeight();
-      if (measuredWidth == 0 || measuredHeight == 0) {
+      int width = target.getWidth();
+      int height = target.getHeight();
+      if (width == 0 || height == 0) {
         setPlaceholder(target, placeholderResId, placeholderDrawable);
         picasso.defer(target, new DeferredRequestCreator(this, target, callback));
         return;
       }
-      data.resize(measuredWidth, measuredHeight);
+      data.resize(width, height);
     }
 
     Request request = createRequest(started);

--- a/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
@@ -101,8 +101,8 @@ public class DeferredRequestCreatorTest {
 
   @Test public void waitsForAnotherLayoutIfWidthOrHeightIsZero() throws Exception {
     ImageView target = mockFitImageViewTarget(true);
-    when(target.getMeasuredWidth()).thenReturn(0);
-    when(target.getMeasuredHeight()).thenReturn(0);
+    when(target.getWidth()).thenReturn(0);
+    when(target.getHeight()).thenReturn(0);
     RequestCreator creator = mock(RequestCreator.class);
     DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
     request.onPreDraw();
@@ -134,8 +134,8 @@ public class DeferredRequestCreatorTest {
     RequestCreator creator = new RequestCreator(picasso, URI_1, 0);
 
     ImageView target = mockFitImageViewTarget(true);
-    when(target.getMeasuredWidth()).thenReturn(100);
-    when(target.getMeasuredHeight()).thenReturn(100);
+    when(target.getWidth()).thenReturn(100);
+    when(target.getHeight()).thenReturn(100);
 
     ViewTreeObserver observer = target.getViewTreeObserver();
 

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -300,8 +300,8 @@ public class RequestCreatorTest {
   @Test
   public void intoImageViewWithFitAndDimensionsQueuesImageViewRequest() throws Exception {
     ImageView target = mockFitImageViewTarget(true);
-    when(target.getMeasuredWidth()).thenReturn(100);
-    when(target.getMeasuredHeight()).thenReturn(100);
+    when(target.getWidth()).thenReturn(100);
+    when(target.getHeight()).thenReturn(100);
     new RequestCreator(picasso, URI_1, 0).fit().into(target);
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
     assertThat(actionCaptor.getValue()).isInstanceOf(ImageViewAction.class);


### PR DESCRIPTION
Some `ViewGroup`s doesn't always use subviews' exact measured size, so Picasso should use the `ImageView`'s actual `width` and `height` instead.

See details and example project: #552
