### PR TITLE
Handle contact thumbnail photos with appropriate request handler.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoRequestHandler.java
@@ -54,7 +54,7 @@ class ContactsPhotoRequestHandler extends RequestHandler {
     matcher.addURI(ContactsContract.AUTHORITY, "display_photo/#", ID_DISPLAY_PHOTO);
   }
 
-  final Context context;
+  private final Context context;
 
   ContactsPhotoRequestHandler(Context context) {
     this.context = context;
@@ -64,7 +64,7 @@ class ContactsPhotoRequestHandler extends RequestHandler {
     final Uri uri = data.uri;
     return (SCHEME_CONTENT.equals(uri.getScheme())
         && ContactsContract.Contacts.CONTENT_URI.getHost().equals(uri.getHost())
-        && !uri.getPathSegments().contains(ContactsContract.Contacts.Photo.CONTENT_DIRECTORY));
+        && matcher.match(data.uri) != UriMatcher.NO_MATCH);
   }
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -46,6 +46,8 @@ import static com.squareup.picasso.TestUtils.CONTACT_KEY_1;
 import static com.squareup.picasso.TestUtils.CONTACT_URI_1;
 import static com.squareup.picasso.TestUtils.CONTENT_1_URL;
 import static com.squareup.picasso.TestUtils.CONTENT_KEY_1;
+import static com.squareup.picasso.TestUtils.CONTACT_PHOTO_KEY_1;
+import static com.squareup.picasso.TestUtils.CONTACT_PHOTO_URI_1;
 import static com.squareup.picasso.TestUtils.CUSTOM_URI;
 import static com.squareup.picasso.TestUtils.CUSTOM_URI_KEY;
 import static com.squareup.picasso.TestUtils.FILE_1_URL;
@@ -272,6 +274,13 @@ public class BitmapHunterTest {
     Action action = mockAction(CONTACT_KEY_1, CONTACT_URI_1);
     BitmapHunter hunter = forRequest(mockPicasso(new ContactsPhotoRequestHandler(context)),
         dispatcher, cache, stats, action);
+    assertThat(hunter.requestHandler).isInstanceOf(ContactsPhotoRequestHandler.class);
+  }
+
+  @Test public void forContactsThumbnailPhotoRequest() {
+    Action action = mockAction(CONTACT_PHOTO_KEY_1, CONTACT_PHOTO_URI_1);
+    BitmapHunter hunter = forRequest(mockPicasso(new ContactsPhotoRequestHandler(context)),
+      dispatcher, cache, stats, action);
     assertThat(hunter.requestHandler).isInstanceOf(ContactsPhotoRequestHandler.class);
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -66,10 +66,10 @@ class TestUtils {
       createKey(new Request.Builder(MEDIA_STORE_CONTENT_1_URL).build());
   static final Uri CONTENT_1_URL = Uri.parse("content://zip/zap/zoop.jpg");
   static final String CONTENT_KEY_1 = createKey(new Request.Builder(CONTENT_1_URL).build());
-  static final Uri CONTACT_URI_1 = CONTENT_URI.buildUpon().path("1234").build();
+  static final Uri CONTACT_URI_1 = CONTENT_URI.buildUpon().appendPath("1234").build();
   static final String CONTACT_KEY_1 = createKey(new Request.Builder(CONTACT_URI_1).build());
   static final Uri CONTACT_PHOTO_URI_1 =
-      CONTENT_URI.buildUpon().path("1234").path(CONTENT_DIRECTORY).build();
+      CONTENT_URI.buildUpon().appendPath("1234").appendPath(CONTENT_DIRECTORY).build();
   static final String CONTACT_PHOTO_KEY_1 =
       createKey(new Request.Builder(CONTACT_PHOTO_URI_1).build());
   static final int RESOURCE_ID_1 = 1;
@@ -92,7 +92,7 @@ class TestUtils {
   static final String RESOURCE_TYPE_URI_KEY =
       createKey(new Request.Builder(RESOURCE_TYPE_URI).build());
   static final Uri CUSTOM_URI = Uri.parse("foo://bar");
-  static final String CUSTOM_URI_KEY = createKey(new Request.Builder(CUSTOM_URI).build());;
+  static final String CUSTOM_URI_KEY = createKey(new Request.Builder(CUSTOM_URI).build());
 
   static Context mockPackageResourceContext() {
     Context context = mock(Context.class);


### PR DESCRIPTION
`ContactsPhotoRequestHandler` didn't handle contact thumbnail photos because of an unnecessary check. Instead the request fell back to `ContentStreamRequestHandler`. 