### PR TITLE
BitmapHunter.decodeStream uses larger read limit 

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -114,7 +114,7 @@ class BitmapHunter implements Runnable {
     MarkableInputStream markStream = new MarkableInputStream(stream);
     stream = markStream;
 
-    long mark = markStream.savePosition(65536); // TODO fix this crap.
+    long mark = markStream.savePosition(67108863); // TODO fix this crap.
 
     final BitmapFactory.Options options = RequestHandler.createBitmapOptions(request);
     final boolean calculateSize = RequestHandler.requiresInSampleSize(options);


### PR DESCRIPTION
BitmapHunter.decodeStream uses more reasonable read limit when saving position.  Left //TODO in because this seems likely to continue to cause problems in the future.

A change somewhere into 2.5 has created issues in this area.  Our app attempts to load some thumbnails from disk, but fails at L140 as parsing the bitmap header on some devices has resulted in reading past 65535 bytes.  