### PR TITLE
Add gradle information to the download section

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,9 @@ Picasso.with(context).load(new File(...)).into(imageView3);</pre>
   &lt;version><span class="version pln"><em>(insert latest version)</em></span>&lt;/version>
 &lt;/dependency></pre>
 
+            <h4>Gradle</h4>
+            <pre class="prettyprint">compile 'com.squareup.picasso:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
+
             <h3 id="contributing">Contributing</h3>
             <p>If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request.</p>
             <p>When submitting code, please make every effort to follow existing conventions and style in order to keep the code as readable as possible. Please also make sure your code compiles by running <code>mvn clean verify</code>.</p>


### PR DESCRIPTION
Just noticed that there was no Gradle information in the download section of the [page](http://square.github.io/picasso/). This simply adds it.
