### PR TITLE
Add custom cache key functionality

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -47,6 +47,13 @@ public final class Request {
    * This is mutually exclusive with {@link #uri}.
    */
   public final int resourceId;
+  /**
+   * The optional stable key for this request to be used instead of the URI or resource ID to
+   * generate cache key.
+   * <p>
+   * {@code null} if no stable key is defined.
+   */
+  public final String stableKey;
   /** List of custom transformations to be applied after the built-in transformations. */
   public final List<Transformation> transformations;
   /** Target image width for resizing. */
@@ -78,12 +85,13 @@ public final class Request {
   /** The priority of this request. */
   public final Priority priority;
 
-  private Request(Uri uri, int resourceId, List<Transformation> transformations, int targetWidth,
-      int targetHeight, boolean centerCrop, boolean centerInside, float rotationDegrees,
-      float rotationPivotX, float rotationPivotY, boolean hasRotationPivot, Bitmap.Config config,
-      Priority priority) {
+  private Request(Uri uri, int resourceId, String stableKey, List<Transformation> transformations,
+      int targetWidth, int targetHeight, boolean centerCrop, boolean centerInside,
+      float rotationDegrees, float rotationPivotX, float rotationPivotY, boolean hasRotationPivot,
+      Bitmap.Config config, Priority priority) {
     this.uri = uri;
     this.resourceId = resourceId;
+    this.stableKey = stableKey;
     if (transformations == null) {
       this.transformations = null;
     } else {
@@ -112,6 +120,9 @@ public final class Request {
       for (Transformation transformation : transformations) {
         sb.append(' ').append(transformation.key());
       }
+    }
+    if (stableKey != null) {
+      sb.append(" stableKey(").append(stableKey).append(')');
     }
     if (targetWidth > 0) {
       sb.append(" resize(").append(targetWidth).append(',').append(targetHeight).append(')');
@@ -180,6 +191,7 @@ public final class Request {
   public static final class Builder {
     private Uri uri;
     private int resourceId;
+    private String stableKey;
     private int targetWidth;
     private int targetHeight;
     private boolean centerCrop;
@@ -210,6 +222,7 @@ public final class Request {
     private Builder(Request request) {
       uri = request.uri;
       resourceId = request.resourceId;
+      stableKey = request.stableKey;
       targetWidth = request.targetWidth;
       targetHeight = request.targetHeight;
       centerCrop = request.centerCrop;
@@ -262,6 +275,14 @@ public final class Request {
       }
       this.resourceId = resourceId;
       this.uri = null;
+      return this;
+    }
+
+    /**
+     * Set the stableKey for this Request.
+     */
+    public Builder stableKey(String stableKey) {
+      this.stableKey = stableKey;
       return this;
     }
 
@@ -407,9 +428,9 @@ public final class Request {
       if (priority == null) {
         priority = Priority.NORMAL;
       }
-      return new Request(uri, resourceId, transformations, targetWidth, targetHeight, centerCrop,
-          centerInside, rotationDegrees, rotationPivotX, rotationPivotY, hasRotationPivot, config,
-          priority);
+      return new Request(uri, resourceId, stableKey, transformations, targetWidth, targetHeight,
+          centerCrop, centerInside, rotationDegrees, rotationPivotX, rotationPivotY,
+          hasRotationPivot, config, priority);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -282,6 +282,15 @@ public class RequestCreator {
   }
 
   /**
+   * Sets the stable key for this request to be used instead of the URI or resource ID to generate
+   * the cache key.
+   */
+  public RequestCreator stableKey(String stableKey) {
+    data.stableKey(stableKey);
+    return this;
+  }
+
+  /**
    * Set the priority of this request.
    * <p>
    * This will affect the order in which the requests execute but does not guarantee it.

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -164,7 +164,10 @@ final class Utils {
   }
 
   static String createKey(Request data, StringBuilder builder) {
-    if (data.uri != null) {
+    if (data.stableKey != null) {
+      builder.ensureCapacity(data.stableKey.length() + KEY_PADDING);
+      builder.append(data.stableKey);
+    } else if (data.uri != null) {
       String path = data.uri.toString();
       builder.ensureCapacity(path.length() + KEY_PADDING);
       builder.append(path);

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -40,6 +40,8 @@ import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.RemoteViewsAction.AppWidgetAction;
 import static com.squareup.picasso.RemoteViewsAction.NotificationAction;
 import static com.squareup.picasso.TestUtils.BITMAP_1;
+import static com.squareup.picasso.TestUtils.STABLE_1;
+import static com.squareup.picasso.TestUtils.STABLE_URI_KEY_1;
 import static com.squareup.picasso.TestUtils.TRANSFORM_REQUEST_ANSWER;
 import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
@@ -744,5 +746,17 @@ public class RequestCreatorTest {
       fail("Null Target should throw exception.");
     } catch (IllegalArgumentException ignored) {
     }
+  }
+
+  @Test public void imageViewActionWithStableyKey() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).stableKey(STABLE_1).into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getKey()).isEqualTo(STABLE_URI_KEY_1);
+  }
+
+  @Test public void imageViewActionWithStableKeyNull() throws Exception {
+    new RequestCreator(picasso, URI_1, 0).stableKey(null).into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getKey()).isEqualTo(URI_KEY_1);
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -51,8 +51,10 @@ class TestUtils {
   };
   static final Uri URI_1 = Uri.parse("http://example.com/1.png");
   static final Uri URI_2 = Uri.parse("http://example.com/2.png");
+  static final String STABLE_1 = "stableExampleKey1";
   static final String URI_KEY_1 = createKey(new Request.Builder(URI_1).build());
   static final String URI_KEY_2 = createKey(new Request.Builder(URI_2).build());
+  static final String STABLE_URI_KEY_1 = createKey(new Request.Builder(URI_1).stableKey(STABLE_1).build());
   static final Bitmap VIDEO_THUMBNAIL_1 = Bitmap.createBitmap(10, 10, null);
   static final Bitmap IMAGE_THUMBNAIL_1 = Bitmap.createBitmap(20, 20, null);
   static final Bitmap BITMAP_1 = Bitmap.createBitmap(10, 10, null);


### PR DESCRIPTION
Had to create a new PR because my old repo had old merge commits. So made a new repo and PR to clean the commits up as asked in the old PR.

Adds the option to set a custom cache key to be used instead of the uri based one.
I hope this is alright. Should be similar to the last PR that was made for this. I am new to writing tests and feedback is very welcome. If something should be changed comment please.

Thanks
