### PR TITLE
Set max pool size before core to avoid IAE by OpenJDK implementation.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
@@ -78,8 +78,8 @@ class PicassoExecutorService extends ThreadPoolExecutor {
   }
 
   private void setThreadCount(int threadCount) {
-    setCorePoolSize(threadCount);
     setMaximumPoolSize(threadCount);
+    setCorePoolSize(threadCount);
   }
 
   @Override


### PR DESCRIPTION
Closes #1319