### PR TITLE
Added Codecov.io coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: android
 
+before_install: sudo pip install codecov
+
 jdk:
  - oraclejdk7
  - oraclejdk8
@@ -17,3 +19,5 @@ branches:
 
 notifications:
   email: false
+
+after_success: codecov

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Picasso
+Picasso [![codecov.io](https://codecov.io/github/square/picasso/coverage.svg?branch=master)](https://codecov.io/github/square/picasso?branch=master)
 =======
 
 A powerful image downloading and caching library for Android

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,26 @@
           <autoVersionSubmodules>true</autoVersionSubmodules>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.5.8.201207111220</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Hey Friends! I'm from [Codecov.io](https://codecov.io/) and wanted to personally add our coverage reporting tools to **picasso**! 

You can see the reports **now** here: [codecov.io/github/stevepeak/picasso](https://codecov.io/github/stevepeak/picasso?ref=00fecd35e2723c58ee41935af290aa45f1c4d5a3)

[![codecov.io](https://codecov.io/github/stevepeak/picasso/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/picasso?branch=master)

I'm excited to hear your feedback! Thank you for your time.
