### PR TITLE
Clear the reference to the placeholder when not needed anymore

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoDrawable.java
@@ -92,6 +92,7 @@ final class PicassoDrawable extends BitmapDrawable {
 
   @Override public void draw(Canvas canvas) {
     if (!animating) {
+      placeholder = null;
       super.draw(canvas);
     } else {
       float normalized = (SystemClock.uptimeMillis() - startTimeMillis) / FADE_DURATION;


### PR DESCRIPTION
Should fix #968 