### PR TITLE
Use TransitionDrawable for PicassoDrawable

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -18,25 +18,24 @@ package com.squareup.picasso;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.ColorFilter;
+import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Point;
-import android.graphics.Rect;
 import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
-import android.os.Build;
-import android.os.SystemClock;
+import android.graphics.drawable.TransitionDrawable;
 import android.widget.ImageView;
 
 import static android.graphics.Color.WHITE;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 
-final class PicassoDrawable extends BitmapDrawable {
+final class PicassoDrawable extends TransitionDrawable {
   // Only accessed from main thread.
   private static final Paint DEBUG_PAINT = new Paint();
-  private static final float FADE_DURATION = 200f; //ms
+  private static final int FADE_DURATION = 200; //ms
 
   /**
    * Create or update the drawable on the target {@link ImageView} to display the supplied bitmap
@@ -68,15 +67,12 @@ final class PicassoDrawable extends BitmapDrawable {
   private final float density;
   private final Picasso.LoadedFrom loadedFrom;
 
-  Drawable placeholder;
-
-  long startTimeMillis;
-  boolean animating;
-  int alpha = 0xFF;
-
   PicassoDrawable(Context context, Bitmap bitmap, Drawable placeholder,
       Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging) {
-    super(context.getResources(), bitmap);
+    super(new Drawable[] {
+      placeholder == null ? new ColorDrawable(Color.TRANSPARENT) : placeholder,
+      new BitmapDrawable(context.getResources(), bitmap)
+    });
 
     this.debugging = debugging;
     this.density = context.getResources().getDisplayMetrics().density;
@@ -85,61 +81,19 @@ final class PicassoDrawable extends BitmapDrawable {
 
     boolean fade = loadedFrom != MEMORY && !noFade;
     if (fade) {
-      this.placeholder = placeholder;
-      animating = true;
-      startTimeMillis = SystemClock.uptimeMillis();
+      startTransition(FADE_DURATION);
+    } else {
+      // Transition straight to the final drawable.
+      startTransition(0);
     }
   }
 
   @Override public void draw(Canvas canvas) {
-    if (!animating) {
-      super.draw(canvas);
-    } else {
-      float normalized = (SystemClock.uptimeMillis() - startTimeMillis) / FADE_DURATION;
-      if (normalized >= 1f) {
-        animating = false;
-        placeholder = null;
-        super.draw(canvas);
-      } else {
-        if (placeholder != null) {
-          placeholder.draw(canvas);
-        }
-
-        int partialAlpha = (int) (alpha * normalized);
-        super.setAlpha(partialAlpha);
-        super.draw(canvas);
-        super.setAlpha(alpha);
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.GINGERBREAD_MR1) {
-          invalidateSelf();
-        }
-      }
-    }
+    super.draw(canvas);
 
     if (debugging) {
       drawDebugIndicator(canvas);
     }
-  }
-
-  @Override public void setAlpha(int alpha) {
-    this.alpha = alpha;
-    if (placeholder != null) {
-      placeholder.setAlpha(alpha);
-    }
-    super.setAlpha(alpha);
-  }
-
-  @Override public void setColorFilter(ColorFilter cf) {
-    if (placeholder != null) {
-      placeholder.setColorFilter(cf);
-    }
-    super.setColorFilter(cf);
-  }
-
-  @Override protected void onBoundsChange(Rect bounds) {
-    if (placeholder != null) {
-      placeholder.setBounds(bounds);
-    }
-    super.onBoundsChange(bounds);
   }
 
   private void drawDebugIndicator(Canvas canvas) {

--- a/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import org.junit.Test;
@@ -40,22 +41,21 @@ public class PicassoDrawableTest {
   
   @Test public void createWithNoPlaceholderAnimation() {
     PicassoDrawable pd = new PicassoDrawable(context, bitmap, null, DISK, false, false);
-    assertThat(pd.getBitmap()).isSameAs(bitmap);
-    assertThat(pd.placeholder).isNull();
-    assertThat(pd.animating).isTrue();
+    assertThat(pd.getNumberOfLayers()).isEqualTo(2);
+    assertThat(((BitmapDrawable) pd.getDrawable(1)).getBitmap()).isSameAs(bitmap);
   }
 
   @Test public void createWithPlaceholderAnimation() {
     PicassoDrawable pd = new PicassoDrawable(context, bitmap, placeholder, DISK, false, false);
-    assertThat(pd.getBitmap()).isSameAs(bitmap);
-    assertThat(pd.placeholder).isSameAs(placeholder);
-    assertThat(pd.animating).isTrue();
+    assertThat(pd.getNumberOfLayers()).isEqualTo(2);
+    assertThat(((BitmapDrawable) pd.getDrawable(1)).getBitmap()).isSameAs(bitmap);
+    assertThat(pd.getDrawable(0)).isSameAs(placeholder);
   }
 
   @Test public void createWithBitmapCacheHit() {
     PicassoDrawable pd = new PicassoDrawable(context, bitmap, placeholder, MEMORY, false, false);
-    assertThat(pd.getBitmap()).isSameAs(bitmap);
-    assertThat(pd.placeholder).isNull();
-    assertThat(pd.animating).isFalse();
+    assertThat(pd.getNumberOfLayers()).isEqualTo(2);
+    assertThat(((BitmapDrawable) pd.getDrawable(1)).getBitmap()).isSameAs(bitmap);
+    assertThat(pd.getDrawable(0)).isSameAs(placeholder);
   }
 }


### PR DESCRIPTION
Before, it was using a BitmapDrawable with a hacked-in placeholder.
This often caused the placeholder to draw with the incorrect aspect
ratio during loading.

Using a LayerDrawable fixes the aspect ratio; using TransitionDrawable
gives us the facility for cross-fading built into Android.

This PR addresses #427 (though we should determine if it does so in a satisfactory manner).