### PR TITLE
Added support for notification tags.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RemoteViewsAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/RemoteViewsAction.java
@@ -102,19 +102,21 @@ abstract class RemoteViewsAction extends Action<RemoteViewsAction.RemoteViewsTar
 
   static class NotificationAction extends RemoteViewsAction {
     private final int notificationId;
+    private final String notificationTag;
     private final Notification notification;
 
     NotificationAction(Picasso picasso, Request data, RemoteViews remoteViews, int viewId,
-        int notificationId, Notification notification, int memoryPolicy, int networkPolicy,
-        String key, Object tag, int errorResId) {
+        int notificationId, Notification notification, String notificationTag, int memoryPolicy,
+        int networkPolicy, String key, Object tag, int errorResId) {
       super(picasso, data, remoteViews, viewId, errorResId, memoryPolicy, networkPolicy, tag, key);
       this.notificationId = notificationId;
+      this.notificationTag = notificationTag;
       this.notification = notification;
     }
 
     @Override void update() {
       NotificationManager manager = getService(picasso.context, NOTIFICATION_SERVICE);
-      manager.notify(notificationId, notification);
+      manager.notify(notificationTag, notificationId, notification);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -534,6 +534,15 @@ public class RequestCreator {
    */
   public void into(RemoteViews remoteViews, int viewId, int notificationId,
       Notification notification) {
+    into(remoteViews, viewId, notificationId, notification, null);
+  }
+
+  /**
+   * Asynchronously fulfills the request into the specified {@link RemoteViews} object with the
+   * given {@code viewId}. This is used for loading bitmaps into a {@link Notification}.
+   */
+  public void into(RemoteViews remoteViews, int viewId, int notificationId,
+      Notification notification, String notificationTag) {
     long started = System.nanoTime();
 
     if (remoteViews == null) {
@@ -555,7 +564,7 @@ public class RequestCreator {
 
     RemoteViewsAction action =
         new NotificationAction(picasso, request, remoteViews, viewId, notificationId, notification,
-            memoryPolicy, networkPolicy, key, tag, errorResId);
+            notificationTag, memoryPolicy, networkPolicy, key, tag, errorResId);
 
     performRemoteViewInto(action);
   }


### PR DESCRIPTION
From http://developer.android.com/reference/android/app/NotificationManager.html
>Each of the notify methods takes an int id parameter and optionally a String tag parameter, which may be null. These parameters are used to form a pair (tag, id), or (null, id) if tag is unspecified. This pair identifies this notification from your app to the system, so that pair should be unique within your app.

Current Picasso API supports referring to a notification only by the notification id which means you can't find the correct notification if you're using the optional notification tags.

There is also an overloaded method without the optional tag for API backwards-compatibility.