### PR TITLE
Revert "Fail early if missing INTERNET permission."

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.picasso;
 
-import android.Manifest;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.NetworkInfo;
@@ -25,7 +24,6 @@ import java.io.InputStream;
 import static com.squareup.picasso.Downloader.Response;
 import static com.squareup.picasso.Picasso.LoadedFrom.DISK;
 import static com.squareup.picasso.Picasso.LoadedFrom.NETWORK;
-import static com.squareup.picasso.Utils.hasPermission;
 
 class NetworkBitmapHunter extends BitmapHunter {
   static final int DEFAULT_RETRY_COUNT = 2;
@@ -40,13 +38,6 @@ class NetworkBitmapHunter extends BitmapHunter {
     super(picasso, dispatcher, cache, stats, action);
     this.downloader = downloader;
     this.retryCount = DEFAULT_RETRY_COUNT;
-    if (!hasPermission(picasso.context, Manifest.permission.INTERNET)) {
-      Picasso.HANDLER.post(new Runnable() {
-        @Override public void run() {
-          throw new IllegalStateException("INTERNET permission is required.");
-        }
-      });
-    }
   }
 
   @Override Bitmap decode(Request data) throws IOException {

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -61,7 +61,6 @@ import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.mockAction;
 import static com.squareup.picasso.TestUtils.mockImageViewTarget;
-import static com.squareup.picasso.TestUtils.mockPicasso;
 import static org.fest.assertions.api.ANDROID.assertThat;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.entry;
@@ -78,15 +77,14 @@ import static org.robolectric.Robolectric.shadowOf;
 public class BitmapHunterTest {
 
   @Mock Context context;
+  @Mock Picasso picasso;
   @Mock Cache cache;
   @Mock Stats stats;
   @Mock Dispatcher dispatcher;
   @Mock Downloader downloader;
-  Picasso picasso;
 
   @Before public void setUp() throws Exception {
     initMocks(this);
-    picasso = mockPicasso();
   }
 
   @Test public void nullDecodeResponseIsError() throws Exception {

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.picasso;
 
-import android.Manifest;
 import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
@@ -49,6 +48,7 @@ import static com.squareup.picasso.TestUtils.mockTarget;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -406,10 +406,8 @@ public class DispatcherTest {
 
   private Dispatcher createDispatcher(ExecutorService service, boolean scansNetworkChanges) {
     when(context.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(connectivityManager);
-    when(context.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)).thenReturn(
+    when(context.checkCallingOrSelfPermission(anyString())).thenReturn(
         scansNetworkChanges ? PERMISSION_GRANTED : PERMISSION_DENIED);
-    when(context.checkCallingOrSelfPermission(Manifest.permission.INTERNET)).thenReturn(
-        PERMISSION_GRANTED);
     return new Dispatcher(context, service, mainThreadHandler, downloader, cache, stats);
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/NetworkBitmapHunterTest.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.picasso;
 
-import android.Manifest;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.NetworkInfo;
@@ -29,11 +28,9 @@ import org.mockito.Mock;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import static android.content.pm.PackageManager.PERMISSION_DENIED;
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
-import static com.squareup.picasso.TestUtils.mockContext;
 import static com.squareup.picasso.TestUtils.mockInputStream;
 import static com.squareup.picasso.TestUtils.mockNetworkInfo;
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -50,19 +47,15 @@ import static org.mockito.MockitoAnnotations.initMocks;
 @Config(manifest = Config.NONE)
 public class NetworkBitmapHunterTest {
 
-  @Mock Picasso.Listener listener;
+  @Mock Context context;
+  @Mock Picasso picasso;
   @Mock Cache cache;
   @Mock Stats stats;
   @Mock Dispatcher dispatcher;
   @Mock Downloader downloader;
-  @Mock Picasso.RequestTransformer transformer;
-  Picasso picasso;
-  Context context;
 
   @Before public void setUp() throws Exception {
     initMocks(this);
-    context = mockContext();
-    picasso = new Picasso(context, dispatcher, cache, listener, transformer, stats, false, false);
     when(downloader.load(any(Uri.class), anyBoolean())).thenReturn(mock(Downloader.Response.class));
   }
 
@@ -140,7 +133,7 @@ public class NetworkBitmapHunterTest {
     try {
       hunter.decode(action.getRequest());
       fail("Should have thrown IOException.");
-    } catch (IOException expected) {
+    } catch(IOException expected) {
       verifyZeroInteractions(stats);
       verify(stream).close();
     }
@@ -169,16 +162,5 @@ public class NetworkBitmapHunterTest {
 
     Bitmap actual = hunter.decode(action.getRequest());
     assertThat(actual).isSameAs(expected);
-  }
-
-  @Test public void failsIfMissingInternetPermission() throws Exception {
-    when(context.checkCallingOrSelfPermission(Manifest.permission.INTERNET)).thenReturn(
-        PERMISSION_DENIED);
-    Action action = TestUtils.mockAction(URI_KEY_1, URI_1);
-    try {
-      new NetworkBitmapHunter(picasso, dispatcher, cache, stats, action, downloader);
-      fail("Expected IllegalStateException");
-    } catch (IllegalStateException exception) {
-    }
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -15,7 +15,6 @@
 */
 package com.squareup.picasso;
 
-import android.Manifest;
 import android.app.Notification;
 import android.content.Context;
 import android.content.pm.PackageManager;
@@ -33,7 +32,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static android.content.ContentResolver.SCHEME_ANDROID_RESOURCE;
-import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.provider.ContactsContract.Contacts.CONTENT_URI;
 import static android.provider.ContactsContract.Contacts.Photo.CONTENT_DIRECTORY;
 import static com.squareup.picasso.Utils.createKey;
@@ -125,11 +123,10 @@ class TestUtils {
 
   static Action mockAction(String key, Request request, Object target) {
     Action action = mock(Action.class);
-    Picasso picasso = mockPicasso();
     when(action.getKey()).thenReturn(key);
     when(action.getRequest()).thenReturn(request);
     when(action.getTarget()).thenReturn(target);
-    when(action.getPicasso()).thenReturn(picasso);
+    when(action.getPicasso()).thenReturn(mock(Picasso.class));
     return action;
   }
 
@@ -138,22 +135,6 @@ class TestUtils {
     action.cancelled = true;
     when(action.isCancelled()).thenReturn(true);
     return action;
-  }
-
-  static Picasso mockPicasso() {
-    Context context = mockContext();
-    when(context.checkCallingOrSelfPermission(Manifest.permission.INTERNET)).thenReturn(
-        PERMISSION_GRANTED);
-    return new Picasso(context, mock(Dispatcher.class), mock(Cache.class),
-        mock(Picasso.Listener.class), mock(Picasso.RequestTransformer.class), mock(Stats.class),
-        false, false);
-  }
-
-  static Context mockContext() {
-    Context context = mock(Context.class);
-    when(context.checkCallingOrSelfPermission(Manifest.permission.INTERNET)).thenReturn(
-        PERMISSION_GRANTED);
-    return context;
   }
 
   static ImageView mockImageViewTarget() {


### PR DESCRIPTION
This reverts commit 4bbb3fb305c4d695e674605c35b920a8e6ae704f.

There are reports of crashing if the permission is missing when clear it is not. Anyone who ideas on why this occurs besides the fact the check occurs in a bg thread can let me know.

Closes #596 
