### PR TITLE
Possible fix for #769

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -451,19 +451,21 @@ class BitmapHunter implements Runnable {
       if (data.centerCrop) {
         float widthRatio = targetWidth / (float) inWidth;
         float heightRatio = targetHeight / (float) inHeight;
-        float scale;
+        float scaleX, scaleY;
         if (widthRatio > heightRatio) {
-          scale = widthRatio;
           int newSize = (int) Math.ceil(inHeight * (heightRatio / widthRatio));
           drawY = (inHeight - newSize) / 2;
           drawHeight = newSize;
+          scaleX = widthRatio;
+          scaleY = targetHeight / (float) drawHeight;
         } else {
-          scale = heightRatio;
           int newSize = (int) Math.ceil(inWidth * (widthRatio / heightRatio));
           drawX = (inWidth - newSize) / 2;
           drawWidth = newSize;
+          scaleX = targetWidth / (float) drawWidth;
+          scaleY = heightRatio;
         }
-        matrix.preScale(scale, scale);
+        matrix.preScale(scaleX, scaleY);
       } else if (data.centerInside) {
         float widthRatio = targetWidth / (float) inWidth;
         float heightRatio = targetHeight / (float) inHeight;

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -431,6 +431,27 @@ public class BitmapHunterTest {
     assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
   }
 
+  @Test public void centerCropResultMatchesTargetSize() throws Exception {
+    Request request = new Request.Builder(URI_1).resize(1080, 642).centerCrop().build();
+    Bitmap source = Bitmap.createBitmap(640, 640, ARGB_8888);
+
+    Bitmap result = transformResult(request, source, 0);
+
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    String scalePreOperation = shadowMatrix.getPreOperations().get(0);
+
+    assertThat(scalePreOperation).startsWith("scale ");
+    float scaleX = Float.valueOf(scalePreOperation.split(" ")[1]);
+    float scaleY = Float.valueOf(scalePreOperation.split(" ")[2]);
+
+    int transformedWidth = Math.round(result.getWidth() * scaleX);
+    int transformedHeight = Math.round(result.getHeight() * scaleY);
+    assertThat(transformedWidth).isEqualTo(1080);
+    assertThat(transformedHeight).isEqualTo(642);
+  }
+
   @Test public void exifRotationWithManualRotation() throws Exception {
     Bitmap source = Bitmap.createBitmap(10, 10, ARGB_8888);
     Request data = new Request.Builder(URI_1).rotate(-45).build();


### PR DESCRIPTION
When Center Crop is used, a single scale factor is calculated to transform the input image to a target image size. This does not work for all input cases. I'm not sure if this is the best solution but hope this at least starts a discussion. The summary of the problem: integers multiplied by a transformation matrix of floats cannot always create the requested targetSize. A single scale factor cannot be used for both X and Y because the input sizes are integers. Test included.