### PR TITLE
Catch OutOfMemoryError caused when setting error image

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/ImageViewAction.java
@@ -56,10 +56,14 @@ class ImageViewAction extends Action<ImageView> {
     if (target == null) {
       return;
     }
-    if (errorResId != 0) {
-      target.setImageResource(errorResId);
-    } else if (errorDrawable != null) {
-      target.setImageDrawable(errorDrawable);
+    try {
+      if (errorResId != 0) {
+        target.setImageResource(errorResId);
+      } else if (errorDrawable != null) {
+        target.setImageDrawable(errorDrawable);
+      }
+    } catch (OutOfMemoryError e) {
+      // Not much we can do here, better to swallow the OOM than to crash
     }
 
     if (callback != null) {


### PR DESCRIPTION
I wrote a simple app to reproduce the crash we occasionally were seeing via Crashlytics. 

https://github.com/jonathan-caryl/PicassoOnErrorOOMTest

It seems better to swallow the OOM and not display an error image than to crash.