### PR TITLE
Allow Callback WeakReferences.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -24,6 +24,7 @@ import android.net.Uri;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jetbrains.annotations.TestOnly;
@@ -41,6 +42,7 @@ import static com.squareup.picasso.Utils.VERB_CREATED;
 import static com.squareup.picasso.Utils.checkMain;
 import static com.squareup.picasso.Utils.checkNotMain;
 import static com.squareup.picasso.Utils.createKey;
+import static com.squareup.picasso.Utils.getCallback;
 import static com.squareup.picasso.Utils.isMain;
 import static com.squareup.picasso.Utils.log;
 
@@ -459,7 +461,7 @@ public class RequestCreator {
    * automatically support object recycling.
    */
   public void into(ImageView target) {
-    into(target, null);
+    into(target, (Callback) null);
   }
 
   /**
@@ -472,11 +474,44 @@ public class RequestCreator {
    * {@link Picasso#cancelRequest(android.widget.ImageView)} call to prevent temporary leaking.
    */
   public void into(ImageView target, Callback callback) {
+    into(target, callback, null);
+  }
+
+  /**
+   * Asynchronously fulfills the request into the specified {@link ImageView} and invokes the
+   * target {@link Callback} if it's not {@code null}.
+   * <p>
+   * <em>Note:</em> The {@link Callback} param is a weak reference and *will not* prevent your
+   * {@link android.app.Activity} or {@link android.app.Fragment} from being garbage collected. If
+   * you use this method, you *don't* need to invoke
+   * {@link Picasso#cancelRequest(android.widget.ImageView)} call to prevent temporary leaking.
+   * But you have to make sure that your callback will live long enough to be called, i.e.
+   * the callback should be held by a {@link android.app.Activity} or {@link android.app.Fragment}
+   * as a data member for instance, not a local variable.
+   */
+  public void into(ImageView target, WeakReference<Callback> callbackRef) {
+    if (callbackRef == null) {
+      throw new IllegalArgumentException("CallbackRef must not be null.");
+    }
+
+    into(target, null, callbackRef);
+  }
+
+  /**
+   * Supports either a {@link Callback} or a {@link java.lang.ref.WeakReference} of
+   * a {@link Callback}.
+   */
+  private void into(ImageView target, Callback callback, WeakReference<Callback> callbackRef) {
     long started = System.nanoTime();
     checkMain();
 
     if (target == null) {
       throw new IllegalArgumentException("Target must not be null.");
+    }
+
+    if (callback != null && callbackRef != null) {
+      //sanity check
+      throw new AssertionError("Either callback or callbackRef, or both, must be null.");
     }
 
     if (!data.hasImage()) {
@@ -493,7 +528,12 @@ public class RequestCreator {
       int height = target.getHeight();
       if (width == 0 || height == 0) {
         setPlaceholder(target, placeholderResId, placeholderDrawable);
-        picasso.defer(target, new DeferredRequestCreator(this, target, callback));
+        if (callbackRef != null) {
+          picasso.defer(target, new DeferredRequestCreator(this, target, callbackRef));
+        } else {
+          picasso.defer(target, new DeferredRequestCreator(this, target, callback));
+        }
+
         return;
       }
       data.resize(width, height);
@@ -510,8 +550,9 @@ public class RequestCreator {
         if (picasso.loggingEnabled) {
           log(OWNER_MAIN, VERB_COMPLETED, request.plainId(), "from " + MEMORY);
         }
-        if (callback != null) {
-          callback.onSuccess();
+          Callback realCallback = getCallback(callback, callbackRef);
+          if (realCallback != null) {
+          realCallback.onSuccess();
         }
         return;
       }
@@ -519,9 +560,15 @@ public class RequestCreator {
 
     setPlaceholder(target, placeholderResId, placeholderDrawable);
 
-    Action action =
-        new ImageViewAction(picasso, target, request, skipMemoryCache, noFade, errorResId,
-            errorDrawable, requestKey, callback);
+    Action action = null;
+    if (callback != null) {
+      action = new ImageViewAction(picasso, target, request, skipMemoryCache, noFade, errorResId,
+          errorDrawable, requestKey, callback);
+    } else {
+      action = new ImageViewAction(picasso, target, request, skipMemoryCache, noFade, errorResId,
+          errorDrawable, requestKey, callbackRef);
+    }
+
 
     picasso.enqueueAndSubmit(action);
   }

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
 
@@ -406,5 +407,15 @@ final class Utils {
     static Downloader create(Context context) {
       return new OkHttpDownloader(context);
     }
+  }
+
+  public static Callback getCallback(Callback callback, WeakReference<Callback> callbackRef) {
+    if (callback != null) {
+      return callback;
+    }
+    if (callbackRef == null) {
+      return null;
+    }
+    return callbackRef.get();
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
@@ -44,7 +44,7 @@ public class ImageViewActionTest {
   public void throwsErrorWithNullResult() throws Exception {
     ImageViewAction action =
         new ImageViewAction(mock(Picasso.class), mockImageViewTarget(), null, false, false, 0, null,
-            URI_KEY_1, null);
+            URI_KEY_1, (Callback) null);
     action.complete(null, MEMORY);
   }
 


### PR DESCRIPTION
Solves https://github.com/square/picasso/issues/580.

This PR allows to use `into(Image, Callback)` or `into(Image, WeakReference<Callback>)`. The second form has the advantage of not obliging to call `cancel(ImageView)`, but a reference to the `Callback` has to be held long enough to be called back when the request is finished. 

Typically, using this second form, `Activity` or `Fragment` will hold a reference to the callback and pass a `WeakReference` to it to Picasso.

---

I think it's one way to do it. It should be valid, but I am not sure it meets Picasso coding style. I introduced a private `into` method overload that accepts both a `Callback` or `WeakReference<Callback>` and will use one of the 2. This is not my most beautiful piece of code, but the fastest way I found to get it working without code duplication. 
