### PR TITLE
Added ResultCallback interface to return the result Bitmap and LoadedFrom in the callback

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Callback.java
+++ b/picasso/src/main/java/com/squareup/picasso/Callback.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.picasso;
 
+import android.graphics.Bitmap;
+
 public interface Callback {
   void onSuccess();
 
@@ -28,4 +30,25 @@ public interface Callback {
     @Override public void onError() {
     }
   }
+
+  public interface ResultCallback extends Callback {
+    /**
+     * Callback called after {@link #onSuccess()} with the requested {@link Bitmap} and the
+     * {@link Picasso.LoadedFrom} .
+     */
+    void onSuccess(Bitmap bitmap, Picasso.LoadedFrom from);
+  }
+
+  public static class EmptyResultCallback implements ResultCallback {
+
+    @Override public void onSuccess() {
+    }
+
+    @Override public void onError() {
+    }
+
+    @Override public void onSuccess(Bitmap bitmap, Picasso.LoadedFrom from) {
+    }
+  }
+
 }

--- a/picasso/src/main/java/com/squareup/picasso/FetchAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/FetchAction.java
@@ -32,6 +32,13 @@ class FetchAction extends Action<Object> {
   @Override void complete(Bitmap result, Picasso.LoadedFrom from) {
     if (callback != null) {
       callback.onSuccess();
+
+      if (callback instanceof Callback.ResultCallback) {
+        ((Callback.ResultCallback) callback).onSuccess(result, from);
+        if (result.isRecycled()) {
+          throw new IllegalStateException("Callback must not recycle bitmap!");
+        }
+      }
     }
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -49,6 +49,13 @@ class ImageViewAction extends Action<ImageView> {
 
     if (callback != null) {
       callback.onSuccess();
+
+      if (callback instanceof Callback.ResultCallback) {
+        ((Callback.ResultCallback) callback).onSuccess(result, from);
+        if (result.isRecycled()) {
+            throw new IllegalStateException("Callback must not recycle bitmap!");
+        }
+      }
     }
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -398,7 +398,8 @@ public class RequestCreator {
   /**
    * Asynchronously fulfills the request without a {@link ImageView} or {@link Target},
    * and invokes the target {@link Callback} with the result. This is useful when you want to warm
-   * up the cache with an image.
+   * up the cache with an image. You can use the target {@link Callback.ResultCallback} to retrieve
+   * the requested {@link Bitmap} and the {@link Picasso.LoadedFrom}.
    * <p>
    * <em>Note:</em> The {@link Callback} param is a strong reference and will prevent your
    * {@link android.app.Activity} or {@link android.app.Fragment} from being garbage collected
@@ -426,6 +427,13 @@ public class RequestCreator {
         }
         if (callback != null) {
           callback.onSuccess();
+
+          if (callback instanceof Callback.ResultCallback) {
+            ((Callback.ResultCallback) callback).onSuccess(bitmap, MEMORY);
+            if (bitmap.isRecycled()) {
+                throw new IllegalStateException("Callback must not recycle bitmap!");
+            }
+          }
         }
       } else {
         Action action =
@@ -598,6 +606,8 @@ public class RequestCreator {
    * {@link android.app.Activity} or {@link android.app.Fragment} from being garbage collected. If
    * you use this method, it is <b>strongly</b> recommended you invoke an adjacent
    * {@link Picasso#cancelRequest(android.widget.ImageView)} call to prevent temporary leaking.
+   * You can use the target {@link Callback.ResultCallback} to retrieve the requested
+   * {@link Bitmap} and the {@link Picasso.LoadedFrom}.
    */
   public void into(ImageView target, Callback callback) {
     long started = System.nanoTime();
@@ -644,6 +654,13 @@ public class RequestCreator {
         }
         if (callback != null) {
           callback.onSuccess();
+
+          if (callback instanceof Callback.ResultCallback) {
+            ((Callback.ResultCallback) callback).onSuccess(bitmap, MEMORY);
+            if (bitmap.isRecycled()) {
+                throw new IllegalStateException("Callback must not recycle bitmap!");
+            }
+          }
         }
         return;
       }


### PR DESCRIPTION
This callback would help to retrieve the Bitmap the user requested after an action fetch(Callback) or into(ImageView, Callback).

Sometime the user can have the necessity to use the requested Bitmap. I know he can achieve this implementing the Target callback, but he would need to create a strong reference to it, and as Jake replied to a guy somewhere here, the Target is intended to be used as an interface to be implemented by a custom view, not as a callback.

Another way to get the Bitmap would be call the method get() after the onSuccess() callback, but it looks a like workaround.

Thanks :)