### PR TITLE
add a custom resizing function

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkBitmapHunter.java
@@ -105,12 +105,14 @@ class NetworkBitmapHunter extends BitmapHunter {
       byte[] bytes = Utils.toByteArray(stream);
       if (calculateSize) {
         BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
+        applyResizer(data, options);
         calculateInSampleSize(data.targetWidth, data.targetHeight, options);
       }
       return BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
     } else {
       if (calculateSize) {
         BitmapFactory.decodeStream(stream, null, options);
+        applyResizer(data, options);
         calculateInSampleSize(data.targetWidth, data.targetHeight, options);
 
         markStream.reset(mark);

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -46,10 +46,12 @@ public final class Request {
   public final int resourceId;
   /** List of custom transformations to be applied after the built-in transformations. */
   public final List<Transformation> transformations;
+  /** A custom function to compute the target image size. */
+  public final Resizer resizer;
   /** Target image width for resizing. */
-  public final int targetWidth;
+  public int targetWidth;
   /** Target image height for resizing. */
-  public final int targetHeight;
+  public int targetHeight;
   /**
    * True if the final image should use the 'centerCrop' scale technique.
    * <p>
@@ -73,7 +75,7 @@ public final class Request {
   /** Target image config for decoding. */
   public final Bitmap.Config config;
 
-  private Request(Uri uri, int resourceId, List<Transformation> transformations, int targetWidth,
+  private Request(Uri uri, int resourceId, List<Transformation> transformations, Resizer resizer, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
       float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config) {
     this.uri = uri;
@@ -83,6 +85,7 @@ public final class Request {
     } else {
       this.transformations = unmodifiableList(transformations);
     }
+    this.resizer = resizer;
     this.targetWidth = targetWidth;
     this.targetHeight = targetHeight;
     this.centerCrop = centerCrop;
@@ -182,6 +185,7 @@ public final class Request {
     private float rotationPivotY;
     private boolean hasRotationPivot;
     private List<Transformation> transformations;
+    private Resizer resizer;
     private Bitmap.Config config;
 
     /** Start building a request using the specified {@link Uri}. */
@@ -357,6 +361,15 @@ public final class Request {
       return this;
     }
 
+    /** Use the provided resizer object to pick a target size after the image has loaded. */
+    public Builder resizer(Resizer resizer) {
+      if (resizer == null) {
+        throw new IllegalArgumentException("Resizer must not be null.");
+      }
+      this.resizer = resizer;
+      return this;
+    }
+
     /** Create the immutable {@link Request} object. */
     public Request build() {
       if (centerInside && centerCrop) {
@@ -368,7 +381,7 @@ public final class Request {
       if (centerInside && targetWidth == 0) {
         throw new IllegalStateException("Center inside requires calling resize.");
       }
-      return new Request(uri, resourceId, transformations, targetWidth, targetHeight, centerCrop,
+      return new Request(uri, resourceId, transformations, resizer, targetWidth, targetHeight, centerCrop,
           centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config);
     }
   }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -239,6 +239,12 @@ public class RequestCreator {
     return this;
   }
 
+  /** Use the provided resizer object to pick a target size after the image has loaded. */
+  public RequestCreator resizer(Resizer resizer) {
+    data.resizer(resizer);
+    return this;
+  }
+
   /**
    * Indicate that this action should not use the memory cache for attempting to load or save the
    * image. This can be useful when you know an image will only ever be used once (e.g., loading

--- a/picasso/src/main/java/com/squareup/picasso/Resizer.java
+++ b/picasso/src/main/java/com/squareup/picasso/Resizer.java
@@ -1,0 +1,28 @@
+package com.squareup.picasso;
+
+import android.graphics.Point;
+
+/** Flexible image resizer. */
+public interface Resizer {
+  /**
+   * Dynamically pick a size to scale the new bitmap to.  This function is called after an image's
+   * inherent bounds are known but before the image is decoded.  That makes it a great time to
+   * pick a target bitmap size that will fit on the screen or in memory.
+   *
+   * Here is a specific example implementation that makes an image fit within a specific width but
+   * chooses a height automatically to preserve aspect ratio.
+   *
+   *   public Point resize(int width, int height) {
+   *     if (width <= MAX_IMAGE_WIDTH) return null;
+   *     float scaleRatio = MAX_IMAGE_WIDTH / (float)width;
+   *     int newWidth = (int)(width * scaleRatio);
+   *     int newHeight = (int)(height * scaleRatio);
+   *     return new Point(newWidth, newHeight);
+   *   }
+   *
+   * {@code width} and {@code height} are the image's inherent size.
+   * Return a point containing the size you want the image scaled to.
+   * Return null to indicate that {@code width} x {@code height} is fine after all.
+   */
+  public Point resize(int width, int height);
+}

--- a/picasso/src/main/java/com/squareup/picasso/Transformation.java
+++ b/picasso/src/main/java/com/squareup/picasso/Transformation.java
@@ -17,8 +17,10 @@ package com.squareup.picasso;
 
 import android.graphics.Bitmap;
 
+import java.io.Serializable;
+
 /** Image transformation. */
-public interface Transformation {
+public interface Transformation extends Serializable {
   /**
    * Transform the source bitmap into a new bitmap. If you create a new bitmap instance, you must
    * call {@link android.graphics.Bitmap#recycle()} on {@code source}. You may return the original


### PR DESCRIPTION
I have a fairly straightforward use case that I couldn't find a good way to implement with Picasso, so I added a new `resizer` stage to the decoding pipeline.

The use case is: display images as a column of ImageViews in a ListView, with all images scaled to no-larger-than the ListView's width, while preserving aspect ratio.  ImageView heights are sized based on the images Picasso loads into them, rather than the other way around.  Think web browser, messaging app, or chat room.

A custom transformation can sort of implement this, but not well enough.  Some of the images are pretty big, up to 10 megapixels, which means that merely creating the Bitmap to transform takes 20-40MB of RAM per image.  Even if that Bitmap is scaled down and recycled, it's a waste of RAM and CPU to create it full-scale.  Doing a whole column of these thrashes the GC, then starts failing image loads with OOM, then eventually crashes the whole app with OOM.  I want to scale the images at `decode` time, not `transform` time, but without knowing the exact width and height up front.

So what I want is the ability to pick image bounds after the image is retrieved and its inherent (full-size) bounds are known, but before it is actually decoded into a Bitmap.

Rather than build something specific to my fit-to-width use case -- e.g., `resize(maxImageWidth, -1)` -- I generalized.  I added a new function to the fluent builder pipeline, `resizer`, to specify a dynamic resizing function.  Here's how it works:

```
Resizer fitWidth = new Resizer() {
    @Override
    public Point resize(int width, int height) {
        if (width <= maxImageWidth) return null;  // small enough; don't increase the size
        float scaleRatio = maxImageWidth / (float)width;
        int newWidth = (int)(width * scaleRatio);
        int newHeight = (int)(height * scaleRatio);
        return new Point(newWidth, newHeight);
    }
};
Picasso.with(context).load(imageUrl).resizer(fitWidth).error(R.drawable.img_broken).into(ivBody);
```

I believe this would be useful for https://github.com/square/picasso/issues/226.