### PR TITLE
Add DownloaderOptions to allow customization of a download when a request results in a download

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -149,7 +149,7 @@ class BitmapHunter implements Runnable {
       }
     }
 
-    data.loadFromLocalCacheOnly = (retryCount == 0);
+    data.loadFromCacheIf(retryCount == 0);
     RequestHandler.Result result = requestHandler.load(data);
     if (result != null) {
       bitmap = result.getBitmap();

--- a/picasso/src/main/java/com/squareup/picasso/Downloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/Downloader.java
@@ -26,14 +26,13 @@ public interface Downloader {
    * Download the specified image {@code url} from the internet.
    *
    * @param uri Remote image URL.
-   * @param localCacheOnly If {@code true} the URL should only be loaded if available in a local
-   * disk cache.
+   * @param options A set of options that are applied to the download.
    * @return {@link Response} containing either a {@link Bitmap} representation of the request or an
    * {@link InputStream} for the image data. {@code null} can be returned to indicate a problem
    * loading the bitmap.
    * @throws IOException if the requested URL cannot successfully be loaded.
    */
-  Response load(Uri uri, boolean localCacheOnly) throws IOException;
+  Response load(Uri uri, DownloaderOptions options) throws IOException;
 
   /** Thrown for non-2XX responses. */
   class ResponseException extends IOException {

--- a/picasso/src/main/java/com/squareup/picasso/DownloaderOptions.java
+++ b/picasso/src/main/java/com/squareup/picasso/DownloaderOptions.java
@@ -1,0 +1,44 @@
+package com.squareup.picasso;
+
+import java.util.HashMap;
+
+public class DownloaderOptions {
+  private final HashMap<String, String> requestProperties = new HashMap<String, String>();
+
+  private boolean loadFromLocalCacheOnly;
+
+  /**
+   * Whether or not this request should only load from local cache.
+   */
+  boolean loadFromLocalCacheOnly() {
+    return loadFromLocalCacheOnly;
+  }
+
+  /**
+   * Whether or not this request should only load from local cache.
+   */
+  void setLoadFromLocalCacheOnly(boolean loadFromLocalCacheOnly) {
+    this.loadFromLocalCacheOnly = loadFromLocalCacheOnly;
+  }
+
+  /**
+   * A set of requestProperties to apply to a download.
+   */
+  HashMap<String, String> getRequestProperties() {
+    return requestProperties;
+  }
+
+  /**
+   * Adds a request property to be applied if this request results in a download.
+   *
+   * @param name  The name of the property to apply. Example: "Referer"
+   * @param value The value of the property.
+   */
+  public DownloaderOptions setRequestProperty(String name, String value) {
+    if (name != null) {
+      requestProperties.put(name, value);
+    }
+
+    return this;
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso/NetworkRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkRequestHandler.java
@@ -46,7 +46,7 @@ class NetworkRequestHandler extends RequestHandler {
   }
 
   @Override public Result load(Request data) throws IOException {
-    Response response = downloader.load(data.uri, data.loadFromLocalCacheOnly);
+    Response response = downloader.load(data.uri, data.downloaderOptions);
     if (response == null) {
       return null;
     }

--- a/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttpDownloader.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashMap;
 
 import static com.squareup.picasso.Utils.parseResponseSourceHeader;
 
@@ -95,12 +96,13 @@ public class OkHttpDownloader implements Downloader {
     return urlFactory.client();
   }
 
-  @Override public Response load(Uri uri, boolean localCacheOnly) throws IOException {
+  @Override public Response load(Uri uri, DownloaderOptions downloaderOptions) throws IOException {
     HttpURLConnection connection = openConnection(uri);
     connection.setUseCaches(true);
-    if (localCacheOnly) {
+    if (downloaderOptions.loadFromLocalCacheOnly()) {
       connection.setRequestProperty("Cache-Control", "only-if-cached,max-age=" + Integer.MAX_VALUE);
     }
+    applyRequestProperties(connection, downloaderOptions.getRequestProperties());
 
     int responseCode = connection.getResponseCode();
     if (responseCode >= 300) {
@@ -117,5 +119,14 @@ public class OkHttpDownloader implements Downloader {
     boolean fromCache = parseResponseSourceHeader(responseSource);
 
     return new Response(connection.getInputStream(), fromCache, contentLength);
+  }
+
+  private static void applyRequestProperties(HttpURLConnection connection,
+                                             HashMap<String, String> properties) {
+    if (properties != null && !properties.isEmpty()) {
+      for (String key : properties.keySet()) {
+        connection.setRequestProperty(key, properties.get(key));
+      }
+    }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -32,8 +32,6 @@ public final class Request {
   int id;
   /** The time that the request was first submitted (in nanos). */
   long started;
-  /** Whether or not this request should only load from local cache. */
-  boolean loadFromLocalCacheOnly;
 
   /**
    * The image URI.
@@ -77,11 +75,15 @@ public final class Request {
   public final Bitmap.Config config;
   /** The priority of this request. */
   public final Priority priority;
+  /**
+   * A set of options that will be used if this request requires a download.
+   */
+  public final DownloaderOptions downloaderOptions;
 
   private Request(Uri uri, int resourceId, List<Transformation> transformations, int targetWidth,
       int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
       float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config,
-      Priority priority) {
+      Priority priority, DownloaderOptions downloaderOptions) {
     this.uri = uri;
     this.resourceId = resourceId;
     if (transformations == null) {
@@ -99,6 +101,7 @@ public final class Request {
     this.hasRotationPivot = hasRotationPivot;
     this.config = config;
     this.priority = priority;
+    this.downloaderOptions = downloaderOptions;
   }
 
   @Override public String toString() {
@@ -172,6 +175,10 @@ public final class Request {
     return transformations != null;
   }
 
+  void loadFromCacheIf(boolean condition) {
+    downloaderOptions.setLoadFromLocalCacheOnly(condition);
+  }
+
   public Builder buildUpon() {
     return new Builder(this);
   }
@@ -191,6 +198,7 @@ public final class Request {
     private List<Transformation> transformations;
     private Bitmap.Config config;
     private Priority priority;
+    private DownloaderOptions downloaderOptions;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(Uri uri) {
@@ -366,6 +374,18 @@ public final class Request {
       return this;
     }
 
+    /** Execute request using the specified {@link DownloaderOptions}. */
+    public Builder setDownloadOptions(DownloaderOptions downloaderOptions) {
+      if (downloaderOptions == null) {
+        throw new IllegalArgumentException("DownloaderOptions invalid.");
+      }
+      if (this.downloaderOptions != null) {
+        throw new IllegalStateException("DownloaderOptions already set.");
+      }
+      this.downloaderOptions = downloaderOptions;
+      return this;
+    }
+
     /**
      * Add a custom transformation to be applied to the image.
      * <p>
@@ -396,9 +416,12 @@ public final class Request {
       if (priority == null) {
         priority = Priority.NORMAL;
       }
+      if (downloaderOptions == null) {
+        downloaderOptions = new DownloaderOptions();
+      }
       return new Request(uri, resourceId, transformations, targetWidth, targetHeight, centerCrop,
           centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config,
-          priority);
+          priority, downloaderOptions);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -283,6 +283,14 @@ public class RequestCreator {
   }
 
   /**
+   * Sets parameters that will be applied if the request results in a download.
+   */
+  public RequestCreator downloaderOptions(DownloaderOptions options) {
+    data.setDownloadOptions(options);
+    return this;
+  }
+
+  /**
    * Indicate that this action should not use the memory cache for attempting to load or save the
    * image. This can be useful when you know an image will only ever be used once (e.g., loading
    * an image from the filesystem and uploading to a remote server).

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -256,6 +256,15 @@ class TestUtils {
     return picasso;
   }
 
+
+  static DownloaderOptions mockDownloaderOptions(boolean loadFromCache) {
+    DownloaderOptions options = mock(DownloaderOptions.class);
+
+    when(options.loadFromLocalCacheOnly()).thenReturn(loadFromCache);
+
+    return options;
+  }
+
   private TestUtils() {
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/UrlConnectionDownloaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UrlConnectionDownloaderTest.java
@@ -65,12 +65,12 @@ public class UrlConnectionDownloaderTest {
     UrlConnectionDownloader.cache = null;
 
     server.enqueue(new MockResponse());
-    loader.load(URL, false);
+    loader.load(URL, TestUtils.mockDownloaderOptions(false));
     Object cache = UrlConnectionDownloader.cache;
     assertThat(cache).isNotNull();
 
     server.enqueue(new MockResponse());
-    loader.load(URL, false);
+    loader.load(URL, TestUtils.mockDownloaderOptions(false));
     assertThat(UrlConnectionDownloader.cache).isSameAs(cache);
   }
 
@@ -79,7 +79,7 @@ public class UrlConnectionDownloaderTest {
     UrlConnectionDownloader.cache = null;
 
     server.enqueue(new MockResponse());
-    loader.load(URL, false);
+    loader.load(URL, TestUtils.mockDownloaderOptions(false));
     Object cache = UrlConnectionDownloader.cache;
     assertThat(cache).isNull();
   }
@@ -87,38 +87,66 @@ public class UrlConnectionDownloaderTest {
   @Config(reportSdk = GINGERBREAD)
   @Test public void allowExpiredSetsCacheControl() throws Exception {
     server.enqueue(new MockResponse());
-    loader.load(URL, false);
+    loader.load(URL, TestUtils.mockDownloaderOptions(false));
     RecordedRequest request1 = server.takeRequest();
     assertThat(request1.getHeader("Cache-Control")).isNull();
 
     server.enqueue(new MockResponse());
-    loader.load(URL, true);
+    loader.load(URL, TestUtils.mockDownloaderOptions(true));
     RecordedRequest request2 = server.takeRequest();
     assertThat(request2.getHeader("Cache-Control")) //
         .isEqualTo("only-if-cached,max-age=" + Integer.MAX_VALUE);
   }
 
   @Config(reportSdk = GINGERBREAD)
+  @Test public void requestPropertyAppliedToRequestWhenRefererSpecified() throws Exception {
+    final String REFERER_VALUE = "http://my.bogus.referer.url/path";
+
+    server.enqueue(new MockResponse());
+    loader.load(URL, new DownloaderOptions()
+      .setRequestProperty("REFERER", REFERER_VALUE));
+    RecordedRequest request1 = server.takeRequest();
+    assertThat(request1.getHeader("REFERER")).isEqualTo(REFERER_VALUE);
+  }
+
+  @Config(reportSdk = GINGERBREAD)
+  @Test public void requestPropertyAppliedToRequestWhenRefererNull() throws Exception {
+    server.enqueue(new MockResponse());
+    loader.load(URL, new DownloaderOptions()
+      .setRequestProperty("REFERER", null));
+    RecordedRequest request1 = server.takeRequest();
+    assertThat(request1.getHeader("REFERER")).isNullOrEmpty();
+  }
+
+  @Config(reportSdk = GINGERBREAD)
+  @Test public void noRequestPropertyAppliedToRequestWhenNoneSpecified() throws Exception {
+    server.enqueue(new MockResponse());
+    loader.load(URL, new DownloaderOptions());
+    RecordedRequest request1 = server.takeRequest();
+    assertThat(request1.getHeaders()).doesNotContain("REFERER");
+  }
+
+  @Config(reportSdk = GINGERBREAD)
   @Test public void responseSourceHeaderSetsResponseValue() throws Exception {
     server.enqueue(new MockResponse());
-    Downloader.Response response1 = loader.load(URL, false);
+    Downloader.Response response1 = loader.load(URL, TestUtils.mockDownloaderOptions(false));
     assertThat(response1.cached).isFalse();
 
     server.enqueue(new MockResponse().addHeader(RESPONSE_SOURCE, "CACHE 200"));
-    Downloader.Response response2 = loader.load(URL, true);
+    Downloader.Response response2 = loader.load(URL, TestUtils.mockDownloaderOptions(true));
     assertThat(response2.cached).isTrue();
   }
 
   @Test public void readsContentLengthHeader() throws Exception {
     server.enqueue(new MockResponse().addHeader("Content-Length", 1024));
-    Downloader.Response response = loader.load(URL, true);
+    Downloader.Response response = loader.load(URL, TestUtils.mockDownloaderOptions(true));
     assertThat(response.contentLength).isEqualTo(1024);
   }
 
   @Test public void throwsResponseException() throws Exception {
     server.enqueue(new MockResponse().setStatus("HTTP/1.1 401 Not Authorized"));
     try {
-      loader.load(URL, false);
+      loader.load(URL, TestUtils.mockDownloaderOptions(false));
       fail("Expected ResponseException.");
     } catch (Downloader.ResponseException e) {
       assertThat(e).hasMessage("401 Not Authorized");


### PR DESCRIPTION
Implement `DownloaderOptions` though request flow to allow optional customization of request properties on every request.

This consolidates the `loadFromLocalCacheOnly` argument from the `Downloader` interface into `DownloaderOptions`.
- Note: This breaks backwards compatibility of the `Downloader` interface. If this is unacceptable, we can discuss other ideas for passing options to the downloaders.

This is offered as an alternate solution to initializing Picasso with a custom Downloader when it is necessary to customize every request differently. Issues:
- https://github.com/square/picasso/issues/459
- https://github.com/square/picasso/issues/693
- https://github.com/square/picasso/issues/84
