### PR TITLE
Parametrised crop using Gravity flags

### DIFF
--- a/picasso-pollexor/src/test/java/com/squareup/picasso/pollexor/PollexorRequestTransformerTest.java
+++ b/picasso-pollexor/src/test/java/com/squareup/picasso/pollexor/PollexorRequestTransformerTest.java
@@ -56,7 +56,7 @@ public class PollexorRequestTransformerTest {
     Request output = transformer.transformRequest(input);
     assertThat(output).isNotSameAs(input);
     assertThat(output.hasSize()).isFalse();
-    assertThat(output.centerCrop).isFalse();
+    assertThat(output.crop).isFalse();
 
     String expected = Thumbor.create(HOST).buildImage(IMAGE).resize(50, 50).toUrl();
     assertThat(output.uri.toString()).isEqualTo(expected);

--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -19,6 +19,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.NetworkInfo;
+import android.view.Gravity;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -570,7 +572,7 @@ class BitmapHunter implements Runnable {
         }
       }
 
-      if (data.centerCrop) {
+      if (data.crop) {
         // Keep aspect ratio if one dimension is set to 0
         float widthRatio =
             targetWidth != 0 ? targetWidth / (float) inWidth : targetHeight / (float) inHeight;
@@ -579,13 +581,17 @@ class BitmapHunter implements Runnable {
         float scaleX, scaleY;
         if (widthRatio > heightRatio) {
           int newSize = (int) Math.ceil(inHeight * (heightRatio / widthRatio));
-          drawY = (inHeight - newSize) / 2;
+          drawY = (data.cropGravity & Gravity.TOP) == Gravity.TOP ? 0
+              : (data.cropGravity & Gravity.BOTTOM) == Gravity.BOTTOM ? inHeight - newSize
+                  : (inHeight - newSize) / 2;
           drawHeight = newSize;
           scaleX = widthRatio;
           scaleY = targetHeight / (float) drawHeight;
         } else if (widthRatio < heightRatio) {
           int newSize = (int) Math.ceil(inWidth * (widthRatio / heightRatio));
-          drawX = (inWidth - newSize) / 2;
+          drawX = (data.cropGravity & Gravity.LEFT) == Gravity.LEFT ? 0
+              : (data.cropGravity & Gravity.RIGHT) == Gravity.RIGHT ? inWidth - newSize
+                  : (inWidth - newSize) / 2;
           drawWidth = newSize;
           scaleX = targetWidth / (float) drawWidth;
           scaleY = heightRatio;

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -242,6 +242,16 @@ public class RequestCreator {
   }
 
   /**
+   * Crops an image inside of the bounds specified by {@link #resize(int, int)} rather than
+   * distorting the aspect ratio. This cropping technique scales the image so that it fills the
+   * requested bounds and then crops the extra using gravity to position image.
+   */
+  public RequestCreator crop(int gravity) {
+    data.crop(gravity);
+    return this;
+  }
+
+  /**
    * Centers an image inside of the bounds specified by {@link #resize(int, int)}. This scales
    * the image so that both dimensions are equal to or less than the requested bounds.
    */

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -201,8 +201,8 @@ final class Utils {
       builder.append("resize:").append(data.targetWidth).append('x').append(data.targetHeight);
       builder.append(KEY_SEPARATOR);
     }
-    if (data.centerCrop) {
-      builder.append("centerCrop").append(KEY_SEPARATOR);
+    if (data.crop) {
+      builder.append("crop:").append(data.cropGravity).append(KEY_SEPARATOR);
     } else if (data.centerInside) {
       builder.append("centerInside").append(KEY_SEPARATOR);
     }


### PR DESCRIPTION
I've added customisable crop() with android.view.Gravity flags as parameters.

This change enables to call such code:

```java
Picasso.with(context)
        .load(imageUrl)
        .fit()
        .crop(Gravity.START | Gravity.BOTTOM)
        .into(imageView);
```

This will make Picasso position image first and then perform crop. For example above, image start and bottom will be shown (cropping end or top part of the image)

Code is backwards compatible, centerCrop() call is now alias to crop(Gravity.CENTER).