### PR TITLE
Solves #581 : Add source ImageView parameter for shared Callback

### DIFF
--- a/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.java
@@ -72,7 +72,7 @@ public class SampleGalleryActivity extends PicassoSampleActivity {
     animator.setDisplayedChild(1);
 
     Picasso.with(this).load(image).into(imageView, new EmptyCallback() {
-      @Override public void onSuccess() {
+      @Override public void onSuccess(ImageView source) {
         // Index 0 is the image view.
         animator.setDisplayedChild(0);
       }

--- a/picasso/src/main/java/com/squareup/picasso/Callback.java
+++ b/picasso/src/main/java/com/squareup/picasso/Callback.java
@@ -15,17 +15,19 @@
  */
 package com.squareup.picasso;
 
-public interface Callback {
-  void onSuccess();
+import android.widget.ImageView;
 
-  void onError();
+public interface Callback {
+  void onSuccess(ImageView source);
+
+  void onError(ImageView source);
 
   public static class EmptyCallback implements Callback {
 
-    @Override public void onSuccess() {
+    @Override public void onSuccess(ImageView source) {
     }
 
-    @Override public void onError() {
+    @Override public void onError(ImageView source) {
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -46,7 +46,7 @@ class ImageViewAction extends Action<ImageView> {
     PicassoDrawable.setBitmap(target, context, result, from, noFade, indicatorsEnabled);
 
     if (callback != null) {
-      callback.onSuccess();
+      callback.onSuccess(target);
     }
   }
 
@@ -62,7 +62,7 @@ class ImageViewAction extends Action<ImageView> {
     }
 
     if (callback != null) {
-      callback.onError();
+      callback.onError(target);
     }
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -511,7 +511,7 @@ public class RequestCreator {
           log(OWNER_MAIN, VERB_COMPLETED, request.plainId(), "from " + MEMORY);
         }
         if (callback != null) {
-          callback.onSuccess();
+          callback.onSuccess(target);
         }
         return;
       }

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -213,7 +213,7 @@ public class RequestCreatorTest {
     Callback callback = mockCallback();
     new RequestCreator(picasso, URI_1, 0).into(target, callback);
     verify(target).setImageDrawable(any(PicassoDrawable.class));
-    verify(callback).onSuccess();
+    verify(callback).onSuccess(target);
     verify(picasso).cancelRequest(target);
     verify(picasso, never()).enqueueAndSubmit(any(Action.class));
   }


### PR DESCRIPTION
An additional test has been added to check the ability of Picasso to distinguish sources in case of a shared callback (on an error).
