### PR TITLE
added BitmapOptionsTransformer to allow transform on the BitmapFactor…

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -138,7 +138,7 @@ class BitmapHunter implements Runnable {
       if (request.optionsTransformer != null) {
           options = request.optionsTransformer.transformOptions(bytes, options);
       }
-      if (calculateSize) {
+      if (options != null && calculateSize) {
         if (options.outWidth == -0 || options.outHeight == 0) {
             BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
         }
@@ -151,14 +151,14 @@ class BitmapHunter implements Runnable {
           options = request.optionsTransformer.transformOptions(stream, options);
       }
       if (calculateSize) {
-        if (options.outWidth == 0 || options.outHeight == 0) {
+        if (options != null && options.outWidth == 0 || options.outHeight == 0) {
             BitmapFactory.decodeStream(stream, null, options);
         }
         RequestHandler.calculateInSampleSize(request.targetWidth, request.targetHeight, options,
             request);
 
-        markStream.reset(mark);
       }
+      markStream.reset(mark);
       Bitmap bitmap = BitmapFactory.decodeStream(stream, null, options);
       if (bitmap == null) {
         // Treat null as an IO exception, we will eventually retry.

--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -124,7 +124,7 @@ class BitmapHunter implements Runnable {
 
     long mark = markStream.savePosition(65536); // TODO fix this crap.
 
-    final BitmapFactory.Options options = RequestHandler.createBitmapOptions(request);
+    BitmapFactory.Options options = RequestHandler.createBitmapOptions(request);
     final boolean calculateSize = RequestHandler.requiresInSampleSize(options);
 
     boolean isWebPFile = Utils.isWebPFile(stream);
@@ -135,15 +135,25 @@ class BitmapHunter implements Runnable {
     // purgeable, which only affects bitmaps decoded from byte arrays.
     if (isWebPFile || isPurgeable) {
       byte[] bytes = Utils.toByteArray(stream);
+      if (request.optionsTransformer != null) {
+          options = request.optionsTransformer.transformOptions(bytes, options);
+      }
       if (calculateSize) {
-        BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
+        if (options.outWidth == -0 || options.outHeight == 0) {
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
+        }
         RequestHandler.calculateInSampleSize(request.targetWidth, request.targetHeight, options,
             request);
       }
       return BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
     } else {
+      if (request.optionsTransformer != null) {
+          options = request.optionsTransformer.transformOptions(stream, options);
+      }
       if (calculateSize) {
-        BitmapFactory.decodeStream(stream, null, options);
+        if (options.outWidth == 0 || options.outHeight == 0) {
+            BitmapFactory.decodeStream(stream, null, options);
+        }
         RequestHandler.calculateInSampleSize(request.targetWidth, request.targetHeight, options,
             request);
 

--- a/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
+++ b/picasso/src/main/java/com/squareup/picasso/MarkableInputStream.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
  * marking and resetting. Each cursor is a token, and it's the caller's
  * responsibility to keep track of these.
  */
-final class MarkableInputStream extends InputStream {
+public final class MarkableInputStream extends InputStream {
   private static final int DEFAULT_BUFFER_SIZE = 4096;
 
   private final InputStream in;

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.unmodifiableList;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 /** Immutable data about an image and the transformations that will be applied to it. */
@@ -41,7 +42,10 @@ public final class Request {
        */
       BitmapFactory.Options transformOptions(byte[] bytes, BitmapFactory.Options options);
 
-      BitmapFactory.Options transformOptions(InputStream stream, BitmapFactory.Options options);
+      BitmapFactory.Options transformOptions(MarkableInputStream stream, BitmapFactory.Options options, long mark) throws IOException;
+      
+      int calculateInSampleSize(BitmapFactory.Options options,
+              int reqWidth, int reqHeight);
     }
 
   /** A unique ID for the request. */

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
           <version>4.1.1</version>
           <configuration>
             <sdk>
-              <platform>17</platform>
+              <platform>23</platform>
             </sdk>
           </configuration>
         </plugin>


### PR DESCRIPTION
…y.Options

The idea is based on the work actually going on for the BitmapPool.
The problem for be was that i needed to handle the bitmappool outside of Picasso while still support it inside Picasso.
The simpler solution was to add `BitmapOptionsTransformer`
Then in it i can do something like this

```
private static BitmapOptionsTransformer _optionsTransformer = new BitmapOptionsTransformer() {
        @Override
        public Options transformOptions(InputStream stream, Options options) {
            if (options.outWidth == 0 || options.outHeight == 0) {
                options.inJustDecodeBounds = true;
                stream.mark(Integer.MAX_VALUE);
                BitmapFactory.decodeStream(stream, null, options);
                if (stream.markSupported()) {
                    try {
                        stream.reset();
                    } catch (IOException e) {
                        // TODO Auto-generated catch block
                        e.printStackTrace();
                    }
                }

                options.inJustDecodeBounds = false;
                options.inBitmap = TiBitmapPool.tryFindBitmap(options);
            }
            return options;
        }

        @Override
        public Options transformOptions(byte[] bytes, Options options) {
            if (options.outWidth == 0 || options.outHeight == 0) {
                options.inJustDecodeBounds = true;
                BitmapFactory.decodeByteArray(bytes, 0, bytes.length, options);
                options.inJustDecodeBounds = false;
                options.inBitmap = TiBitmapPool.tryFindBitmap(options);
            }
            return options;
        }
    };
```

Don't hesitate if it needs any modification.
I hope it's going to make it through ;)
