### PR TITLE
Add two failing resize center crop tests

### DIFF
--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -461,6 +461,48 @@ public class BitmapHunterTest {
     assertThat(transformedHeight).isEqualTo(642);
   }
 
+  @Test public void centerCropResultMatchesTargetSizeWhileDesiredWidthIs0() {
+    Request request = new Request.Builder(URI_1).resize(0, 642).centerCrop().build();
+    Bitmap source = Bitmap.createBitmap(640, 640, ARGB_8888);
+
+    Bitmap result = transformResult(request, source, 0);
+
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    String scalePreOperation = shadowMatrix.getPreOperations().get(0);
+
+    assertThat(scalePreOperation).startsWith("scale ");
+    float scaleX = Float.valueOf(scalePreOperation.split(" ")[1]);
+    float scaleY = Float.valueOf(scalePreOperation.split(" ")[2]);
+
+    int transformedWidth = Math.round(result.getWidth() * scaleX);
+    int transformedHeight = Math.round(result.getHeight() * scaleY);
+    assertThat(transformedWidth).isEqualTo(642);
+    assertThat(transformedHeight).isEqualTo(642);
+  }
+
+  @Test public void centerCropResultMatchesTargetSizeWhileDesiredHeightIs0() {
+    Request request = new Request.Builder(URI_1).resize(1080, 0).centerCrop().build();
+    Bitmap source = Bitmap.createBitmap(640, 640, ARGB_8888);
+
+    Bitmap result = transformResult(request, source, 0);
+
+    ShadowBitmap shadowBitmap = shadowOf(result);
+    Matrix matrix = shadowBitmap.getCreatedFromMatrix();
+    ShadowMatrix shadowMatrix = shadowOf(matrix);
+    String scalePreOperation = shadowMatrix.getPreOperations().get(0);
+
+    assertThat(scalePreOperation).startsWith("scale ");
+    float scaleX = Float.valueOf(scalePreOperation.split(" ")[1]);
+    float scaleY = Float.valueOf(scalePreOperation.split(" ")[2]);
+
+    int transformedWidth = Math.round(result.getWidth() * scaleX);
+    int transformedHeight = Math.round(result.getHeight() * scaleY);
+    assertThat(transformedWidth).isEqualTo(1080);
+    assertThat(transformedHeight).isEqualTo(1080);
+  }
+
   @Test public void exifRotationWithManualRotation() {
     Bitmap source = Bitmap.createBitmap(10, 10, ARGB_8888);
     Request data = new Request.Builder(URI_1).rotate(-45).build();


### PR DESCRIPTION
Demonstrates a bitmap transformation failure when either requested target width or height are set to 0, related to #995 and #989.

When BitmapHunder is [transforming](https://github.com/square/picasso/blob/master/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java#L530) a result one of the matrix scale parameters gets set to NaN. I am not sure how to fix it myself but maybe these failing tests will help you ;]