### PR TITLE
centerCrop() align gravity options

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -19,6 +19,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.NetworkInfo;
+import android.view.Gravity;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -579,13 +581,17 @@ class BitmapHunter implements Runnable {
         float scaleX, scaleY;
         if (widthRatio > heightRatio) {
           int newSize = (int) Math.ceil(inHeight * (heightRatio / widthRatio));
-          drawY = (inHeight - newSize) / 2;
+          drawY = (data.centerCropGravity & Gravity.TOP) == Gravity.TOP ? 0
+              : (data.centerCropGravity & Gravity.BOTTOM) == Gravity.BOTTOM ? inHeight - newSize
+              : (inHeight - newSize) / 2;
           drawHeight = newSize;
           scaleX = widthRatio;
           scaleY = targetHeight / (float) drawHeight;
         } else if (widthRatio < heightRatio) {
           int newSize = (int) Math.ceil(inWidth * (widthRatio / heightRatio));
-          drawX = (inWidth - newSize) / 2;
+          drawX = (data.centerCropGravity & Gravity.LEFT) == Gravity.LEFT ? 0
+              : (data.centerCropGravity & Gravity.RIGHT) == Gravity.RIGHT ? inWidth - newSize
+              : (inWidth - newSize) / 2;
           drawWidth = newSize;
           scaleX = targetWidth / (float) drawWidth;
           scaleY = heightRatio;

--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.view.Gravity;
 import com.squareup.picasso.Picasso.Priority;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,6 +65,8 @@ public final class Request {
    * This is mutually exclusive with {@link #centerInside}.
    */
   public final boolean centerCrop;
+  /** If centerCrop is set, controls alignment of centered image */
+  public final int centerCropGravity;
   /**
    * True if the final image should use the 'centerInside' scale technique.
    * <p>
@@ -88,8 +91,9 @@ public final class Request {
 
   private Request(Uri uri, int resourceId, String stableKey, List<Transformation> transformations,
       int targetWidth, int targetHeight, boolean centerCrop, boolean centerInside,
-      boolean onlyScaleDown, float rotationDegrees, float rotationPivotX, float rotationPivotY,
-      boolean hasRotationPivot, boolean purgeable, Bitmap.Config config, Priority priority) {
+      int centerCropGravity, boolean onlyScaleDown, float rotationDegrees,
+      float rotationPivotX, float rotationPivotY, boolean hasRotationPivot,
+      boolean purgeable, Bitmap.Config config, Priority priority) {
     this.uri = uri;
     this.resourceId = resourceId;
     this.stableKey = stableKey;
@@ -102,6 +106,7 @@ public final class Request {
     this.targetHeight = targetHeight;
     this.centerCrop = centerCrop;
     this.centerInside = centerInside;
+    this.centerCropGravity = centerCropGravity;
     this.onlyScaleDown = onlyScaleDown;
     this.rotationDegrees = rotationDegrees;
     this.rotationPivotX = rotationPivotX;
@@ -201,6 +206,7 @@ public final class Request {
     private int targetWidth;
     private int targetHeight;
     private boolean centerCrop;
+    private int centerCropGravity;
     private boolean centerInside;
     private boolean onlyScaleDown;
     private float rotationDegrees;
@@ -236,6 +242,7 @@ public final class Request {
       targetHeight = request.targetHeight;
       centerCrop = request.centerCrop;
       centerInside = request.centerInside;
+      centerCropGravity = request.centerCropGravity;
       rotationDegrees = request.rotationDegrees;
       rotationPivotX = request.rotationPivotX;
       rotationPivotY = request.rotationPivotY;
@@ -332,16 +339,27 @@ public final class Request {
      * requested bounds and then crops the extra.
      */
     public Builder centerCrop() {
+      return centerCrop(Gravity.CENTER);
+    }
+
+    /**
+     * Crops an image inside of the bounds specified by {@link #resize(int, int)} rather than
+     * distorting the aspect ratio. This cropping technique scales the image so that it fills the
+     * requested bounds, aligns it using provided gravity parameter and then crops the extra.
+     */
+    public Builder centerCrop(int alignGravity) {
       if (centerInside) {
         throw new IllegalStateException("Center crop can not be used after calling centerInside");
       }
       centerCrop = true;
+      centerCropGravity = alignGravity;
       return this;
     }
 
     /** Clear the center crop transformation flag, if set. */
     public Builder clearCenterCrop() {
       centerCrop = false;
+      centerCropGravity = Gravity.CENTER;
       return this;
     }
 
@@ -479,8 +497,8 @@ public final class Request {
         priority = Priority.NORMAL;
       }
       return new Request(uri, resourceId, stableKey, transformations, targetWidth, targetHeight,
-          centerCrop, centerInside, onlyScaleDown, rotationDegrees, rotationPivotX, rotationPivotY,
-          hasRotationPivot, purgeable, config, priority);
+          centerCrop, centerInside, centerCropGravity, onlyScaleDown, rotationDegrees,
+          rotationPivotX, rotationPivotY, hasRotationPivot, purgeable, config, priority);
     }
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -21,6 +21,7 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.view.Gravity;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
 import java.io.IOException;
@@ -237,7 +238,12 @@ public class RequestCreator {
    * requested bounds and then crops the extra.
    */
   public RequestCreator centerCrop() {
-    data.centerCrop();
+    data.centerCrop(Gravity.CENTER);
+    return this;
+  }
+
+  public RequestCreator centerCrop(int alignGravity) {
+    data.centerCrop(alignGravity);
     return this;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -202,7 +202,7 @@ final class Utils {
       builder.append(KEY_SEPARATOR);
     }
     if (data.centerCrop) {
-      builder.append("centerCrop").append(KEY_SEPARATOR);
+      builder.append("centerCrop:").append(data.centerCropGravity).append(KEY_SEPARATOR);
     } else if (data.centerInside) {
       builder.append("centerInside").append(KEY_SEPARATOR);
     }


### PR DESCRIPTION
I've added overloaded centerCrop() method with align gravity parameter (```android.view.Gravity```).

When gravity parameter is supplied, image is aligned first, then cropped.

Example call:
```
Picasso.with(context)
    .load(url)
    .fit()
    .centerCrop(Gravity.TOP)
    .into(imageView);
```

Parameterless ```centerCrop()``` is synonymous to ```centerCrop(Gravity.CENTER)```

Example results:

* ```centerCrop(Gravity.TOP | Gravity.START)```
![top_start](https://cloud.githubusercontent.com/assets/743666/11942659/61d3d348-a838-11e5-8f52-4a5565405c05.png)

* ```centerCrop(Gravity.BOTTOM | Gravity.END)```
![bottom_end](https://cloud.githubusercontent.com/assets/743666/11942661/65745a72-a838-11e5-8305-fcd398dbc3d6.png)

ImageViews used in examples:
```
<ImageView
    android:id="@+id/image_horizontal"
    android:layout_width="200dp"
    android:layout_height="100dp" 
    />
    
<ImageView
    android:id="@+id/image_vertial"
    android:layout_width="100dp"
    android:layout_height="200dp" 
    />
```