### PR TITLE
Added dynamic limit option to MarkableInputStream

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -121,8 +121,8 @@ class BitmapHunter implements Runnable {
   static Bitmap decodeStream(InputStream stream, Request request) throws IOException {
     MarkableInputStream markStream = new MarkableInputStream(stream);
     stream = markStream;
-
-    long mark = markStream.savePosition(65536); // TODO fix this crap.
+    markStream.allowMarksToExpire(false);
+    long mark = markStream.savePosition(1024);
 
     final BitmapFactory.Options options = RequestHandler.createBitmapOptions(request);
     final boolean calculateSize = RequestHandler.requiresInSampleSize(options);
@@ -146,9 +146,9 @@ class BitmapHunter implements Runnable {
         BitmapFactory.decodeStream(stream, null, options);
         RequestHandler.calculateInSampleSize(request.targetWidth, request.targetHeight, options,
             request);
-
         markStream.reset(mark);
       }
+      markStream.allowMarksToExpire(true);
       Bitmap bitmap = BitmapFactory.decodeStream(stream, null, options);
       if (bitmap == null) {
         // Treat null as an IO exception, we will eventually retry.

--- a/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
+++ b/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
@@ -26,23 +26,30 @@ import java.io.InputStream;
  */
 final class MarkableInputStream extends InputStream {
   private static final int DEFAULT_BUFFER_SIZE = 4096;
-
+  private static final int DEFAULT_LIMIT_INCREMENT = 1024;
   private final InputStream in;
 
   private long offset;
   private long reset;
   private long limit;
   private long defaultMark = -1;
+  private boolean allowExpire = true;
+  private int limitIncrement = -1;
 
   public MarkableInputStream(InputStream in) {
     this(in, DEFAULT_BUFFER_SIZE);
   }
 
   public MarkableInputStream(InputStream in, int size) {
+    this(in, size, DEFAULT_LIMIT_INCREMENT);
+  }
+
+  private MarkableInputStream(InputStream in, int size, int limitIncrement) {
     if (!in.markSupported()) {
       in = new BufferedInputStream(in, size);
     }
     this.in = in;
+    this.limitIncrement = limitIncrement;
   }
 
   /** Marks this place in the stream so we can reset back to it later. */
@@ -64,6 +71,9 @@ final class MarkableInputStream extends InputStream {
     return offset;
   }
 
+  public void allowMarksToExpire(boolean allowExpire) {
+      this.allowExpire = allowExpire;
+  }
   /**
    * Makes sure that the underlying stream can backtrack the full range from
    * {@code reset} thru {@code limit}. Since we can't call {@code mark()}
@@ -119,6 +129,9 @@ final class MarkableInputStream extends InputStream {
   }
 
   @Override public int read() throws IOException {
+    if (!allowExpire && (offset + 1 > limit)) {
+      setLimit(limit + limitIncrement);
+    }
     int result = in.read();
     if (result != -1) {
       offset++;
@@ -127,6 +140,9 @@ final class MarkableInputStream extends InputStream {
   }
 
   @Override public int read(byte[] buffer) throws IOException {
+    if (!allowExpire && (offset + buffer.length > limit)) {
+      setLimit(offset + buffer.length + limitIncrement);
+    }
     int count = in.read(buffer);
     if (count != -1) {
       offset += count;
@@ -135,6 +151,9 @@ final class MarkableInputStream extends InputStream {
   }
 
   @Override public int read(byte[] buffer, int offset, int length) throws IOException {
+    if (!allowExpire && (offset + length > limit)) {
+      setLimit(offset + length + limitIncrement);
+    }
     int count = in.read(buffer, offset, length);
     if (count != -1) {
       this.offset += count;
@@ -143,6 +162,9 @@ final class MarkableInputStream extends InputStream {
   }
 
   @Override public long skip(long byteCount) throws IOException {
+    if (!allowExpire && (offset + byteCount > limit)) {
+      setLimit(offset + byteCount + limitIncrement);
+    }
     long skipped = in.skip(byteCount);
     offset += skipped;
     return skipped;

--- a/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
+++ b/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
@@ -151,8 +151,8 @@ final class MarkableInputStream extends InputStream {
   }
 
   @Override public int read(byte[] buffer, int offset, int length) throws IOException {
-    if (!allowExpire && (offset + length > limit)) {
-      setLimit(offset + length + limitIncrement);
+    if (!allowExpire && (this.offset + length > limit)) {
+      setLimit(this.offset + length + limitIncrement);
     }
     int count = in.read(buffer, offset, length);
     if (count != -1) {

--- a/picasso/src/test/java/com/squareup/picasso/MarkableInputStreamTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/MarkableInputStreamTest.java
@@ -25,7 +25,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public class MarkableInputStreamTest {
-  @Test
+@Test
   public void test() throws Exception {
     MarkableInputStream in = new MarkableInputStream(new ByteArrayInputStream(
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(Charset.forName("US-ASCII"))));
@@ -50,6 +50,30 @@ public class MarkableInputStreamTest {
       fail();
     } catch (IOException expected) {
     }
+  }
+
+  @Test
+  public void exceedLimitTest() throws Exception {
+    MarkableInputStream in = new MarkableInputStream(new ByteArrayInputStream(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ".getBytes(Charset.forName("US-ASCII"))));
+    in.allowMarksToExpire(false);
+    assertThat(readBytes(in, 3)).isEqualTo("ABC");
+    long posA = in.savePosition(7);// DEFGHIJ
+    assertThat(readBytes(in, 4)).isEqualTo("DEFG");
+    in.mark(5); // HIJKL
+    assertThat(readBytes(in, 4)).isEqualTo("HIJK");
+    in.reset(); // Back to 'H'
+    assertThat(readBytes(in, 3)).isEqualTo("HIJ");
+    in.reset(posA); // Back to 'D'
+    assertThat(readBytes(in, 7)).isEqualTo("DEFGHIJ");
+    in.reset(); // Back to 'H' again.
+    assertThat(readBytes(in, 6)).isEqualTo("HIJKLM");
+    
+    in.reset(); // Back to 'H' again despite the original limit being exceeded
+    assertThat(readBytes(in, 2)).isEqualTo("HI"); // confirm we're really back at H
+
+    in.reset(posA); // Back to 'D' again despite the original limit being exceeded
+    assertThat(readBytes(in, 2)).isEqualTo("DE"); // confirm that we're really back at D  
   }
 
   private String readBytes(InputStream in, int count) throws IOException {


### PR DESCRIPTION
A fix for the problem encountered in issues #364, #465, #626, #686, #881, #907 and #965. The approach I took was to automatically increase the read limit if a read from the stream would exceed the current limit.