### PR TITLE
Using colourblind friendly LoadedFrom indicator colours

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -775,7 +775,7 @@ public class Picasso {
   /** Describes where the image was loaded from. */
   public enum LoadedFrom {
     MEMORY(Color.GREEN),
-    DISK(Color.YELLOW),
+    DISK(Color.BLUE),
     NETWORK(Color.RED);
 
     final int debugColor;


### PR DESCRIPTION
This is a solution for https://github.com/square/picasso/issues/753 where display indicators are now identifiable by colourblind folk.
