### PR TITLE
Add disk cache to store transformed images

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -34,6 +34,7 @@ import static android.content.ContentResolver.SCHEME_CONTENT;
 import static android.content.ContentResolver.SCHEME_FILE;
 import static android.provider.ContactsContract.Contacts;
 import static com.squareup.picasso.AssetBitmapHunter.ANDROID_ASSET;
+import static com.squareup.picasso.Picasso.LoadedFrom.DISK_CACHE;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 import static com.squareup.picasso.Utils.OWNER_HUNTER;
 import static com.squareup.picasso.Utils.VERB_DECODED;
@@ -141,6 +142,17 @@ abstract class BitmapHunter implements Runnable {
       }
     }
 
+    if (picasso.diskCache != null) {
+      bitmap = picasso.diskCache.get(key);
+      if (bitmap != null) {
+        loadedFrom = DISK_CACHE;
+        if (picasso.loggingEnabled) {
+          log(OWNER_HUNTER, VERB_DECODED, data.logId(), "from disk cache");
+        }
+        return bitmap;
+      }
+    }
+
     bitmap = decode(data);
 
     if (bitmap != null) {
@@ -166,6 +178,9 @@ abstract class BitmapHunter implements Runnable {
         if (bitmap != null) {
           stats.dispatchBitmapTransformed(bitmap);
         }
+      }
+      if (picasso.diskCache != null && loadedFrom != Picasso.LoadedFrom.DISK_CACHE) {
+        picasso.diskCache.set(key, bitmap);
       }
     }
 

--- a/picasso/src/main/java/com/squareup/picasso/Cache.java
+++ b/picasso/src/main/java/com/squareup/picasso/Cache.java
@@ -32,10 +32,10 @@ public interface Cache {
   void set(String key, Bitmap bitmap);
 
   /** Returns the current size of the cache in bytes. */
-  int size();
+  long size();
 
   /** Returns the maximum size in bytes that the cache can hold. */
-  int maxSize();
+  long maxSize();
 
   /** Clears the cache. */
   void clear();
@@ -50,11 +50,11 @@ public interface Cache {
       // Ignore.
     }
 
-    @Override public int size() {
+    @Override public long size() {
       return 0;
     }
 
-    @Override public int maxSize() {
+    @Override public long maxSize() {
       return 0;
     }
 

--- a/picasso/src/main/java/com/squareup/picasso/LruCache.java
+++ b/picasso/src/main/java/com/squareup/picasso/LruCache.java
@@ -111,12 +111,12 @@ public class LruCache implements Cache {
   }
 
   /** Returns the sum of the sizes of the entries in this cache. */
-  public final synchronized int size() {
+  public final synchronized long size() {
     return size;
   }
 
   /** Returns the maximum sum of the sizes of the entries in this cache. */
-  public final synchronized int maxSize() {
+  public final synchronized long maxSize() {
     return maxSize;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -123,18 +123,20 @@ public class Picasso {
   final Map<Object, Action> targetToAction;
   final Map<ImageView, DeferredRequestCreator> targetToDeferredRequestCreator;
   final ReferenceQueue<Object> referenceQueue;
+  final Cache diskCache;
 
   boolean indicatorsEnabled;
   volatile boolean loggingEnabled;
 
   boolean shutdown;
 
-  Picasso(Context context, Dispatcher dispatcher, Cache cache, Listener listener,
+  Picasso(Context context, Dispatcher dispatcher, Cache cache, Cache diskCache, Listener listener,
       RequestTransformer requestTransformer, Stats stats, boolean indicatorsEnabled,
       boolean loggingEnabled) {
     this.context = context;
     this.dispatcher = dispatcher;
     this.cache = cache;
+    this.diskCache = diskCache;
     this.listener = listener;
     this.requestTransformer = requestTransformer;
     this.stats = stats;
@@ -145,6 +147,13 @@ public class Picasso {
     this.referenceQueue = new ReferenceQueue<Object>();
     this.cleanupThread = new CleanupThread(referenceQueue, HANDLER);
     this.cleanupThread.start();
+  }
+
+  Picasso(Context context, Dispatcher dispatcher, Cache cache, Listener listener,
+      RequestTransformer requestTransformer, Stats stats, boolean indicatorsEnabled,
+      boolean loggingEnabled) {
+    this(context, dispatcher, cache, null, listener, requestTransformer, stats, indicatorsEnabled,
+        loggingEnabled);
   }
 
   /** Cancel any existing requests for the specified target {@link ImageView}. */
@@ -493,6 +502,7 @@ public class Picasso {
     private Downloader downloader;
     private ExecutorService service;
     private Cache cache;
+    private Cache diskCache;
     private Listener listener;
     private RequestTransformer transformer;
 
@@ -540,6 +550,15 @@ public class Picasso {
         throw new IllegalStateException("Memory cache already set.");
       }
       this.cache = memoryCache;
+      return this;
+    }
+
+    /** Specify the disk cache used for the most recent images. Can be null (default).*/
+    public Builder diskCache(Cache diskCache) {
+      if (this.diskCache != null) {
+        throw new IllegalStateException("Disk cache already set.");
+      }
+      this.diskCache = diskCache;
       return this;
     }
 
@@ -618,7 +637,7 @@ public class Picasso {
 
       Dispatcher dispatcher = new Dispatcher(context, service, HANDLER, downloader, cache, stats);
 
-      return new Picasso(context, dispatcher, cache, listener, transformer, stats,
+      return new Picasso(context, dispatcher, cache, diskCache, listener, transformer, stats,
           indicatorsEnabled, loggingEnabled);
     }
   }
@@ -626,6 +645,7 @@ public class Picasso {
   /** Describes where the image was loaded from. */
   public enum LoadedFrom {
     MEMORY(Color.GREEN),
+    DISK_CACHE(Color.BLUE),
     DISK(Color.YELLOW),
     NETWORK(Color.RED);
 

--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -31,6 +31,7 @@ import android.os.SystemClock;
 import android.widget.ImageView;
 
 import static android.graphics.Color.WHITE;
+import static com.squareup.picasso.Picasso.LoadedFrom.DISK_CACHE;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 
 final class PicassoDrawable extends BitmapDrawable {
@@ -87,7 +88,7 @@ final class PicassoDrawable extends BitmapDrawable {
 
     this.loadedFrom = loadedFrom;
 
-    boolean fade = loadedFrom != MEMORY && !noFade;
+    boolean fade = loadedFrom != MEMORY && loadedFrom != DISK_CACHE && !noFade;
     if (fade) {
       this.placeholder = placeholder;
       animating = true;

--- a/picasso/src/main/java/com/squareup/picasso/StatsSnapshot.java
+++ b/picasso/src/main/java/com/squareup/picasso/StatsSnapshot.java
@@ -23,8 +23,8 @@ import static com.squareup.picasso.Picasso.TAG;
 
 /** Represents all stats for a {@link Picasso} instance at a single point in time. */
 public class StatsSnapshot {
-  public final int maxSize;
-  public final int size;
+  public final long maxSize;
+  public final long size;
   public final long cacheHits;
   public final long cacheMisses;
   public final long totalDownloadSize;
@@ -39,7 +39,7 @@ public class StatsSnapshot {
 
   public final long timeStamp;
 
-  public StatsSnapshot(int maxSize, int size, long cacheHits, long cacheMisses,
+  public StatsSnapshot(long maxSize, long size, long cacheHits, long cacheMisses,
       long totalDownloadSize, long totalOriginalBitmapSize, long totalTransformedBitmapSize,
       long averageDownloadSize, long averageOriginalBitmapSize, long averageTransformedBitmapSize,
       int downloadCount, int originalBitmapCount, int transformedBitmapCount, long timeStamp) {

--- a/picasso/src/main/java/com/squareup/picasso/ThumbnailCache.java
+++ b/picasso/src/main/java/com/squareup/picasso/ThumbnailCache.java
@@ -1,0 +1,143 @@
+package com.squareup.picasso;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import com.squareup.okhttp.internal.DiskLruCache;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * This cache is a {@link LruCache} backed by
+ * a {@link DiskLruCache}. It can be used to cache
+ * thumbnail of images, i.e. cache images on disk after
+ * transformations.
+ * Shamelessly inspired by : http://stackoverflow.com/a/10235381/693752
+ *
+ * @author Stephane Nicolas
+ * @author Carlos Sessa
+ */
+public class ThumbnailCache implements Cache {
+  public static final int IO_BUFFER_SIZE = 8 * 1024;
+
+  private DiskLruCache diskLruCache;
+  private static final Bitmap.CompressFormat COMPRESS_FORMAT = Bitmap.CompressFormat.WEBP;
+  private static final int COMPRESS_QUALITY = 100;
+
+  private int putCount;
+  private int hitCount;
+  private int missCount;
+
+  public ThumbnailCache(DiskLruCache diskLruCache) {
+    this.diskLruCache = diskLruCache;
+  }
+
+  @Override public Bitmap get(String key) {
+    key = sanitize(key);
+    Bitmap bitmap = getBitmap(key);
+
+    if (bitmap != null) {
+      hitCount++;
+    } else {
+      missCount++;
+    }
+
+    return bitmap;
+  }
+
+  @Override public void set(String key, Bitmap bitmap) {
+    key = sanitize(key);
+    setInDiskCache(key, bitmap);
+  }
+
+  @Override public long size() {
+    return diskLruCache.size();
+  }
+
+  @Override public long maxSize() {
+    return diskLruCache.getMaxSize();
+  }
+
+  @Override public void clear() {
+    try {
+      diskLruCache.delete();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private static String sanitize(String key) {
+    key = key.toLowerCase().replaceAll("[^a-z0-9_-]", "_");
+    if (key.length() > 64) {
+      key = key.substring(key.length() - 64);
+    }
+    return key;
+  }
+
+  public void setInDiskCache(String key, Bitmap bitmap) {
+    putCount++;
+    DiskLruCache.Editor editor = null;
+    try {
+      editor = diskLruCache.edit(key);
+      if (editor == null) {
+        return;
+      }
+
+      if (writeBitmapToFile(bitmap, editor)) {
+        diskLruCache.flush();
+        editor.commit();
+      } else {
+        editor.abort();
+      }
+    } catch (IOException e) {
+      try {
+        if (editor != null) {
+          editor.abort();
+        }
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  public Bitmap getBitmap(String key) {
+    key = sanitize(key);
+    Bitmap bitmap = null;
+    DiskLruCache.Snapshot snapshot = null;
+    try {
+
+      snapshot = diskLruCache.get(key);
+      if (snapshot == null) {
+        return null;
+      }
+      final InputStream in = snapshot.getInputStream(0);
+      if (in != null) {
+        final BufferedInputStream buffIn = new BufferedInputStream(in, IO_BUFFER_SIZE);
+        bitmap = BitmapFactory.decodeStream(buffIn);
+      }
+    } catch (IOException e) {
+      e.printStackTrace();
+    } finally {
+      if (snapshot != null) {
+        snapshot.close();
+      }
+    }
+
+    return bitmap;
+  }
+
+  private boolean writeBitmapToFile(Bitmap bitmap, DiskLruCache.Editor editor)
+      throws IOException {
+    OutputStream out = null;
+    try {
+      out = new BufferedOutputStream(editor.newOutputStream(0), IO_BUFFER_SIZE);
+
+      return bitmap.compress(COMPRESS_FORMAT, COMPRESS_QUALITY, out);
+    } finally {
+      if (out != null) {
+        out.close();
+      }
+    }
+  }
+}


### PR DESCRIPTION
Solves https://github.com/square/picasso/issues/205

Unfortunately, I didn't have time to write tests yet (as I would prefer to mock the disk lru cache.. ;))
