### PR TITLE
add try for SecurityException in isAirplaneModeOn

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -299,6 +299,9 @@ final class Utils {
       // https://github.com/square/picasso/issues/761, some devices might crash here, assume that
       // airplane mode is off.
       return false;
+    } catch (SecurityException e) {
+      //https://github.com/square/picasso/issues/1197
+      return false;
     }
   }
 


### PR DESCRIPTION
@JakeWharton https://github.com/square/picasso/issues/1197  Unable to find cause but happened 3000+ times during 10% rollout of NYT app.