### PR TITLE
When center cropping, add a top crop option for portrait bitmaps.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -577,13 +577,16 @@ class BitmapHunter implements Runnable {
         float heightRatio =
             targetHeight != 0 ? targetHeight / (float) inHeight : targetWidth / (float) inWidth;
         float scaleX, scaleY;
+        boolean shouldTopCrop = data.topCropPortrait && (inHeight > inWidth);
         if (widthRatio > heightRatio) {
+          // Need to scale and some vertical portions will not be visible
           int newSize = (int) Math.ceil(inHeight * (heightRatio / widthRatio));
-          drawY = (inHeight - newSize) / 2;
+          drawY = shouldTopCrop ? 0 : (inHeight - newSize) / 2;
           drawHeight = newSize;
           scaleX = widthRatio;
           scaleY = targetHeight / (float) drawHeight;
         } else if (widthRatio < heightRatio) {
+          // Need to scale and some horizontal portions will not be visible
           int newSize = (int) Math.ceil(inWidth * (widthRatio / heightRatio));
           drawX = (inWidth - newSize) / 2;
           drawWidth = newSize;

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -65,6 +65,14 @@ public final class Request {
    */
   public final boolean centerCrop;
   /**
+   * This is an alternate cropping treatment applied if the image is a portrait image and would be
+   * center cropped vertically. Instead of cutting an equal amount off the top and bottom, the top
+   * of the image would be preserved and only excess along the bottom would be hidden.
+   * <p>
+   * This is ignored if {@link #centerCrop} is not also selected.
+   */
+  public final boolean topCropPortrait;
+  /**
    * True if the final image should use the 'centerInside' scale technique.
    * <p>
    * This is mutually exclusive with {@link #centerCrop}.
@@ -87,7 +95,7 @@ public final class Request {
   public final Priority priority;
 
   private Request(Uri uri, int resourceId, String stableKey, List<Transformation> transformations,
-      int targetWidth, int targetHeight, boolean centerCrop, boolean centerInside,
+      int targetWidth, int targetHeight, boolean centerCrop, boolean topCropPortrait, boolean centerInside,
       boolean onlyScaleDown, float rotationDegrees, float rotationPivotX, float rotationPivotY,
       boolean hasRotationPivot, boolean purgeable, Bitmap.Config config, Priority priority) {
     this.uri = uri;
@@ -101,6 +109,7 @@ public final class Request {
     this.targetWidth = targetWidth;
     this.targetHeight = targetHeight;
     this.centerCrop = centerCrop;
+    this.topCropPortrait = topCropPortrait;
     this.centerInside = centerInside;
     this.onlyScaleDown = onlyScaleDown;
     this.rotationDegrees = rotationDegrees;
@@ -132,6 +141,9 @@ public final class Request {
     }
     if (centerCrop) {
       sb.append(" centerCrop");
+    }
+    if (topCropPortrait) {
+      sb.append(" topCropPortrait");
     }
     if (centerInside) {
       sb.append(" centerInside");
@@ -201,6 +213,7 @@ public final class Request {
     private int targetWidth;
     private int targetHeight;
     private boolean centerCrop;
+    private boolean topCropPortrait;
     private boolean centerInside;
     private boolean onlyScaleDown;
     private float rotationDegrees;
@@ -235,6 +248,7 @@ public final class Request {
       targetWidth = request.targetWidth;
       targetHeight = request.targetHeight;
       centerCrop = request.centerCrop;
+      topCropPortrait = request.topCropPortrait;
       centerInside = request.centerInside;
       rotationDegrees = request.rotationDegrees;
       rotationPivotX = request.rotationPivotX;
@@ -322,6 +336,7 @@ public final class Request {
       targetWidth = 0;
       targetHeight = 0;
       centerCrop = false;
+      topCropPortrait = false;
       centerInside = false;
       return this;
     }
@@ -342,6 +357,22 @@ public final class Request {
     /** Clear the center crop transformation flag, if set. */
     public Builder clearCenterCrop() {
       centerCrop = false;
+      return this;
+    }
+
+    /**
+     * This adds an alternative treatment for a center crop when the image to be cropped has a portrait
+     * aspect ratio and would have vertical space trimmed. Instead of trimming equally at the top and
+     * bottom, instead 2x the amount is trimmed at the bottom to preserve the top part of the picture.
+     */
+    public Builder topCropPortrait() {
+      topCropPortrait = true;
+      return this;
+    }
+
+    /** Clear the top crop portrait transformation flag, if set. */
+    public Builder clearTopCropPortrait() {
+      topCropPortrait = false;
       return this;
     }
 
@@ -479,7 +510,7 @@ public final class Request {
         priority = Priority.NORMAL;
       }
       return new Request(uri, resourceId, stableKey, transformations, targetWidth, targetHeight,
-          centerCrop, centerInside, onlyScaleDown, rotationDegrees, rotationPivotX, rotationPivotY,
+          centerCrop, topCropPortrait, centerInside, onlyScaleDown, rotationDegrees, rotationPivotX, rotationPivotY,
           hasRotationPivot, purgeable, config, priority);
     }
   }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -23,10 +23,12 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
+
+import org.jetbrains.annotations.TestOnly;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.jetbrains.annotations.TestOnly;
 
 import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.MemoryPolicy.NO_CACHE;
@@ -238,6 +240,16 @@ public class RequestCreator {
    */
   public RequestCreator centerCrop() {
     data.centerCrop();
+    return this;
+  }
+
+  /**
+   * This adds an alternative treatment for a center crop when the image to be cropped has a portrait
+   * aspect ratio and would have vertical space trimmed. Instead of trimming equally at the top and
+   * bottom, instead 2x the amount is trimmed at the bottom to preserve the top part of the picture.
+   */
+  public RequestCreator topCropPortrait() {
+    data.topCropPortrait();
     return this;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -203,6 +203,9 @@ final class Utils {
     }
     if (data.centerCrop) {
       builder.append("centerCrop").append(KEY_SEPARATOR);
+      if (data.topCropPortrait) {
+        builder.append("topCropPortrait").append(KEY_SEPARATOR);
+      }
     } else if (data.centerInside) {
       builder.append("centerInside").append(KEY_SEPARATOR);
     }


### PR DESCRIPTION
This request is something that initially I thought was a small/irrelevant request but has come up multiple times. When cropping bitmaps, various people have requested the ability to crop focusing on the top for portrait images rather than focusing on the center in order to reduce the risk of a head or face being cut off.

The actual code is super simple, but making it fit cleanly into existing options is less obvious. It seemed better to treat this as an extension to center crop because the behavior is basically the exact same but with one line changed to set drawY to 0 instead of splitting the offset in some cases.

If there is a better way for this to fit in, please feel free to call it out and I'll adjust the PR.