### PR TITLE
Add support to dither a decoded image.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -83,13 +83,16 @@ public final class Request {
   public final boolean purgeable;
   /** Target image config for decoding. */
   public final Bitmap.Config config;
+  /** True if image should be decoded with inDither. */
+  public final boolean dither;
   /** The priority of this request. */
   public final Priority priority;
 
   private Request(Uri uri, int resourceId, String stableKey, List<Transformation> transformations,
       int targetWidth, int targetHeight, boolean centerCrop, boolean centerInside,
       boolean onlyScaleDown, float rotationDegrees, float rotationPivotX, float rotationPivotY,
-      boolean hasRotationPivot, boolean purgeable, Bitmap.Config config, Priority priority) {
+      boolean hasRotationPivot, boolean purgeable, Bitmap.Config config, boolean dither,
+      Priority priority) {
     this.uri = uri;
     this.resourceId = resourceId;
     this.stableKey = stableKey;
@@ -109,6 +112,7 @@ public final class Request {
     this.hasRotationPivot = hasRotationPivot;
     this.purgeable = purgeable;
     this.config = config;
+    this.dither = dither;
     this.priority = priority;
   }
 
@@ -148,6 +152,9 @@ public final class Request {
     }
     if (config != null) {
       builder.append(' ').append(config);
+    }
+    if (dither) {
+      builder.append(" dither");
     }
     builder.append('}');
 
@@ -210,6 +217,7 @@ public final class Request {
     private boolean purgeable;
     private List<Transformation> transformations;
     private Bitmap.Config config;
+    private boolean dither;
     private Priority priority;
 
     /** Start building a request using the specified {@link Uri}. */
@@ -246,6 +254,7 @@ public final class Request {
         transformations = new ArrayList<Transformation>(request.transformations);
       }
       config = request.config;
+      dither = request.dither;
       priority = request.priority;
     }
 
@@ -416,6 +425,12 @@ public final class Request {
       return this;
     }
 
+    /** Attempt to dither the decoded image. */
+    public Builder dither() {
+      this.dither = true;
+      return this;
+    }
+
     /** Execute request using the specified priority. */
     public Builder priority(Priority priority) {
       if (priority == null) {
@@ -480,7 +495,7 @@ public final class Request {
       }
       return new Request(uri, resourceId, stableKey, transformations, targetWidth, targetHeight,
           centerCrop, centerInside, onlyScaleDown, rotationDegrees, rotationPivotX, rotationPivotY,
-          hasRotationPivot, purgeable, config, priority);
+          hasRotationPivot, purgeable, config, dither, priority);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -282,6 +282,12 @@ public class RequestCreator {
     return this;
   }
 
+  /** Attempt to dither the decoded image. */
+  public RequestCreator dither() {
+    data.dither();
+    return this;
+  }
+
   /**
    * Sets the stable key for this request to be used instead of the URI or resource ID when
    * caching. Two requests with the same value are considered to be for the same resource.

--- a/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
@@ -132,11 +132,12 @@ public abstract class RequestHandler {
     final boolean justBounds = data.hasSize();
     final boolean hasConfig = data.config != null;
     BitmapFactory.Options options = null;
-    if (justBounds || hasConfig || data.purgeable) {
+    if (justBounds || hasConfig || data.purgeable || data.dither) {
       options = new BitmapFactory.Options();
       options.inJustDecodeBounds = justBounds;
       options.inInputShareable = data.purgeable;
       options.inPurgeable = data.purgeable;
+      options.inDither = data.dither;
       if (hasConfig) {
         options.inPreferredConfig = data.config;
       }

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -867,4 +867,16 @@ public class RequestCreatorTest {
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
     assertThat(actionCaptor.getValue().getRequest().purgeable).isTrue();
   }
+
+  @Test public void noDither() {
+    new RequestCreator(picasso, URI_1, 0).into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getRequest().dither).isFalse();
+  }
+
+  @Test public void dither() {
+    new RequestCreator(picasso, URI_1, 0).dither().into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getRequest().dither).isTrue();
+  }
 }

--- a/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
@@ -102,6 +102,7 @@ public class RequestHandlerTest {
     assertThat(resizeOptions.inJustDecodeBounds).isTrue();
     assertThat(resizeOptions.inPurgeable).isFalse();
     assertThat(resizeOptions.inInputShareable).isFalse();
+    assertThat(resizeOptions.inDither).isFalse();
   }
 
   @Test public void inPurgeableIfInPurgeable() {
@@ -111,6 +112,7 @@ public class RequestHandlerTest {
     assertThat(options.inPurgeable).isTrue();
     assertThat(options.inInputShareable).isTrue();
     assertThat(options.inJustDecodeBounds).isFalse();
+    assertThat(options.inDither).isFalse();
   }
 
   @Test public void createWithConfigAndNotInJustDecodeBoundsOrInPurgeable() {
@@ -121,5 +123,17 @@ public class RequestHandlerTest {
     assertThat(configOptions.inJustDecodeBounds).isFalse();
     assertThat(configOptions.inPurgeable).isFalse();
     assertThat(configOptions.inInputShareable).isFalse();
+    assertThat(configOptions.inDither).isFalse();
+  }
+
+  @Test public void inDitherIfDither() {
+    // Dither must return bitmap options with inDither = true
+    final Request config = new Request.Builder(URI_1).dither().build();
+    final BitmapFactory.Options ditherOptions = createBitmapOptions(config);
+    assertThat(ditherOptions).isNotNull();
+    assertThat(ditherOptions.inJustDecodeBounds).isFalse();
+    assertThat(ditherOptions.inPurgeable).isFalse();
+    assertThat(ditherOptions.inInputShareable).isFalse();
+    assertThat(ditherOptions.inDither).isTrue();
   }
 }


### PR DESCRIPTION
Add support to dither decoded images. Using the bitmap config RGB\_565 causes banding issues in the image, which dithering will make less apparent.