### PR TITLE
Expose BitmapFactory.Options.inPurgeable through RequestCreator.purgeable()

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -120,10 +120,12 @@ class BitmapHunter implements Runnable {
     final boolean calculateSize = RequestHandler.requiresInSampleSize(options);
 
     boolean isWebPFile = Utils.isWebPFile(stream);
+    boolean isPurgeable = request.purgeable && android.os.Build.VERSION.SDK_INT < 21;
     markStream.reset(mark);
-    // When decode WebP network stream, BitmapFactory throw JNI Exception and make app crash.
-    // Decode byte array instead
-    if (isWebPFile) {
+    // We decode from a byte array because, a) when decoding a WebP network stream, BitmapFactory
+    // throws a JNI Exception, so we workaround by decoding a byte array, or b) user requested
+    // purgeable, which only affects bitmaps decoded from byte arrays.
+    if (isWebPFile || isPurgeable) {
       byte[] bytes = Utils.toByteArray(stream);
       if (calculateSize) {
         BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -79,6 +79,7 @@ public final class Request {
   public final float rotationPivotY;
   /** Whether or not {@link #rotationPivotX} and {@link #rotationPivotY} are set. */
   public final boolean hasRotationPivot;
+  public final boolean purgeable;
   /** Target image config for decoding. */
   public final Bitmap.Config config;
   /** The priority of this request. */
@@ -87,7 +88,7 @@ public final class Request {
   private Request(Uri uri, int resourceId, String stableKey, List<Transformation> transformations,
       int targetWidth, int targetHeight, boolean centerCrop, boolean centerInside,
       boolean onlyScaleDown, float rotationDegrees, float rotationPivotX, float rotationPivotY,
-      boolean hasRotationPivot, Bitmap.Config config, Priority priority) {
+      boolean hasRotationPivot, boolean purgeable, Bitmap.Config config, Priority priority) {
     this.uri = uri;
     this.resourceId = resourceId;
     this.stableKey = stableKey;
@@ -105,6 +106,7 @@ public final class Request {
     this.rotationPivotX = rotationPivotX;
     this.rotationPivotY = rotationPivotY;
     this.hasRotationPivot = hasRotationPivot;
+    this.purgeable = purgeable;
     this.config = config;
     this.priority = priority;
   }
@@ -201,6 +203,7 @@ public final class Request {
     private float rotationPivotX;
     private float rotationPivotY;
     private boolean hasRotationPivot;
+    private boolean purgeable;
     private List<Transformation> transformations;
     private Bitmap.Config config;
     private Priority priority;
@@ -397,6 +400,11 @@ public final class Request {
       return this;
     }
 
+    public Builder purgeable() {
+      purgeable = true;
+      return this;
+    }
+
     /** Decode the image using the specified config. */
     public Builder config(Bitmap.Config config) {
       this.config = config;
@@ -467,7 +475,7 @@ public final class Request {
       }
       return new Request(uri, resourceId, stableKey, transformations, targetWidth, targetHeight,
           centerCrop, centerInside, onlyScaleDown, rotationDegrees, rotationPivotX, rotationPivotY,
-          hasRotationPivot, config, priority);
+          hasRotationPivot, purgeable, config, priority);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -79,6 +79,7 @@ public final class Request {
   public final float rotationPivotY;
   /** Whether or not {@link #rotationPivotX} and {@link #rotationPivotY} are set. */
   public final boolean hasRotationPivot;
+  /** True if image should be decoded with inPurgeable and inInputShareable. */
   public final boolean purgeable;
   /** Target image config for decoding. */
   public final Bitmap.Config config;
@@ -141,6 +142,9 @@ public final class Request {
         sb.append(" @ ").append(rotationPivotX).append(',').append(rotationPivotY);
       }
       sb.append(')');
+    }
+    if (purgeable) {
+      sb.append(" purgeable");
     }
     if (config != null) {
       sb.append(' ').append(config);
@@ -236,6 +240,7 @@ public final class Request {
       rotationPivotX = request.rotationPivotX;
       rotationPivotY = request.rotationPivotY;
       hasRotationPivot = request.hasRotationPivot;
+      purgeable = request.purgeable;
       onlyScaleDown = request.onlyScaleDown;
       if (request.transformations != null) {
         transformations = new ArrayList<Transformation>(request.transformations);

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -366,6 +366,17 @@ public class RequestCreator {
     return this;
   }
 
+  /** Set inPurgeable and inInputShareable when decoding. This will force the bitmap to be decoded
+   * from a byte array instead of a stream, since inPurgeable only affects the former.
+   * <p>
+   * <em>Note</em>: as of API level 21 (Lollipop), the inPurgeable field is deprecated and will be
+   * ignored.
+   */
+  public RequestCreator purgeable() {
+    data.purgeable();
+    return this;
+  }
+
   /** Disable brief fade in of images loaded from the disk cache or network. */
   public RequestCreator noFade() {
     noFade = true;

--- a/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
@@ -132,9 +132,11 @@ public abstract class RequestHandler {
     final boolean justBounds = data.hasSize();
     final boolean hasConfig = data.config != null;
     BitmapFactory.Options options = null;
-    if (justBounds || hasConfig) {
+    if (justBounds || hasConfig || data.purgeable) {
       options = new BitmapFactory.Options();
       options.inJustDecodeBounds = justBounds;
+      options.inInputShareable = data.purgeable;
+      options.inPurgeable = data.purgeable;
       if (hasConfig) {
         options.inPreferredConfig = data.config;
       }

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -843,4 +843,16 @@ public class RequestCreatorTest {
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
     assertThat(actionCaptor.getValue().getKey()).isEqualTo(URI_KEY_1);
   }
+
+  @Test public void notPurgeable() {
+    new RequestCreator(picasso, URI_1, 0).into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getRequest().purgeable).isFalse();
+  }
+
+  @Test public void purgeable() {
+    new RequestCreator(picasso, URI_1, 0).purgeable().into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getRequest().purgeable).isTrue();
+  }
 }

--- a/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
@@ -87,7 +87,7 @@ public class RequestHandlerTest {
     assertThat(options.inSampleSize).isEqualTo(2);
   }
 
-  @Test public void nullBitmapOptionsIfNoResizing() {
+  @Test public void nullBitmapOptionsIfNoResizingOrPurgeable() {
     // No resize must return no bitmap options
     final Request noResize = new Request.Builder(URI_1).build();
     final BitmapFactory.Options noResizeOptions = createBitmapOptions(noResize);
@@ -100,13 +100,26 @@ public class RequestHandlerTest {
     final BitmapFactory.Options resizeOptions = createBitmapOptions(requiresResize);
     assertThat(resizeOptions).isNotNull();
     assertThat(resizeOptions.inJustDecodeBounds).isTrue();
+    assertThat(resizeOptions.inPurgeable).isFalse();
+    assertThat(resizeOptions.inInputShareable).isFalse();
   }
 
-  @Test public void createWithConfigAndNotInJustDecodeBounds() {
-    // Given a config must return bitmap options and false inJustDecodeBounds
+  @Test public void inPurgeableIfInPurgeable() {
+    final Request request = new Request.Builder(URI_1).purgeable().build();
+    final BitmapFactory.Options options = createBitmapOptions(request);
+    assertThat(options).isNotNull();
+    assertThat(options.inPurgeable).isTrue();
+    assertThat(options.inInputShareable).isTrue();
+    assertThat(options.inJustDecodeBounds).isFalse();
+  }
+
+  @Test public void createWithConfigAndNotInJustDecodeBoundsOrInPurgeable() {
+    // Given a config, must return bitmap options and false inJustDecodeBounds/inPurgeable
     final Request config = new Request.Builder(URI_1).config(RGB_565).build();
     final BitmapFactory.Options configOptions = createBitmapOptions(config);
     assertThat(configOptions).isNotNull();
     assertThat(configOptions.inJustDecodeBounds).isFalse();
+    assertThat(configOptions.inPurgeable).isFalse();
+    assertThat(configOptions.inInputShareable).isFalse();
   }
 }


### PR DESCRIPTION
When purgeable() is called, we set inPurgeable and inInputShareable to true. We
also decode the bitmap from a byte array instead of a stream, because
inPurgeable only affects the fomer (we only do this for API level <21 because
inPurgeable has no effect for API level 21+).