### PR TITLE
Trim url/file path passed in before do anything else

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -295,7 +295,7 @@ public class Picasso {
     if (path.trim().length() == 0) {
       throw new IllegalArgumentException("Path must not be empty.");
     }
-    return load(Uri.parse(path));
+    return load(Uri.parse(path.trim()));
   }
 
   /**
@@ -356,7 +356,10 @@ public class Picasso {
     if (path == null) {
       throw new IllegalArgumentException("path == null");
     }
-    invalidate(Uri.parse(path));
+    if (path.trim().length() == 0) {
+      throw new IllegalArgumentException("Path must not be empty.");
+    }
+    invalidate(Uri.parse(path.trim()));
   }
 
   /**


### PR DESCRIPTION
Which should be a right thing to do here in the library. 
The current version cannot handle this properly, e.g. load(" http://square.github.io/picasso/static/sample.png") would fail even it's a valid url.