### PR TITLE
Allow injected RequestHandlers to override the defaults

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -147,15 +147,15 @@ public class Picasso {
     // forcing other RequestHandlers to perform null checks on request.uri
     // to cover the (request.resourceId != 0) case.
     allRequestHandlers.add(new ResourceRequestHandler(context));
+    if (extraRequestHandlers != null) {
+      allRequestHandlers.addAll(extraRequestHandlers);
+    }
     allRequestHandlers.add(new ContactsPhotoRequestHandler(context));
     allRequestHandlers.add(new MediaStoreRequestHandler(context));
     allRequestHandlers.add(new ContentStreamRequestHandler(context));
     allRequestHandlers.add(new AssetRequestHandler(context));
     allRequestHandlers.add(new FileRequestHandler(context));
     allRequestHandlers.add(new NetworkRequestHandler(dispatcher.downloader, stats));
-    if (extraRequestHandlers != null) {
-      allRequestHandlers.addAll(extraRequestHandlers);
-    }
     requestHandlers = Collections.unmodifiableList(allRequestHandlers);
 
     this.stats = stats;

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -17,30 +17,26 @@ package com.squareup.picasso;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.Uri;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.FutureTask;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowBitmap;
 import org.robolectric.shadows.ShadowMatrix;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
-import static android.graphics.Bitmap.Config.RGB_565;
 import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.BitmapHunter.transformResult;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
-import static com.squareup.picasso.RequestHandler.calculateInSampleSize;
-import static com.squareup.picasso.RequestHandler.createBitmapOptions;
-import static com.squareup.picasso.RequestHandler.requiresInSampleSize;
 import static com.squareup.picasso.TestUtils.ASSET_KEY_1;
 import static com.squareup.picasso.TestUtils.ASSET_URI_1;
 import static com.squareup.picasso.TestUtils.BITMAP_1;
@@ -327,6 +323,17 @@ public class BitmapHunterTest {
     BitmapHunter hunter = forRequest(mockPicasso(new CustomRequestHandler()), dispatcher, cache,
         stats, action);
     assertThat(hunter.requestHandler).isInstanceOf(CustomRequestHandler.class);
+  }
+
+  @Test public void forOverrideRequest() {
+    Action action = mockAction(ASSET_KEY_1, ASSET_URI_1);
+    RequestHandler handler = new AssetRequestHandler(context);
+    List<RequestHandler> handlers = Arrays.asList(handler);
+    // Must use non-mock constructor because that is where Picasso's list of handlers is created.
+    Picasso picasso = new Picasso(context, dispatcher, cache, null, null, handlers, stats,
+        false, false);
+    BitmapHunter hunter = forRequest(picasso, dispatcher, cache, stats, action);
+    assertThat(hunter.requestHandler).isEqualTo(handler);
   }
 
   @Test public void exifRotation() throws Exception {


### PR DESCRIPTION
Addresses an issue where the default `RequestHandler`s took priority over user supplied `RequestHandler`s.

For example, if you created a `RequestHandler` that could handle `content://` URIs, Picasso would always use the first eligible `RequestHandler` in the list - the `MediaStoreRequestHandler` - because user-supplied request handlers are always appended to the end of the list.

The content of the test is a bit different than the other tests as it is not using a mock `Picasso` object.  This is because the logic that needs to be tested exists within the `Picasso` constructor.  This should probably be changed, but I wanted to keep this PR as concise as possible.
