### PR TITLE
Only use OkHttp in versions greater than Froyo

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ThreadFactory;
 import static android.content.Context.ACTIVITY_SERVICE;
 import static android.content.pm.ApplicationInfo.FLAG_LARGE_HEAP;
 import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.GINGERBREAD;
 import static android.os.Build.VERSION_CODES.HONEYCOMB;
 import static android.os.Build.VERSION_CODES.HONEYCOMB_MR1;
 import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
@@ -245,10 +246,12 @@ final class Utils {
   }
 
   static Downloader createDefaultDownloader(Context context) {
-    try {
-      Class.forName("com.squareup.okhttp.OkHttpClient");
-      return OkHttpLoaderCreator.create(context);
-    } catch (ClassNotFoundException ignored) {
+    if (SDK_INT >= GINGERBREAD) {
+        try {
+          Class.forName("com.squareup.okhttp.OkHttpClient");
+          return OkHttpLoaderCreator.create(context);
+        } catch (ClassNotFoundException ignored) {
+        }
     }
     return new UrlConnectionDownloader(context);
   }

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -20,9 +20,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static android.os.Build.VERSION_CODES.FROYO;
+import static android.os.Build.VERSION_CODES.GINGERBREAD;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_URI;
 import static com.squareup.picasso.TestUtils.RESOURCE_TYPE_URI;
@@ -115,5 +118,15 @@ public class UtilsTest {
     Resources resources = Utils.getResources(mockPackageResourceContext(), request);
     int id = Utils.getResourceId(resources, request);
     assertThat(id).isEqualTo(RESOURCE_ID_1);
+  }
+
+  @Test @Config(reportSdk=GINGERBREAD) public void useOkHttpByDefault() throws Exception {
+    Downloader downloader = Utils.createDefaultDownloader(Robolectric.application);
+    assertThat(downloader).isInstanceOf(OkHttpDownloader.class);
+  }
+
+  @Test @Config(reportSdk=FROYO) public void noOkHttpInFroyo() throws Exception {
+    Downloader downloader = Utils.createDefaultDownloader(Robolectric.application);
+    assertThat(downloader).isNotInstanceOf(OkHttpDownloader.class);
   }
 }


### PR DESCRIPTION
OkHttp doesn't support versions prior to Gingerbread, so apps that use Picasso and OkHttp crash on Froyo devices.