### PR TITLE
No retry on FileNotFound exception

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso/BitmapHunter.java
@@ -19,6 +19,8 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Matrix;
 import android.net.NetworkInfo;
+
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
@@ -181,6 +183,9 @@ class BitmapHunter implements Runnable {
     } catch (NetworkRequestHandler.ContentLengthException e) {
       exception = e;
       dispatcher.dispatchRetry(this);
+    } catch (FileNotFoundException e) {
+      exception = e;
+      dispatcher.dispatchFailed(this);
     } catch (IOException e) {
       exception = e;
       dispatcher.dispatchRetry(this);

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -20,6 +20,7 @@ import android.graphics.Bitmap;
 import android.graphics.Matrix;
 import android.net.Uri;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -153,6 +154,14 @@ public class BitmapHunterTest {
         new IOException());
     hunter.run();
     verify(dispatcher).dispatchRetry(hunter);
+  }
+
+  @Test public void runWithFileNotFoundExceptionDispatchFailed() {
+    Action action = mockAction(URI_KEY_1, URI_1);
+    BitmapHunter hunter = new TestableBitmapHunter(picasso, dispatcher, cache, stats, action, null,
+        new FileNotFoundException());
+    hunter.run();
+    verify(dispatcher).dispatchFailed(hunter);
   }
 
   @Test public void huntDecodesWhenNotInCache() throws Exception {


### PR DESCRIPTION
The existing code will queue up a retry (with a 500ms delay),
and then ask the RequestHandler if retry is allowed.
For most handlers (e.g. AssetRequestHandler and FileRequestHandler),
it'll return false, and queue up a fail event.
This change will skip directly to fail, so the callback will be
triggered much faster.