### PR TITLE
Support retrieval of specific frames from MediaStore videos

### DIFF
--- a/picasso/src/test/java/com/squareup/picasso/Shadows.java
+++ b/picasso/src/test/java/com/squareup/picasso/Shadows.java
@@ -3,32 +3,108 @@ package com.squareup.picasso;
 import android.content.ContentResolver;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.media.MediaMetadataRetriever;
+import android.net.Uri;
 import android.provider.MediaStore;
+import android.util.SparseArray;
+
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+
+import java.io.FileDescriptor;
+import java.util.HashMap;
+import java.util.Map;
 
 import static com.squareup.picasso.TestUtils.IMAGE_THUMBNAIL_1;
 import static com.squareup.picasso.TestUtils.VIDEO_THUMBNAIL_1;
 
 public class Shadows {
-
   @Implements(MediaStore.Video.Thumbnails.class)
   public static class ShadowVideoThumbnails {
 
     @Implementation
     public static Bitmap getThumbnail(ContentResolver cr, long origId, int kind,
-        BitmapFactory.Options options) {
+                                        BitmapFactory.Options options) {
       return VIDEO_THUMBNAIL_1;
     }
   }
 
   @Implements(MediaStore.Images.Thumbnails.class)
   public static class ShadowImageThumbnails {
-
     @Implementation
     public static Bitmap getThumbnail(ContentResolver cr, long origId, int kind,
-        BitmapFactory.Options options) {
+                                      BitmapFactory.Options options) {
       return IMAGE_THUMBNAIL_1;
+    }
+  }
+
+  @Implements(value = MediaMetadataRetriever.class)
+  public static class ShadowMediaMetadataRetriever {
+    private String dataSource;
+    private static final Map<String, SparseArray<String>> metadata = new HashMap();
+    private static final Map<String, HashMap<Long, Bitmap>> frames  = new HashMap();
+
+    @Implementation
+    public void setDataSource(String path) {
+      dataSource = path;
+    }
+
+    @Implementation
+    public void setDataSource(android.content.Context context, Uri uri) {
+      dataSource = uri.toString();
+    }
+
+    @Implementation
+    public void setDataSource(Uri uri, Map<String, String> headers) {
+      dataSource = uri.toString();
+    }
+
+    @Implementation
+    public void setDataSource(FileDescriptor fd) {
+      dataSource = fd.toString();
+    }
+
+    @Implementation
+    public void setDataSource(FileDescriptor fd, long offset, long length) {
+      dataSource = fd.toString() + offset;
+    }
+
+    @Implementation
+    public String extractMetadata(int keyCode) {
+      if (metadata.containsKey(dataSource)) {
+        return metadata.get(dataSource).get(keyCode);
+      }
+      return null;
+    }
+
+    @Implementation
+    public Bitmap getFrameAtTime(long timeUs) {
+      return frames.get(dataSource).get(timeUs);
+    }
+
+    @Implementation
+    public Bitmap getFrameAtTime(long timeUs, int option) {
+      return frames.get(dataSource).get(timeUs);
+    }
+
+    public static void addMetadata(String path, int keyCode, String value) {
+      if (!metadata.containsKey(path)) {
+        metadata.put(path, new SparseArray<String>());
+      }
+      metadata.get(path).put(keyCode, value);
+    }
+
+    public static void addFrame(android.content.Context context, Uri uri, long time, Bitmap bitmap) {
+      String uriString = uri.toString();
+      if (!frames.containsKey(uriString)) {
+        frames.put(uriString, new HashMap<Long, Bitmap>());
+      }
+      frames.get(uriString).put(time, bitmap);
+    }
+
+    public static void reset() {
+      metadata.clear();
+      frames.clear();
     }
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -53,6 +53,7 @@ class TestUtils {
   static final String URI_KEY_1 = createKey(new Request.Builder(URI_1).build());
   static final String URI_KEY_2 = createKey(new Request.Builder(URI_2).build());
   static final Bitmap VIDEO_THUMBNAIL_1 = Bitmap.createBitmap(10, 10, null);
+  static final Bitmap VIDEO_FRAME_1 = Bitmap.createBitmap(10, 10, null);
   static final Bitmap IMAGE_THUMBNAIL_1 = Bitmap.createBitmap(20, 20, null);
   static final Bitmap BITMAP_1 = Bitmap.createBitmap(10, 10, null);
   static final Bitmap BITMAP_2 = Bitmap.createBitmap(15, 15, null);


### PR DESCRIPTION
**Motivation**

Picasso supports loading of MediaStore video thumbnails, however the thumbnail generated by Android is pulled from the middle of the video.  For this project, we needed to load the first frame of a video that automatically starts when the user scrolls to the center of the screen, to avoid [this (youtube)](https://www.youtube.com/watch?v=OjrLCzgi0s8).  The end result turned out quite nicely, you can see a demonstration [here (youtube)](https://www.youtube.com/watch?v=O1paNAL7XnM):

**API**

```
Uri uri = myVideoUri.buildUpon().appendQueryParameter("t", "0").build();
Picasso.with(context).load(uri).into(imageview)
```

This is still up in the air.  I had originally suggested `load(Uri uri, long offset)`, but it almost certainly doesn't make sense to add a new method signature for such an obscure feature.  So I settled on the current implementation, which follows YouTube's convention of appending `?t=[position]` to the end of a uri, for example: `https://www.youtube.com/watch?v=wtLJPvx7-ys#t=3945`

YouTube's time query parameter is in seconds, but since the underlying API that this change uses (`android.media.MediaMetadataRetriever`) accepts the time position in microseconds, my initial implementation does as well, but that's definitely not set in stone.

**Tests**

~~In this PR, I upgraded Robolectric from 2.2 to 2.3.  2.2 did not have a shadow MediaMetadataRetriever implementation.  However, the implementation in 2.3 was incomplete so I ended up writing my own shadow MediaMetadataRetriever (which I will be submitting as a PR to them).  All the tests still pass, but this PR doesn't require Robolectric 2.3 to so we can revert to 2.2 if necessary.~~

Travis was failing with Robolectric 2.3 so I reverted to 2.2.
