### PR TITLE
Add volatile to Picasso singleton access.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -139,7 +139,7 @@ public class Picasso {
     }
   };
 
-  static Picasso singleton = null;
+  static volatile Picasso singleton = null;
 
   private final Listener listener;
   private final RequestTransformer requestTransformer;


### PR DESCRIPTION
- Double-checked locking is broken. See Item 71 in Effective Java.
http://www.oracle.com/technetwork/articles/javase/bloch-effective-08-qa-140880.html