### PR TITLE
shouldResize with zero target

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -634,7 +634,7 @@ class BitmapHunter implements Runnable {
 
   private static boolean shouldResize(boolean onlyScaleDown, int inWidth, int inHeight,
       int targetWidth, int targetHeight) {
-    return !onlyScaleDown || inWidth > targetWidth || inHeight > targetHeight;
+    return !onlyScaleDown || inWidth > targetWidth && targetWidth != 0 || inHeight > targetHeight && targetHeight != 0;
   }
 
   static int getExifRotation(int orientation) {


### PR DESCRIPTION
When onlyScaleDown is true and one of the target dimensions are set to 0 it will resize bitmap despite other dimension is smaller than target.