### PR TITLE
Count size of loops once instead of each iteration

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -420,7 +420,8 @@ class BitmapHunter implements Runnable {
 
     // Index-based loop to avoid allocating an iterator.
     //noinspection ForLoopReplaceableByForEach
-    for (int i = 0, count = requestHandlers.size(); i < count; i++) {
+    int size = requestHandlers.size()
+    for (int i = 0, count = size; i < count; i++) {
       RequestHandler requestHandler = requestHandlers.get(i);
       if (requestHandler.canHandleRequest(request)) {
         return new BitmapHunter(picasso, dispatcher, cache, stats, action, requestHandler);
@@ -431,7 +432,8 @@ class BitmapHunter implements Runnable {
   }
 
   static Bitmap applyCustomTransformations(List<Transformation> transformations, Bitmap result) {
-    for (int i = 0, count = transformations.size(); i < count; i++) {
+	int size = transformations.size();
+    for (int i = 0, count = size; i < count; i++) {
       final Transformation transformation = transformations.get(i);
       Bitmap newResult;
       try {

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -112,7 +112,8 @@ public class Picasso {
         case HUNTER_BATCH_COMPLETE: {
           @SuppressWarnings("unchecked") List<BitmapHunter> batch = (List<BitmapHunter>) msg.obj;
           //noinspection ForLoopReplaceableByForEach
-          for (int i = 0, n = batch.size(); i < n; i++) {
+          int size = batch.size();
+          for (int i = 0, n = size; i < n; i++) {
             BitmapHunter hunter = batch.get(i);
             hunter.picasso.complete(hunter);
           }
@@ -243,7 +244,8 @@ public class Picasso {
     List<DeferredRequestCreator> deferredRequestCreators =
         new ArrayList<DeferredRequestCreator>(targetToDeferredRequestCreator.values());
     //noinspection ForLoopReplaceableByForEach
-    for (int i = 0, n = deferredRequestCreators.size(); i < n; i++) {
+    int size = deferredRequestCreators.size();
+    for (int i = 0, n = size; i < n; i++) {
       DeferredRequestCreator deferredRequestCreator = deferredRequestCreators.get(i);
       if (tag.equals(deferredRequestCreator.getTag())) {
         deferredRequestCreator.cancel();
@@ -530,7 +532,8 @@ public class Picasso {
 
     if (hasMultiple) {
       //noinspection ForLoopReplaceableByForEach
-      for (int i = 0, n = joined.size(); i < n; i++) {
+      int size = joined.size();
+      for (int i = 0, n = size; i < n; i++) {
         Action join = joined.get(i);
         deliverAction(result, from, join);
       }


### PR DESCRIPTION
As suggested here: http://developer.android.com/training/articles/perf-tips.html