### PR TITLE
Fixed issues w/ PicassoDrawable + transparent images

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -44,6 +44,12 @@ final class PicassoDrawable extends TransitionDrawable {
   static void setBitmap(ImageView target, Context context, Bitmap bitmap,
       Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging) {
     Drawable placeholder = target.getDrawable();
+
+    // Avoid infinite nesting of placeholders.
+    if (placeholder instanceof PicassoDrawable) {
+      placeholder = ((PicassoDrawable) placeholder).getDrawable(0);
+    }
+
     if (placeholder instanceof AnimationDrawable) {
       ((AnimationDrawable) placeholder).stop();
     }
@@ -73,6 +79,8 @@ final class PicassoDrawable extends TransitionDrawable {
       placeholder == null ? new ColorDrawable(Color.TRANSPARENT) : placeholder,
       new BitmapDrawable(context.getResources(), bitmap)
     });
+
+    setCrossFadeEnabled(true);
 
     this.debugging = debugging;
     this.density = context.getResources().getDisplayMetrics().density;


### PR DESCRIPTION
Two problems were occurring at once which would cause transparent
images to render incorrectly.

1. Recycling of ImageViews. If no placeholder was set, then Picasso
   reuses the previous drawable of the ImageView as a placeholder.
   This causes problems when the previous placeholder is a
   LayerDrawable, since the layers will just pile up.

   Theoretically this behavior might be correct, but I doubt anyone
   is interested in the performance nightmare it could present
   with lots of recycling and no explicit placeholders. Instead,
   we only use the placeholder layer of previous PicassoDrawables.

2. Lack of cross-fade. If a TransitionDrawable is not set to cross
   fade, then after it's done animating it always draws *both*
   layers, where we actually only want the 2nd layer drawn.

Addresses #936