### PR TITLE
Fetch respects MemoryPolicy.NO_CACHE

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -429,20 +429,23 @@ public class RequestCreator {
 
       Request request = createRequest(started);
       String key = createKey(request, new StringBuilder());
-      Bitmap bitmap = picasso.quickMemoryCacheCheck(key);
 
-      if (bitmap != null) {
-        if (picasso.loggingEnabled) {
-          log(OWNER_MAIN, VERB_COMPLETED, request.plainId(), "from " + MEMORY);
+      if (shouldReadFromMemoryCache(memoryPolicy)) {
+        Bitmap bitmap = picasso.quickMemoryCacheCheck(key);
+        if (bitmap != null) {
+          if (picasso.loggingEnabled) {
+            log(OWNER_MAIN, VERB_COMPLETED, request.plainId(), "from " + MEMORY);
+          }
+          if (callback != null) {
+            callback.onSuccess();
+          }
+          return;
         }
-        if (callback != null) {
-          callback.onSuccess();
-        }
-      } else {
-        Action action =
-            new FetchAction(picasso, request, memoryPolicy, networkPolicy, tag, key, callback);
-        picasso.submit(action);
       }
+
+      Action action =
+          new FetchAction(picasso, request, memoryPolicy, networkPolicy, tag, key, callback);
+      picasso.submit(action);
     }
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -152,13 +152,12 @@ public class RequestCreatorTest {
   @Test public void fetchWithCache() {
     when(picasso.quickMemoryCacheCheck(URI_KEY_1)).thenReturn(bitmap);
     new RequestCreator(picasso, URI_1, 0).memoryPolicy(MemoryPolicy.NO_CACHE).fetch();
-    verify(picasso).submit(actionCaptor.capture());
     verify(picasso, never()).enqueueAndSubmit(any(Action.class));
   }
 
   @Test public void fetchWithMemoryPolicyNoCache() {
-    when(picasso.quickMemoryCacheCheck(URI_KEY_1)).thenReturn(bitmap);
     new RequestCreator(picasso, URI_1, 0).memoryPolicy(MemoryPolicy.NO_CACHE).fetch();
+    verify(picasso, never()).quickMemoryCacheCheck(URI_KEY_1);
     verify(picasso).submit(actionCaptor.capture());
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -149,6 +149,19 @@ public class RequestCreatorTest {
     assertThat(actionCaptor.getValue().getPriority()).isEqualTo(HIGH);
   }
 
+  @Test public void fetchWithCache() {
+    when(picasso.quickMemoryCacheCheck(URI_KEY_1)).thenReturn(bitmap);
+    new RequestCreator(picasso, URI_1, 0).memoryPolicy(MemoryPolicy.NO_CACHE).fetch();
+    verify(picasso).submit(actionCaptor.capture());
+    verify(picasso, never()).enqueueAndSubmit(any(Action.class));
+  }
+
+  @Test public void fetchWithMemoryPolicyNoCache() {
+    when(picasso.quickMemoryCacheCheck(URI_KEY_1)).thenReturn(bitmap);
+    new RequestCreator(picasso, URI_1, 0).memoryPolicy(MemoryPolicy.NO_CACHE).fetch();
+    verify(picasso).submit(actionCaptor.capture());
+  }
+
   @Test
   public void intoTargetWithNullThrows() {
     try {


### PR DESCRIPTION
Small fix to make sure fetch respects MemoryPolicy.NO_CACHE. Useful for forcing a refresh on a cached image.