### PR TITLE
Fixes sizing for EXIF-rotated images

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -406,6 +406,7 @@ class BitmapHunter implements Runnable {
     return result;
   }
 
+  @SuppressWarnings("SuspiciousNameCombination")
   static Bitmap transformResult(Request data, Bitmap result, int exifRotation) {
     int inWidth = result.getWidth();
     int inHeight = result.getHeight();
@@ -427,6 +428,15 @@ class BitmapHunter implements Runnable {
           matrix.setRotate(targetRotation, data.rotationPivotX, data.rotationPivotY);
         } else {
           matrix.setRotate(targetRotation);
+        }
+      }
+
+      if (exifRotation != 0) {
+        matrix.preRotate(exifRotation);
+        if (exifRotation == 90 || exifRotation == 270) {
+          int tmpHeight = targetHeight;
+          targetHeight = targetWidth;
+          targetWidth = tmpHeight;
         }
       }
 
@@ -459,10 +469,6 @@ class BitmapHunter implements Runnable {
         float sy = targetHeight / (float) inHeight;
         matrix.preScale(sx, sy);
       }
-    }
-
-    if (exifRotation != 0) {
-      matrix.preRotate(exifRotation);
     }
 
     Bitmap newResult =

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -112,7 +112,7 @@ public class BitmapHunterTest {
     verify(dispatcher).dispatchFailed(hunter);
   }
 
-  @Test public void responseExcpetionDispatchFailed() throws Exception {
+  @Test public void responseExceptionDispatchFailed() throws Exception {
     Action action = mockAction(URI_KEY_1, URI_1);
     BitmapHunter hunter = new TestableBitmapHunter(picasso, dispatcher, cache, stats, action, null,
         new Downloader.ResponseException("Test"));
@@ -403,6 +403,18 @@ public class BitmapHunterTest {
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
     assertThat(shadowMatrix.getPreOperations()).containsOnly("rotate 90.0");
+  }
+
+  @Test public void exifRotationSizing() throws Exception {
+    Request data = new Request.Builder(URI_1).rotate(-45).resize(5, 10).build();
+    Bitmap source = Bitmap.createBitmap(10, 10, ARGB_8888);
+    Bitmap result = transformResult(data, source, 90);
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    assertThat(shadowBitmap.getCreatedFromBitmap()).isSameAs(source);
+
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    assertThat(shadowMatrix.getPreOperations()).contains("scale 1.0 0.5");
   }
 
   @Test public void exifRotationWithManualRotation() throws Exception {


### PR DESCRIPTION
See #689 and #691.  Unfortunately those issues don't do a great job of concisely describing the issue.  

Please note this does not address the issue of sizing images with custom rotation with , for example - `requestCreator.rotate(degrees, pivotX, pivotY)`, because the math is not trivial and there should probably be some discussion about the actual desired behavior.

However, I feel like it's still appropriate to make this change because ideally EXIF rotation should be transparent to the developer, whereas `requestCreator.rotate()` would have to be specifically requested.  