### PR TITLE
Change picasso to accept multiple RequestTransformers registartion

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -85,13 +85,6 @@ public class Picasso {
      * @return The original request or a new request to replace it. Must not be null.
      */
     Request transformRequest(Request request);
-
-    /** A {@link RequestTransformer} which returns the original request. */
-    RequestTransformer IDENTITY = new RequestTransformer() {
-      @Override public Request transformRequest(Request request) {
-        return request;
-      }
-    };
   }
 
   /**
@@ -143,9 +136,9 @@ public class Picasso {
   static volatile Picasso singleton = null;
 
   private final Listener listener;
-  private final RequestTransformer requestTransformer;
   private final CleanupThread cleanupThread;
   private final List<RequestHandler> requestHandlers;
+  private final List<RequestTransformer> requestTransformers;
 
   final Context context;
   final Dispatcher dispatcher;
@@ -162,13 +155,18 @@ public class Picasso {
   boolean shutdown;
 
   Picasso(Context context, Dispatcher dispatcher, Cache cache, Listener listener,
-      RequestTransformer requestTransformer, List<RequestHandler> extraRequestHandlers, Stats stats,
-      Bitmap.Config defaultBitmapConfig, boolean indicatorsEnabled, boolean loggingEnabled) {
+      List<RequestTransformer> requestTransformers, List<RequestHandler> extraRequestHandlers,
+      Stats stats, Bitmap.Config defaultBitmapConfig, boolean indicatorsEnabled,
+      boolean loggingEnabled) {
     this.context = context;
     this.dispatcher = dispatcher;
     this.cache = cache;
     this.listener = listener;
-    this.requestTransformer = requestTransformer;
+    if (requestTransformers == null) {
+      this.requestTransformers = Collections.emptyList();
+    } else {
+      this.requestTransformers = Collections.unmodifiableList(requestTransformers);
+    }
     this.defaultBitmapConfig = defaultBitmapConfig;
 
     int builtInHandlers = 7; // Adjust this as internal handlers are added or removed.
@@ -452,14 +450,17 @@ public class Picasso {
   }
 
   Request transformRequest(Request request) {
-    Request transformed = requestTransformer.transformRequest(request);
-    if (transformed == null) {
-      throw new IllegalStateException("Request transformer "
-          + requestTransformer.getClass().getCanonicalName()
-          + " returned null for "
-          + request);
+    for (RequestTransformer transformer : requestTransformers) {
+      Request transformed = transformer.transformRequest(request);
+      if (transformed == null) {
+        throw new IllegalStateException("Request transformer "
+            + transformer.getClass().getCanonicalName()
+            + " returned null for "
+            + request);
+      }
+      request = transformed;
     }
-    return transformed;
+    return request;
   }
 
   void defer(ImageView view, DeferredRequestCreator request) {
@@ -688,7 +689,7 @@ public class Picasso {
     private ExecutorService service;
     private Cache cache;
     private Listener listener;
-    private RequestTransformer transformer;
+    private List<RequestTransformer> transformers;
     private List<RequestHandler> requestHandlers;
     private Bitmap.Config defaultBitmapConfig;
 
@@ -777,10 +778,30 @@ public class Picasso {
       if (transformer == null) {
         throw new IllegalArgumentException("Transformer must not be null.");
       }
-      if (this.transformer != null) {
+      if (this.transformers != null) {
         throw new IllegalStateException("Transformer already set.");
       }
-      this.transformer = transformer;
+      return addRequestTransformer(transformer);
+    }
+
+    /**
+     * Register a {@link RequestTransformer}. If you register multiple transformers, they are
+     * applied in order of registration.
+     * <p>
+     * <b>NOTE:</b> This is a beta feature. The API is subject to change in a backwards incompatible
+     * way at any time.
+     */
+    public Builder addRequestTransformer(RequestTransformer transformer) {
+      if (transformer == null) {
+        throw new IllegalArgumentException("Transformer must not be null.");
+      }
+      if (this.transformers == null) {
+        transformers = new ArrayList<RequestTransformer>();
+      }
+      if (transformers.contains(transformer)) {
+        throw new IllegalStateException("RequestTransformer already registered.");
+      }
+      transformers.add(transformer);
       return this;
     }
 
@@ -837,15 +858,15 @@ public class Picasso {
       if (service == null) {
         service = new PicassoExecutorService();
       }
-      if (transformer == null) {
-        transformer = RequestTransformer.IDENTITY;
+      if (transformers == null) {
+        transformers = Collections.emptyList();
       }
 
       Stats stats = new Stats(cache);
 
       Dispatcher dispatcher = new Dispatcher(context, service, HANDLER, downloader, cache, stats);
 
-      return new Picasso(context, dispatcher, cache, listener, transformer, requestHandlers, stats,
+      return new Picasso(context, dispatcher, cache, listener, transformers, requestHandlers, stats,
           defaultBitmapConfig, indicatorsEnabled, loggingEnabled);
     }
   }

--- a/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
@@ -18,6 +18,7 @@ package com.squareup.picasso;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.widget.ImageView;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -25,7 +26,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
-import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.makeBitmap;
@@ -82,7 +82,7 @@ public class ImageViewActionTest {
   public void invokesTargetAndCallbackSuccessIfTargetIsNotNull() throws Exception {
     Bitmap bitmap = makeBitmap();
     Picasso picasso =
-        new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
+        new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, null,
             null, mock(Stats.class), Bitmap.Config.ARGB_8888, false, false);
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();

--- a/picasso/src/test/java/com/squareup/picasso/RemoteViewsActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RemoteViewsActionTest.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.graphics.Bitmap;
 import android.widget.RemoteViews;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,7 +27,6 @@ import org.robolectric.annotation.Config;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.picasso.Picasso.LoadedFrom.NETWORK;
-import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.makeBitmap;
 import static org.mockito.Mockito.mock;
@@ -77,7 +77,7 @@ public class RemoteViewsActionTest {
 
   private Picasso createPicasso() {
     return new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null,
-        IDENTITY, null, mock(Stats.class), ARGB_8888, false, false);
+        null, null, mock(Stats.class), ARGB_8888, false, false);
   }
 
   static class TestableRemoteViewsAction extends RemoteViewsAction {

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -20,10 +20,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,12 +31,16 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 import static com.squareup.picasso.Picasso.Priority.HIGH;
 import static com.squareup.picasso.Picasso.Priority.LOW;
 import static com.squareup.picasso.Picasso.Priority.NORMAL;
-import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.RemoteViewsAction.AppWidgetAction;
 import static com.squareup.picasso.RemoteViewsAction.NotificationAction;
 import static com.squareup.picasso.TestUtils.STABLE_1;
@@ -264,7 +265,7 @@ public class RequestCreatorTest {
   public void intoImageViewWithQuickMemoryCacheCheckDoesNotSubmit() {
     Picasso picasso =
         spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null,
-            IDENTITY, null, mock(Stats.class), ARGB_8888, false, false));
+            null, null, mock(Stats.class), ARGB_8888, false, false));
     doReturn(bitmap).when(picasso).quickMemoryCacheCheck(URI_KEY_1);
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
@@ -279,7 +280,7 @@ public class RequestCreatorTest {
   public void intoImageViewSetsPlaceholderDrawable() {
     Picasso picasso =
         spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null,
-            IDENTITY, null, mock(Stats.class), ARGB_8888, false, false));
+            null, null, mock(Stats.class), ARGB_8888, false, false));
     ImageView target = mockImageViewTarget();
     Drawable placeHolderDrawable = mock(Drawable.class);
     new RequestCreator(picasso, URI_1, 0).placeholder(placeHolderDrawable).into(target);
@@ -291,7 +292,7 @@ public class RequestCreatorTest {
   @Test
   public void intoImageViewNoPlaceholderDrawable() {
     Picasso picasso =
-        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
+        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, null,
             null, mock(Stats.class), ARGB_8888, false, false));
     ImageView target = mockImageViewTarget();
     new RequestCreator(picasso, URI_1, 0).noPlaceholder().into(target);
@@ -303,7 +304,7 @@ public class RequestCreatorTest {
   @Test
   public void intoImageViewSetsPlaceholderWithResourceId() {
     Picasso picasso =
-        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, IDENTITY,
+        spy(new Picasso(Robolectric.application, mock(Dispatcher.class), Cache.NONE, null, null,
             null, mock(Stats.class), ARGB_8888, false, false));
     ImageView target = mockImageViewTarget();
     new RequestCreator(picasso, URI_1, 0).placeholder(android.R.drawable.picture_frame).into(target);

--- a/picasso/src/test/java/com/squareup/picasso/TargetActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/TargetActionTest.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -26,7 +27,6 @@ import org.robolectric.annotation.Config;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
-import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.makeBitmap;
@@ -74,7 +74,7 @@ public class TargetActionTest {
     Target target = mockTarget();
     Context context = mock(Context.class);
     Picasso picasso =
-        new Picasso(context, mock(Dispatcher.class), Cache.NONE, null, IDENTITY, null,
+        new Picasso(context, mock(Dispatcher.class), Cache.NONE, null, null, null,
             mock(Stats.class), ARGB_8888, false, false);
     Resources res = mock(Resources.class);
     TargetAction request =

--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -25,12 +25,14 @@ import android.net.Uri;
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import static android.content.ContentResolver.SCHEME_ANDROID_RESOURCE;
 import static android.graphics.Bitmap.Config.ARGB_8888;
@@ -53,6 +55,7 @@ class TestUtils {
   };
   static final Uri URI_1 = Uri.parse("http://example.com/1.png");
   static final Uri URI_2 = Uri.parse("http://example.com/2.png");
+  static final Uri URI_3 = Uri.parse("http://example.com/3.png");
   static final String STABLE_1 = "stableExampleKey1";
   static final String URI_KEY_1 = createKey(new Request.Builder(URI_1).build());
   static final String URI_KEY_2 = createKey(new Request.Builder(URI_2).build());


### PR DESCRIPTION
Keep existing method Picasso.Builder#requestTransformer for backword compatibility, add Picasso.Builder#addRequestTransformer for registering potentially multiple RequestTransformer.

User of library may fetch images from multiple sources and hence have multiple rewrite rules to apply. This PR allows library users to have multiple RequestTransformers with a single responsibility for each.
