### PR TITLE
Let ContentStreamRequestHandler respect Exif orientation

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
@@ -37,7 +37,7 @@ class ContentStreamRequestHandler extends RequestHandler {
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
     int exifOrientation = 0;
-    if(Utils.GOOGLE_PHOTOS_APP_URI_AUTHORITY.equals(request.uri.getAuthority())) {
+    if (Utils.PHOTOS_APP_URI_AUTHORITY.equals(request.uri.getAuthority())) {
       exifOrientation = Utils.getExifOrientation(context.getContentResolver(), request.uri);
     }
     return new Result(null, getInputStream(request), DISK, exifOrientation);

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
@@ -36,7 +36,7 @@ class ContentStreamRequestHandler extends RequestHandler {
   }
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
-    return new Result(getInputStream(request), DISK);
+    return new Result(null, getInputStream(request), DISK, Utils.getExifOrientation(context.getContentResolver(), request.uri));
   }
 
   InputStream getInputStream(Request request) throws FileNotFoundException {

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
@@ -36,7 +36,11 @@ class ContentStreamRequestHandler extends RequestHandler {
   }
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
-    return new Result(null, getInputStream(request), DISK, Utils.getExifOrientation(context.getContentResolver(), request.uri));
+    int exifOrientation = 0;
+    if(Utils.GOOGLE_PHOTOS_APP_URI_AUTHORITY.equals(request.uri.getAuthority())) {
+      exifOrientation = Utils.getExifOrientation(context.getContentResolver(), request.uri);
+    }
+    return new Result(null, getInputStream(request), DISK, exifOrientation);
   }
 
   InputStream getInputStream(Request request) throws FileNotFoundException {

--- a/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
@@ -17,7 +17,6 @@ package com.squareup.picasso;
 
 import android.content.ContentResolver;
 import android.content.Context;
-import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.net.Uri;
@@ -37,10 +36,6 @@ import static com.squareup.picasso.MediaStoreRequestHandler.PicassoKind.MINI;
 import static com.squareup.picasso.Picasso.LoadedFrom.DISK;
 
 class MediaStoreRequestHandler extends ContentStreamRequestHandler {
-  private static final String[] CONTENT_ORIENTATION = new String[] {
-      Images.ImageColumns.ORIENTATION
-  };
-
   MediaStoreRequestHandler(Context context) {
     super(context);
   }
@@ -53,7 +48,7 @@ class MediaStoreRequestHandler extends ContentStreamRequestHandler {
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
     ContentResolver contentResolver = context.getContentResolver();
-    int exifOrientation = getExifOrientation(contentResolver, request.uri);
+    int exifOrientation = Utils.getExifOrientation(contentResolver, request.uri);
 
     String mimeType = contentResolver.getType(request.uri);
     boolean isVideo = mimeType != null && mimeType.startsWith("video/");
@@ -99,24 +94,6 @@ class MediaStoreRequestHandler extends ContentStreamRequestHandler {
       return MINI;
     }
     return FULL;
-  }
-
-  static int getExifOrientation(ContentResolver contentResolver, Uri uri) {
-    Cursor cursor = null;
-    try {
-      cursor = contentResolver.query(uri, CONTENT_ORIENTATION, null, null, null);
-      if (cursor == null || !cursor.moveToFirst()) {
-        return 0;
-      }
-      return cursor.getInt(0);
-    } catch (RuntimeException ignored) {
-      // If the orientation column doesn't exist, assume no rotation.
-      return 0;
-    } finally {
-      if (cursor != null) {
-        cursor.close();
-      }
-    }
   }
 
   enum PicassoKind {

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -63,6 +63,7 @@ final class Utils {
   private static final int MAX_DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
   static final int THREAD_LEAK_CLEANING_MS = 1000;
   static final char KEY_SEPARATOR = '\n';
+  static final String GOOGLE_PHOTOS_APP_URI_AUTHORITY = "com.google.android.apps.photos.contentprovider";
 
   static final String[] CONTENT_ORIENTATION = new String[] {
           MediaStore.Images.ImageColumns.ORIENTATION

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -63,7 +63,7 @@ final class Utils {
   private static final int MAX_DISK_CACHE_SIZE = 50 * 1024 * 1024; // 50MB
   static final int THREAD_LEAK_CLEANING_MS = 1000;
   static final char KEY_SEPARATOR = '\n';
-  static final String GOOGLE_PHOTOS_APP_URI_AUTHORITY = "com.google.android.apps.photos.contentprovider";
+  static final String PHOTOS_APP_URI_AUTHORITY = "com.google.android.apps.photos.contentprovider";
 
   static final String[] CONTENT_ORIENTATION = new String[] {
       MediaStore.Images.ImageColumns.ORIENTATION

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -66,7 +66,7 @@ final class Utils {
   static final String GOOGLE_PHOTOS_APP_URI_AUTHORITY = "com.google.android.apps.photos.contentprovider";
 
   static final String[] CONTENT_ORIENTATION = new String[] {
-          MediaStore.Images.ImageColumns.ORIENTATION
+      MediaStore.Images.ImageColumns.ORIENTATION
   };
 
   /** Thread confined to main thread for key creation. */


### PR DESCRIPTION
Right now `ContentStreamRequestHandler` doesn't check exif orientation, but in some cases (such as Uri is coming from Google Photos App), we can get this data the same way we do that within `MediaStoreRequestHandler`. So I moved `getExifOrientation` method to utilities class and use it when we decode stream via `ContentStreamRequestHandler` 
