### PR TITLE
The fix of unnecessary objects creation

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -21,7 +21,6 @@ import android.graphics.Canvas;
 import android.graphics.ColorFilter;
 import android.graphics.Paint;
 import android.graphics.Path;
-import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.AnimationDrawable;
 import android.graphics.drawable.BitmapDrawable;
@@ -144,22 +143,19 @@ final class PicassoDrawable extends BitmapDrawable {
 
   private void drawDebugIndicator(Canvas canvas) {
     DEBUG_PAINT.setColor(WHITE);
-    Path path = getTrianglePath(new Point(0, 0), (int) (16 * density));
+    Path path = getTrianglePath(0, 0, (int) (16 * density));
     canvas.drawPath(path, DEBUG_PAINT);
 
     DEBUG_PAINT.setColor(loadedFrom.debugColor);
-    path = getTrianglePath(new Point(0, 0), (int) (15 * density));
+    path = getTrianglePath(0, 0, (int) (15 * density));
     canvas.drawPath(path, DEBUG_PAINT);
   }
 
-  private static Path getTrianglePath(Point p1, int width) {
-    Point p2 = new Point(p1.x + width, p1.y);
-    Point p3 = new Point(p1.x, p1.y + width);
-
-    Path path = new Path();
-    path.moveTo(p1.x, p1.y);
-    path.lineTo(p2.x, p2.y);
-    path.lineTo(p3.x, p3.y);
+  private static Path getTrianglePath(int x1, int y1, int width) {
+    final Path path = new Path();
+    path.moveTo(x1, y1);
+    path.lineTo(x1 + width, y1);
+    path.lineTo(x1, y1 + width);
 
     return path;
   }


### PR DESCRIPTION
The `getTrianglePath()` method creates two `Point` objects which will be garbage-collected in no time. These objects can be safely replaced with plain `int` variables to save some work of garbage collector (which conforms to Effective Java item №5 - "Avoid creating unnecessary objects").