### PR TITLE
Implement support for request priorities

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Action.java
+++ b/picasso/src/main/java/com/squareup/picasso/Action.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+import com.squareup.picasso.Picasso.Priority;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 
@@ -84,5 +85,9 @@ abstract class Action<T> {
 
   Picasso getPicasso() {
     return picasso;
+  }
+
+  Priority getPriority() {
+    return request.priority;
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -88,6 +88,17 @@ public class Picasso {
     };
   }
 
+  /**
+   * The priority of a request.
+   *
+   * @see RequestCreator#priority(Priority)
+   */
+  public enum Priority {
+    LOW,
+    NORMAL,
+    HIGH
+  }
+
   static final String TAG = "Picasso";
   static final Handler HANDLER = new Handler(Looper.getMainLooper()) {
     @Override public void handleMessage(Message msg) {

--- a/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
@@ -18,7 +18,10 @@ package com.squareup.picasso;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.telephony.TelephonyManager;
-import java.util.concurrent.LinkedBlockingQueue;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -33,7 +36,7 @@ class PicassoExecutorService extends ThreadPoolExecutor {
 
   PicassoExecutorService() {
     super(DEFAULT_THREAD_COUNT, DEFAULT_THREAD_COUNT, 0, TimeUnit.MILLISECONDS,
-        new LinkedBlockingQueue<Runnable>(), new Utils.PicassoThreadFactory());
+        new PriorityBlockingQueue<Runnable>(), new Utils.PicassoThreadFactory());
   }
 
   void adjustThreadCount(NetworkInfo info) {
@@ -77,5 +80,32 @@ class PicassoExecutorService extends ThreadPoolExecutor {
   private void setThreadCount(int threadCount) {
     setCorePoolSize(threadCount);
     setMaximumPoolSize(threadCount);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    PicassoFutureTask ftask = new PicassoFutureTask((BitmapHunter) task);
+    execute(ftask);
+    return ftask;
+  }
+
+  private static final class PicassoFutureTask extends FutureTask<BitmapHunter>
+      implements Comparable<PicassoFutureTask> {
+    private final BitmapHunter hunter;
+
+    public PicassoFutureTask(BitmapHunter hunter) {
+      super(hunter, null);
+      this.hunter = hunter;
+    }
+
+    @Override
+    public int compareTo(PicassoFutureTask other) {
+      Picasso.Priority p1 = hunter.getPriority();
+      Picasso.Priority p2 = other.hunter.getPriority();
+
+      // High-priority requests are "lesser" so they are sorted to the front.
+      // Equal priorities are sorted by sequence number to provide FIFO ordering.
+      return (p1 == p2 ? hunter.sequence - other.hunter.sequence : p2.ordinal() - p1.ordinal());
+    }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.graphics.Bitmap;
 import android.net.Uri;
+import com.squareup.picasso.Picasso.Priority;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -74,10 +75,13 @@ public final class Request {
   public final boolean hasRotationPivot;
   /** Target image config for decoding. */
   public final Bitmap.Config config;
+  /** The priority of this request. */
+  public final Priority priority;
 
   private Request(Uri uri, int resourceId, List<Transformation> transformations, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
-      float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config) {
+      float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config,
+      Priority priority) {
     this.uri = uri;
     this.resourceId = resourceId;
     if (transformations == null) {
@@ -94,6 +98,7 @@ public final class Request {
     this.rotationPivotY = rotationPivotY;
     this.hasRotationPivot = hasRotationPivot;
     this.config = config;
+    this.priority = priority;
   }
 
   @Override public String toString() {
@@ -185,6 +190,7 @@ public final class Request {
     private boolean hasRotationPivot;
     private List<Transformation> transformations;
     private Bitmap.Config config;
+    private Priority priority;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(Uri uri) {
@@ -216,6 +222,7 @@ public final class Request {
         transformations = new ArrayList<Transformation>(request.transformations);
       }
       config = request.config;
+      priority = request.priority;
     }
 
     boolean hasImage() {
@@ -224,6 +231,10 @@ public final class Request {
 
     boolean hasSize() {
       return targetWidth != 0;
+    }
+
+    boolean hasPriority() {
+      return priority != null;
     }
 
     /**
@@ -343,6 +354,18 @@ public final class Request {
       return this;
     }
 
+    /** Execute request using the specified priority. */
+    public Builder priority(Priority priority) {
+      if (priority == null) {
+        throw new IllegalArgumentException("Priority invalid.");
+      }
+      if (this.priority != null) {
+        throw new IllegalStateException("Priority already set.");
+      }
+      this.priority = priority;
+      return this;
+    }
+
     /**
      * Add a custom transformation to be applied to the image.
      * <p>
@@ -370,8 +393,12 @@ public final class Request {
       if (centerInside && targetWidth == 0) {
         throw new IllegalStateException("Center inside requires calling resize.");
       }
+      if (priority == null) {
+        priority = Priority.NORMAL;
+      }
       return new Request(uri, resourceId, transformations, targetWidth, targetHeight, centerCrop,
-          centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config);
+          centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config,
+          priority);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.TestOnly;
 
 import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
+import static com.squareup.picasso.Picasso.Priority;
 import static com.squareup.picasso.PicassoDrawable.setBitmap;
 import static com.squareup.picasso.PicassoDrawable.setPlaceholder;
 import static com.squareup.picasso.RemoteViewsAction.AppWidgetAction;
@@ -229,6 +230,18 @@ public class RequestCreator {
   }
 
   /**
+   * Set the priority of this request.
+   * <p>
+   * This will affect the order in which the requests execute but does not guarantee it.
+   * By default, all requests have {@link Priority#NORMAL} priority, except for
+   * {@link #fetch()} requests, which have {@link Priority#LOW} priority by default.
+   */
+  public RequestCreator priority(Priority priority) {
+    data.priority(priority);
+    return this;
+  }
+
+  /**
    * Add a custom transformation to be applied to the image.
    * <p>
    * Custom transformations will always be run after the built-in transformations.
@@ -292,6 +305,11 @@ public class RequestCreator {
       throw new IllegalStateException("Fit cannot be used with fetch.");
     }
     if (data.hasImage()) {
+      // Fetch requests have lower priority by default.
+      if (!data.hasPriority()) {
+        data.priority(Priority.LOW);
+      }
+
       Request request = createRequest(started);
       String key = createKey(request, new StringBuilder());
 

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -35,6 +35,9 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
+import static com.squareup.picasso.Picasso.Priority.LOW;
+import static com.squareup.picasso.Picasso.Priority.HIGH;
+import static com.squareup.picasso.Picasso.Priority.NORMAL;
 import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.RemoteViewsAction.AppWidgetAction;
 import static com.squareup.picasso.RemoteViewsAction.NotificationAction;
@@ -129,6 +132,18 @@ public class RequestCreatorTest {
     }
   }
 
+  @Test public void fetchWithDefaultPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).fetch();
+    verify(picasso).submit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(LOW);
+  }
+
+  @Test public void fetchWithCustomPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).priority(HIGH).fetch();
+    verify(picasso).submit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(HIGH);
+  }
+
   @Test
   public void intoTargetWithNullThrows() throws Exception {
     try {
@@ -183,6 +198,18 @@ public class RequestCreatorTest {
     verify(target).onPrepareLoad(placeHolderDrawable);
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
     assertThat(actionCaptor.getValue()).isInstanceOf(TargetAction.class);
+  }
+
+  @Test public void targetActionWithDefaultPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).into(mockTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(NORMAL);
+  }
+
+  @Test public void targetActionWithCustomPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).priority(HIGH).into(mockTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(HIGH);
   }
 
   @Test
@@ -324,6 +351,18 @@ public class RequestCreatorTest {
     }
   }
 
+  @Test public void imageViewActionWithDefaultPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(NORMAL);
+  }
+
+  @Test public void imageViewActionWithCustomPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).priority(HIGH).into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(HIGH);
+  }
+
   @Test public void intoRemoteViewsWidgetQueuesAppWidgetAction() throws Exception {
     new RequestCreator(picasso, URI_1, 0).into(mockRemoteViews(), 0, new int[] { 1, 2, 3 });
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
@@ -432,6 +471,32 @@ public class RequestCreatorTest {
     }
   }
 
+  @Test public void appWidgetActionWithDefaultPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).into(mockRemoteViews(), 0, new int[] { 1, 2, 3 });
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(NORMAL);
+  }
+
+  @Test public void appWidgetActionWithCustomPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).priority(HIGH)
+        .into(mockRemoteViews(), 0, new int[]{1, 2, 3});
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(HIGH);
+  }
+
+  @Test public void notificationActionWithDefaultPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).into(mockRemoteViews(), 0, 0, mockNotification());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(NORMAL);
+  }
+
+  @Test public void notificationActionWithCustomPriority() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).priority(HIGH)
+        .into(mockRemoteViews(), 0, 0, mockNotification());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getPriority()).isEqualTo(HIGH);
+  }
+
   @Test public void invalidResize() throws Exception {
     try {
       new RequestCreator().resize(-1, 10);
@@ -508,6 +573,19 @@ public class RequestCreatorTest {
     try {
       new RequestCreator().error(new ColorDrawable(0)).error(1);
       fail("Two placeholders should throw exception.");
+    } catch (IllegalStateException expected) {
+    }
+  }
+
+  @Test public void invalidPriority() throws Exception {
+    try {
+      new RequestCreator().priority(null);
+      fail("Null priority should throw exception.");
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      new RequestCreator().priority(LOW).priority(HIGH);
+      fail("Two priorities should throw exception.");
     } catch (IllegalStateException expected) {
     }
   }

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -36,6 +36,7 @@ import static android.content.ContentResolver.SCHEME_ANDROID_RESOURCE;
 import static android.provider.ContactsContract.Contacts.CONTENT_URI;
 import static android.provider.ContactsContract.Contacts.Photo.CONTENT_DIRECTORY;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
+import static com.squareup.picasso.Picasso.Priority;
 import static com.squareup.picasso.Utils.createKey;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -114,23 +115,32 @@ class TestUtils {
   }
 
   static Action mockAction(String key, Uri uri, Object target) {
-    return mockAction(key, uri, target, 0);
+    return mockAction(key, uri, target, 0, null);
+  }
+
+  static Action mockAction(String key, Uri uri, Priority priority) {
+    return mockAction(key, uri, null, 0, priority);
   }
 
   static Action mockAction(String key, Uri uri, Object target, int resourceId) {
+    return mockAction(key, uri, target, resourceId, null);
+  }
+
+  static Action mockAction(String key, Uri uri, Object target, int resourceId, Priority priority) {
     Request request = new Request.Builder(uri, resourceId).build();
-    return mockAction(key, request, target);
+    return mockAction(key, request, target, priority);
   }
 
   static Action mockAction(String key, Request request) {
-    return mockAction(key, request, null);
+    return mockAction(key, request, null, null);
   }
 
-  static Action mockAction(String key, Request request, Object target) {
+  static Action mockAction(String key, Request request, Object target, Priority priority) {
     Action action = mock(Action.class);
     when(action.getKey()).thenReturn(key);
     when(action.getRequest()).thenReturn(request);
     when(action.getTarget()).thenReturn(target);
+    when(action.getPriority()).thenReturn(priority != null ? priority : Priority.NORMAL);
 
     Picasso picasso = mockPicasso();
     when(action.getPicasso()).thenReturn(picasso);


### PR DESCRIPTION
Not sure if you've considered something like this in the past but here it is. This patch implements request priority support in Picasso. This feature can be especially handy when you have UIs with lots of images and you want to have tighter control over which images should load first. This is inspired by Volley's API.

It adds a new API in `RequestCreator` to define the request priority:

``` java
Picasso.with(context)
       .load("http://example.com/image.jpg")
       .priority(HIGH)
       .into(someImageView);
```

Priority can be `LOW`, `NORMAL`, `HIGH`, or `IMMEDIATE`. `BitmapHunters` compute their priority in the executor by taking the highest priority of its attached requests. For example, if a `BitmapHunter` has two attached `Actions`, one `LOW` and and one `HIGH` priority, its priority will be `HIGH`.
