### PR TITLE
Add a feature to globally disable fade

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -156,6 +156,7 @@ public class Picasso {
   final ReferenceQueue<Object> referenceQueue;
   final Bitmap.Config defaultBitmapConfig;
 
+  boolean noFade;
   boolean indicatorsEnabled;
   volatile boolean loggingEnabled;
 
@@ -385,6 +386,16 @@ public class Picasso {
       throw new IllegalArgumentException("file == null");
     }
     invalidate(Uri.fromFile(file));
+  }
+
+  /** Enable brief fade in of images loaded from the disk cache or network. */
+  public void enableFade() {
+    noFade = false;
+  }
+
+  /** Disable brief fade in of images loaded from the disk cache or network. */
+  public void disableFade() {
+    noFade = true;
   }
 
   /**

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -72,6 +72,7 @@ public class RequestCreator {
           "Picasso instance already shut down. Cannot submit new requests.");
     }
     this.picasso = picasso;
+    this.noFade = picasso.noFade;
     this.data = new Request.Builder(uri, resourceId, picasso.defaultBitmapConfig);
   }
 
@@ -385,6 +386,12 @@ public class RequestCreator {
    */
   public RequestCreator purgeable() {
     data.purgeable();
+    return this;
+  }
+
+  /** Enable brief fade in of images loaded from the disk cache or network. */
+  public RequestCreator fade() {
+    noFade = false;
     return this;
   }
 


### PR DESCRIPTION
This is useful when testing the app. Looks like Spoon sometimes takes the screenshot while the fade is running.
