### PR TITLE
Added support for generic interface Animatable in placeholder drawables

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -17,7 +17,7 @@ package com.squareup.picasso;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.drawable.AnimationDrawable;
+import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.widget.ImageView;
 
@@ -59,8 +59,8 @@ class ImageViewAction extends Action<ImageView> {
       return;
     }
     Drawable placeholder = target.getDrawable();
-    if (placeholder instanceof AnimationDrawable) {
-      ((AnimationDrawable) placeholder).stop();
+    if (placeholder instanceof Animatable) {
+      ((Animatable) placeholder).stop();
     }
     if (errorResId != 0) {
       target.setImageResource(errorResId);

--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -23,7 +23,7 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.graphics.Point;
 import android.graphics.Rect;
-import android.graphics.drawable.AnimationDrawable;
+import android.graphics.drawable.Animatable;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -45,8 +45,8 @@ final class PicassoDrawable extends BitmapDrawable {
   static void setBitmap(ImageView target, Context context, Bitmap bitmap,
       Picasso.LoadedFrom loadedFrom, boolean noFade, boolean debugging) {
     Drawable placeholder = target.getDrawable();
-    if (placeholder instanceof AnimationDrawable) {
-      ((AnimationDrawable) placeholder).stop();
+    if (placeholder instanceof Animatable) {
+      ((Animatable) placeholder).stop();
     }
     PicassoDrawable drawable =
         new PicassoDrawable(context, bitmap, placeholder, loadedFrom, noFade, debugging);
@@ -59,8 +59,8 @@ final class PicassoDrawable extends BitmapDrawable {
    */
   static void setPlaceholder(ImageView target, Drawable placeholderDrawable) {
     target.setImageDrawable(placeholderDrawable);
-    if (target.getDrawable() instanceof AnimationDrawable) {
-      ((AnimationDrawable) target.getDrawable()).start();
+    if (target.getDrawable() instanceof Animatable) {
+      ((Animatable) target.getDrawable()).start();
     }
   }
 


### PR DESCRIPTION
For better support animated drawables, like AnimatedVectorDrawable and AnimationDrawable use generic interface [Animatable](http://developer.android.com/reference/android/graphics/drawable/Animatable.html). Cos AnimatedVectorDrawable is not subclass of AnimationDrawable therefore animation not start when that set as a placeholder
