### PR TITLE
Fix potential Message leak

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -596,10 +596,15 @@ public class Picasso {
 
     @Override public void run() {
       Process.setThreadPriority(THREAD_PRIORITY_BACKGROUND);
+      // Don't inline message. It's important to make sure we keep no local ref.
+      Message message = null;
       while (true) {
         try {
+          // Blocking.
           RequestWeakReference<?> remove = (RequestWeakReference<?>) referenceQueue.remove();
-          handler.sendMessage(handler.obtainMessage(REQUEST_GCED, remove.action));
+          message = handler.obtainMessage(REQUEST_GCED, remove.action);
+          handler.sendMessage(message);
+          message = null;
         } catch (InterruptedException e) {
           break;
         } catch (final Exception e) {


### PR DESCRIPTION
Introduces a local variable for the Message in CleanupThread, and makes sure to clean it after sending the message.

Here's why:

* I have a heapdump that I took on Genymotion with Android 4.4.4.
* It shows that CleanupThread is keeping a reference to a Message object, long after it's been sent to the handler (and therefore recycled).
* Picasso.shutdown is false (and there's only one Picasso instance). There's also only one CleanupThread instance.
* The reference queue is empty, which means that CleanupThread is blocking on `referenceQueue.remove();`
* So I'm assuming that somehow the message got pushed in a local variable, and won't be cleared until `remove()` unblocks.

This has caused a memory leak when some other code is obtaining a message and then holding on to it (not recycling it). If such code sets `obj` on the message, `obj` will not be GCed until the next Picasso request is GCed.

Call me crazy... I have a heapdump though :) .