### PR TITLE
Fix wrong image loaded when notifyItemChanged() is called

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
@@ -55,6 +55,7 @@ class DeferredRequestCreator implements ViewTreeObserver.OnPreDrawListener {
     }
 
     vto.removeOnPreDrawListener(this);
+    this.target.clear();
 
     this.creator.unfit().resize(width, height).into(target, callback);
     return true;
@@ -72,6 +73,7 @@ class DeferredRequestCreator implements ViewTreeObserver.OnPreDrawListener {
       return;
     }
     vto.removeOnPreDrawListener(this);
+    this.target.clear();
   }
 
   Object getTag() {


### PR DESCRIPTION
https://github.com/square/picasso/issues/954
cause: 
  onPreDraw() is called several times even after removeOnPreDrawListener() has been called.
precondition:
  1 using RecyclerView
  2 calling fit()
  3 calling notifyItemChanged() or notifyItemRangeChanged()
solution:
  Clear target reference after removeOnPreDrawListener to ensure not calling into() again.