### PR TITLE
Fix BitmapFactory inSampleSize logic

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -334,8 +334,8 @@ abstract class BitmapHunter implements Runnable {
       BitmapFactory.Options options) {
     int sampleSize = 1;
     if (height > reqHeight || width > reqWidth) {
-      final int heightRatio = Math.round((float) height / (float) reqHeight);
-      final int widthRatio = Math.round((float) width / (float) reqWidth);
+      final int heightRatio = (int) Math.floor((float) height / (float) reqHeight);
+      final int widthRatio = (int) Math.floor((float) width / (float) reqWidth);
       sampleSize = heightRatio < widthRatio ? heightRatio : widthRatio;
     }
     options.inSampleSize = sampleSize;

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -34,6 +34,7 @@ import org.robolectric.shadows.ShadowMatrix;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static android.graphics.Bitmap.Config.RGB_565;
+import static com.squareup.picasso.BitmapHunter.calculateInSampleSize;
 import static com.squareup.picasso.BitmapHunter.createBitmapOptions;
 import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.BitmapHunter.requiresInSampleSize;
@@ -386,6 +387,12 @@ public class BitmapHunterTest {
     final BitmapFactory.Options justBounds = new BitmapFactory.Options();
     justBounds.inJustDecodeBounds = true;
     assertThat(requiresInSampleSize(justBounds)).isTrue();
+  }
+
+  @Test public void calculateInSampleSizeNoResize() {
+    final BitmapFactory.Options options = new BitmapFactory.Options();
+    calculateInSampleSize(100, 100, 150, 150, options);
+    assertThat(options.inSampleSize).isEqualTo(1);
   }
 
   @Test public void nullBitmapOptionsIfNoResizing() {


### PR DESCRIPTION
Fix rounding error that can result in an incorrect inSampleSize, causing the decoded bitmap to be smaller than the requested size. 
