### PR TITLE
Fixing Message memory leaks

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
+++ b/picasso/src/main/java/com/squareup/picasso/Dispatcher.java
@@ -100,6 +100,7 @@ class Dispatcher {
       Downloader downloader, Cache cache, Stats stats) {
     this.dispatcherThread = new DispatcherThread();
     this.dispatcherThread.start();
+    Utils.flushStackLocalLeaks(dispatcherThread.getLooper());
     this.context = context;
     this.service = service;
     this.hunterMap = new LinkedHashMap<String, BitmapHunter>();

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -42,6 +42,7 @@ import static com.squareup.picasso.Dispatcher.REQUEST_GCED;
 import static com.squareup.picasso.MemoryPolicy.shouldReadFromMemoryCache;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 import static com.squareup.picasso.Utils.OWNER_MAIN;
+import static com.squareup.picasso.Utils.THREAD_LEAK_CLEANING_MS;
 import static com.squareup.picasso.Utils.THREAD_PREFIX;
 import static com.squareup.picasso.Utils.VERB_CANCELED;
 import static com.squareup.picasso.Utils.VERB_COMPLETED;
@@ -583,11 +584,16 @@ public class Picasso {
     }
   }
 
+  /**
+   * When the target of an action is weakly reachable but the request hasn't been canceled, it
+   * gets added to the reference queue. This thread empties the reference queue and cancels the
+   * request.
+   */
   private static class CleanupThread extends Thread {
-    private final ReferenceQueue<?> referenceQueue;
+    private final ReferenceQueue<Object> referenceQueue;
     private final Handler handler;
 
-    CleanupThread(ReferenceQueue<?> referenceQueue, Handler handler) {
+    CleanupThread(ReferenceQueue<Object> referenceQueue, Handler handler) {
       this.referenceQueue = referenceQueue;
       this.handler = handler;
       setDaemon(true);
@@ -598,8 +604,21 @@ public class Picasso {
       Process.setThreadPriority(THREAD_PRIORITY_BACKGROUND);
       while (true) {
         try {
-          RequestWeakReference<?> remove = (RequestWeakReference<?>) referenceQueue.remove();
-          handler.sendMessage(handler.obtainMessage(REQUEST_GCED, remove.action));
+          // Prior to Android 5.0, even when there is no local variable, the result from
+          // remove() & obtainMessage() is kept as a stack local variable.
+          // We're forcing this reference to be cleared and replaced by looping every second
+          // when there is nothing to do.
+          // This behavior has been tested and reproduced with heap dumps.
+          RequestWeakReference<?> remove =
+              (RequestWeakReference<?>) referenceQueue.remove(THREAD_LEAK_CLEANING_MS);
+          Message message = handler.obtainMessage();
+          if (remove != null) {
+            message.what = REQUEST_GCED;
+            message.obj = remove.action;
+            handler.sendMessage(message);
+          } else {
+            message.recycle();
+          }
         } catch (InterruptedException e) {
           break;
         } catch (final Exception e) {

--- a/picasso/src/main/java/com/squareup/picasso/Stats.java
+++ b/picasso/src/main/java/com/squareup/picasso/Stats.java
@@ -52,6 +52,7 @@ class Stats {
     this.cache = cache;
     this.statsThread = new HandlerThread(STATS_THREAD_NAME, THREAD_PRIORITY_BACKGROUND);
     this.statsThread.start();
+    Utils.flushStackLocalLeaks(statsThread.getLooper());
     this.handler = new StatsHandler(statsThread.getLooper(), this);
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -22,7 +22,9 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
+import android.os.Handler;
 import android.os.Looper;
+import android.os.Message;
 import android.os.Process;
 import android.os.StatFs;
 import android.provider.Settings;
@@ -55,6 +57,7 @@ final class Utils {
   private static final int KEY_PADDING = 50; // Determined by exact science.
   private static final int MIN_DISK_CACHE_SIZE = 5 * 1024 * 1024; // 5MB
   private static final int MAX_DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
+  static final int THREAD_LEAK_CLEANING_MS = 1000;
   static final char KEY_SEPARATOR = '\n';
 
   /** Thread confined to main thread for key creation. */
@@ -368,6 +371,20 @@ final class Utils {
     } catch (PackageManager.NameNotFoundException e) {
       throw new FileNotFoundException("Unable to obtain resources for package: " + data.uri);
     }
+  }
+
+  /**
+   * Prior to Android 5, HandlerThread always keeps a stack local reference to the last message
+   * that was sent to it. This method makes sure that stack local reference never stays there
+   * for too long by sending new messages to it every second.
+   */
+  static void flushStackLocalLeaks(Looper looper) {
+    Handler handler = new Handler(looper) {
+      @Override public void handleMessage(Message msg) {
+        sendMessageDelayed(obtainMessage(), THREAD_LEAK_CLEANING_MS);
+      }
+    };
+    handler.sendMessageDelayed(handler.obtainMessage(), THREAD_LEAK_CLEANING_MS);
   }
 
   @TargetApi(HONEYCOMB)


### PR DESCRIPTION
Prior to Android L, the VM caches stack local variables in blocking loops. This can lead to memory leaks of messages for threads that become inactive but aren't shutdown. This change ensure that we never leak for too long and always replace the leaking reference.

These memory leaks tend to be problematic when using Picasso in an app that also uses Dialogs, because Dialogs obtain template Message instance that are never recycled. These messages are listeners and often hold references to the activity. When the dialog is GCed, the messages should be GCed too but they aren't because of the thread stack local message leak.

![screen shot 2015-03-16 at 6 22 52 pm](https://cloud.githubusercontent.com/assets/557033/6697768/1a23632e-ccb0-11e4-840e-35917bd0ef24.png)

![screen shot 2015-03-16 at 6 23 04 pm](https://cloud.githubusercontent.com/assets/557033/6697771/1d8f4794-ccb0-11e4-88bd-1f7cf0c404e7.png)

![screen shot 2015-03-16 at 6 23 11 pm](https://cloud.githubusercontent.com/assets/557033/6697775/21206672-ccb0-11e4-8d45-b75788efa519.png)