### PR TITLE
Add density support.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/AssetRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/AssetRequestHandler.java
@@ -32,8 +32,10 @@ class AssetRequestHandler extends RequestHandler {
       (SCHEME_FILE + ":///" + ANDROID_ASSET + "/").length();
 
   private final AssetManager assetManager;
+  private final Context context;
 
   public AssetRequestHandler(Context context) {
+    this.context = context.getApplicationContext();
     assetManager = context.getAssets();
   }
 
@@ -49,7 +51,7 @@ class AssetRequestHandler extends RequestHandler {
   }
 
   Bitmap decodeAsset(Request data, String filePath) throws IOException {
-    final BitmapFactory.Options options = createBitmapOptions(data);
+    final BitmapFactory.Options options = createBitmapOptions(data, context);
     if (requiresInSampleSize(options)) {
       InputStream is = null;
       try {

--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoRequestHandler.java
@@ -108,7 +108,7 @@ class ContactsPhotoRequestHandler extends RequestHandler {
     if (stream == null) {
       return null;
     }
-    final BitmapFactory.Options options = createBitmapOptions(data);
+    final BitmapFactory.Options options = createBitmapOptions(data, context);
     if (requiresInSampleSize(options)) {
       InputStream is = getInputStream(data);
       try {

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
@@ -42,7 +42,7 @@ class ContentStreamRequestHandler extends RequestHandler {
 
   protected Bitmap decodeContentStream(Request data) throws IOException {
     ContentResolver contentResolver = context.getContentResolver();
-    final BitmapFactory.Options options = createBitmapOptions(data);
+    final BitmapFactory.Options options = createBitmapOptions(data, context);
     if (requiresInSampleSize(options)) {
       InputStream is = null;
       try {

--- a/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
@@ -66,7 +66,7 @@ class MediaStoreRequestHandler extends ContentStreamRequestHandler {
 
       long id = parseId(data.uri);
 
-      BitmapFactory.Options options = createBitmapOptions(data);
+      BitmapFactory.Options options = createBitmapOptions(data, context);
       options.inJustDecodeBounds = true;
 
       calculateInSampleSize(data.targetWidth, data.targetHeight, picassoKind.width,

--- a/picasso/src/main/java/com/squareup/picasso/NetworkRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkRequestHandler.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.picasso;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.NetworkInfo;
@@ -32,10 +33,12 @@ class NetworkRequestHandler extends RequestHandler {
   private static final String SCHEME_HTTP = "http";
   private static final String SCHEME_HTTPS = "https";
 
+  private final Context context;
   private final Downloader downloader;
   private final Stats stats;
 
-  public NetworkRequestHandler(Downloader downloader, Stats stats) {
+  public NetworkRequestHandler(Context context, Downloader downloader, Stats stats) {
+    this.context = context.getApplicationContext();
     this.downloader = downloader;
     this.stats = stats;
   }
@@ -96,7 +99,7 @@ class NetworkRequestHandler extends RequestHandler {
 
     long mark = markStream.savePosition(MARKER);
 
-    final BitmapFactory.Options options = createBitmapOptions(data);
+    final BitmapFactory.Options options = createBitmapOptions(data, context);
     final boolean calculateSize = requiresInSampleSize(options);
 
     boolean isWebPFile = Utils.isWebPFile(stream);

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -183,7 +183,7 @@ public class Picasso {
     allRequestHandlers.add(new ContentStreamRequestHandler(context));
     allRequestHandlers.add(new AssetRequestHandler(context));
     allRequestHandlers.add(new FileRequestHandler(context));
-    allRequestHandlers.add(new NetworkRequestHandler(dispatcher.downloader, stats));
+    allRequestHandlers.add(new NetworkRequestHandler(context, dispatcher.downloader, stats));
     requestHandlers = Collections.unmodifiableList(allRequestHandlers);
 
     this.stats = stats;

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -77,11 +77,13 @@ public final class Request {
   public final Bitmap.Config config;
   /** The priority of this request. */
   public final Priority priority;
+  /** Density of original image. */
+  public final int originalDensity;
 
   private Request(Uri uri, int resourceId, List<Transformation> transformations, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
       float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config,
-      Priority priority) {
+      Priority priority, int originalDensity) {
     this.uri = uri;
     this.resourceId = resourceId;
     if (transformations == null) {
@@ -99,6 +101,7 @@ public final class Request {
     this.hasRotationPivot = hasRotationPivot;
     this.config = config;
     this.priority = priority;
+    this.originalDensity = originalDensity;
   }
 
   @Override public String toString() {
@@ -131,6 +134,9 @@ public final class Request {
     }
     if (config != null) {
       sb.append(' ').append(config);
+    }
+    if (originalDensity > 0) {
+      sb.append(" originalDensity(").append(originalDensity).append(')');
     }
     sb.append('}');
 
@@ -191,6 +197,7 @@ public final class Request {
     private List<Transformation> transformations;
     private Bitmap.Config config;
     private Priority priority;
+    private int originalDensity;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(Uri uri) {
@@ -223,6 +230,7 @@ public final class Request {
       }
       config = request.config;
       priority = request.priority;
+      originalDensity = request.originalDensity;
     }
 
     boolean hasImage() {
@@ -382,6 +390,14 @@ public final class Request {
       return this;
     }
 
+    /**
+     * Specify the density of original image.
+     */
+    public Builder originalDensity(int density) {
+      originalDensity = density;
+      return this;
+    }
+
     /** Create the immutable {@link Request} object. */
     public Request build() {
       if (centerInside && centerCrop) {
@@ -398,7 +414,7 @@ public final class Request {
       }
       return new Request(uri, resourceId, transformations, targetWidth, targetHeight, centerCrop,
           centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config,
-          priority);
+          priority, originalDensity);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -272,6 +272,14 @@ public class RequestCreator {
   }
 
   /**
+   * Set the density DPI of original image and let Picasso adjust.
+   */
+  public RequestCreator originalDensity(int density) {
+    data.originalDensity(density);
+    return this;
+  }
+
+  /**
    * Add a custom transformation to be applied to the image.
    * <p>
    * Custom transformations will always be run after the built-in transformations.

--- a/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.picasso;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.NetworkInfo;
@@ -115,17 +116,23 @@ public abstract class RequestHandler {
 
   /**
    * Lazily create {@link BitmapFactory.Options} based in given
-   * {@link Request}, only instantiating them if needed.
+   * {@link Request} and {@link Context}, only instantiating
+   * them if needed.
    */
-  static BitmapFactory.Options createBitmapOptions(Request data) {
+  static BitmapFactory.Options createBitmapOptions(Request data, Context context) {
     final boolean justBounds = data.hasSize();
     final boolean hasConfig = data.config != null;
+    final boolean adjustDensity = (data.originalDensity > 0) && context != null;
     BitmapFactory.Options options = null;
-    if (justBounds || hasConfig) {
+    if (justBounds || hasConfig || adjustDensity) {
       options = new BitmapFactory.Options();
       options.inJustDecodeBounds = justBounds;
       if (hasConfig) {
         options.inPreferredConfig = data.config;
+      }
+      if (adjustDensity) {
+        options.inDensity = data.originalDensity;
+        options.inTargetDensity = context.getResources().getDisplayMetrics().densityDpi;
       }
     }
     return options;

--- a/picasso/src/main/java/com/squareup/picasso/ResourceRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ResourceRequestHandler.java
@@ -46,7 +46,7 @@ class ResourceRequestHandler extends RequestHandler {
   }
 
   private static Bitmap decodeResource(Resources resources, int id, Request data) {
-    final BitmapFactory.Options options = createBitmapOptions(data);
+    final BitmapFactory.Options options = createBitmapOptions(data, null);
     if (requiresInSampleSize(options)) {
       BitmapFactory.decodeResource(resources, id, options);
       calculateInSampleSize(data.targetWidth, data.targetHeight, options, data);

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -198,6 +198,10 @@ final class Utils {
         builder.append('\n');
       }
     }
+    if (data.originalDensity != 0) {
+      builder.append("originalDensity:").append(data.originalDensity);
+      builder.append('\n');
+    }
 
     return builder.toString();
   }

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -275,7 +275,7 @@ public class BitmapHunterTest {
 
   @Test public void forNetworkRequest() throws Exception {
     Action action = mockAction(URI_KEY_1, URI_1);
-    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(downloader, stats)),
+    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(context, downloader, stats)),
         dispatcher, cache, stats, action);
     assertThat(hunter.requestHandler).isInstanceOf(NetworkRequestHandler.class);
   }
@@ -350,7 +350,7 @@ public class BitmapHunterTest {
 
   @Test public void getPriorityWithNoRequests() throws Exception {
     Action action = mockAction(URI_KEY_1, URI_1);
-    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(downloader, stats)),
+    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(context, downloader, stats)),
         dispatcher, cache, stats, action);
     hunter.detach(action);
     assertThat(hunter.getAction()).isNull();
@@ -360,7 +360,7 @@ public class BitmapHunterTest {
 
   @Test public void getPriorityWithSingleRequest() throws Exception {
     Action action = mockAction(URI_KEY_1, URI_1, HIGH);
-    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(downloader, stats)),
+    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(context, downloader, stats)),
         dispatcher, cache, stats, action);
     assertThat(hunter.getAction()).isEqualTo(action);
     assertThat(hunter.getActions()).isNull();
@@ -370,7 +370,7 @@ public class BitmapHunterTest {
   @Test public void getPriorityWithMultipleRequests() throws Exception {
     Action action1 = mockAction(URI_KEY_1, URI_1, NORMAL);
     Action action2 = mockAction(URI_KEY_1, URI_1, HIGH);
-    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(downloader, stats)),
+    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(context, downloader, stats)),
         dispatcher, cache, stats, action1);
     hunter.attach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);
@@ -381,7 +381,7 @@ public class BitmapHunterTest {
   @Test public void getPriorityAfterDetach() throws Exception {
     Action action1 = mockAction(URI_KEY_1, URI_1, NORMAL);
     Action action2 = mockAction(URI_KEY_1, URI_1, HIGH);
-    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(downloader, stats)),
+    BitmapHunter hunter = forRequest(mockPicasso(new NetworkRequestHandler(context, downloader, stats)),
         dispatcher, cache, stats, action1);
     hunter.attach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);

--- a/picasso/src/test/java/com/squareup/picasso/NetworkRequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/NetworkRequestHandlerTest.java
@@ -48,6 +48,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 public class NetworkRequestHandlerTest {
 
   @Mock Picasso picasso;
+  @Mock Context context;
   @Mock Cache cache;
   @Mock Stats stats;
   @Mock Dispatcher dispatcher;
@@ -56,7 +57,7 @@ public class NetworkRequestHandlerTest {
 
   @Before public void setUp() throws Exception {
     initMocks(this);
-    networkHandler = new NetworkRequestHandler(downloader, stats);
+    networkHandler = new NetworkRequestHandler(context, downloader, stats);
     when(downloader.load(any(Uri.class), anyBoolean())).thenReturn(mock(Downloader.Response.class));
   }
 
@@ -139,7 +140,7 @@ public class NetworkRequestHandlerTest {
       }
     };
     Action action = TestUtils.mockAction(URI_KEY_1, URI_1);
-    NetworkRequestHandler customNetworkHandler = new NetworkRequestHandler(bitmapDownloader, stats);
+    NetworkRequestHandler customNetworkHandler = new NetworkRequestHandler(context, bitmapDownloader, stats);
 
     Bitmap actual = customNetworkHandler.load(action.getRequest()).getBitmap();
     assertThat(actual).isSameAs(expected);

--- a/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
@@ -15,8 +15,11 @@
  */
 package com.squareup.picasso;
 
+import android.content.Context;
+import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.util.DisplayMetrics;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -28,6 +31,8 @@ import static com.squareup.picasso.RequestHandler.createBitmapOptions;
 import static com.squareup.picasso.RequestHandler.requiresInSampleSize;
 import static com.squareup.picasso.TestUtils.URI_1;
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -38,8 +43,8 @@ public class RequestHandlerTest {
       Request data = new Request.Builder(URI_1).config(config).build();
       Request copy = data.buildUpon().build();
 
-      assertThat(createBitmapOptions(data).inPreferredConfig).isSameAs(config);
-      assertThat(createBitmapOptions(copy).inPreferredConfig).isSameAs(config);
+      assertThat(createBitmapOptions(data, null).inPreferredConfig).isSameAs(config);
+      assertThat(createBitmapOptions(copy, null).inPreferredConfig).isSameAs(config);
     }
   }
 
@@ -76,14 +81,14 @@ public class RequestHandlerTest {
   @Test public void nullBitmapOptionsIfNoResizing() {
     // No resize must return no bitmap options
     final Request noResize = new Request.Builder(URI_1).build();
-    final BitmapFactory.Options noResizeOptions = createBitmapOptions(noResize);
+    final BitmapFactory.Options noResizeOptions = createBitmapOptions(noResize, null);
     assertThat(noResizeOptions).isNull();
   }
 
   @Test public void inJustDecodeBoundsIfResizing() {
     // Resize must return bitmap options with inJustDecodeBounds = true
     final Request requiresResize = new Request.Builder(URI_1).resize(20, 15).build();
-    final BitmapFactory.Options resizeOptions = createBitmapOptions(requiresResize);
+    final BitmapFactory.Options resizeOptions = createBitmapOptions(requiresResize, null);
     assertThat(resizeOptions).isNotNull();
     assertThat(resizeOptions.inJustDecodeBounds).isTrue();
   }
@@ -91,8 +96,31 @@ public class RequestHandlerTest {
   @Test public void createWithConfigAndNotInJustDecodeBounds() {
     // Given a config must return bitmap options and false inJustDecodeBounds
     final Request config = new Request.Builder(URI_1).config(RGB_565).build();
-    final BitmapFactory.Options configOptions = createBitmapOptions(config);
+    final BitmapFactory.Options configOptions = createBitmapOptions(config, null);
     assertThat(configOptions).isNotNull();
     assertThat(configOptions.inJustDecodeBounds).isFalse();
+  }
+
+  @Test public void createWithDensity() {
+    Context context = mock(Context.class);
+    Resources resources = mock(Resources.class);
+    DisplayMetrics displayMetrics = new DisplayMetrics();
+    when(context.getResources()).thenReturn(resources);
+    when(resources.getDisplayMetrics()).thenReturn(displayMetrics);
+    displayMetrics.densityDpi = DisplayMetrics.DENSITY_XHIGH;
+
+    int[] densities = {
+      DisplayMetrics.DENSITY_MEDIUM,
+      DisplayMetrics.DENSITY_HIGH,
+      DisplayMetrics.DENSITY_XHIGH,
+      DisplayMetrics.DENSITY_XXHIGH
+    };
+
+    for (int density : densities) {
+      Request data = new Request.Builder(URI_1).originalDensity(density).build();
+      BitmapFactory.Options options = createBitmapOptions(data, context);
+      assertThat(options.inDensity).isEqualTo(density);
+      assertThat(options.inTargetDensity).isEqualTo(DisplayMetrics.DENSITY_XHIGH);
+    }
   }
 }


### PR DESCRIPTION
Add a feature to adjust image density to fit device's one. 
For sources which don't supply original density information, Request now has 'density' parameters so that each RequestHandler can refer.
