### PR TITLE
Set max pool size and core size according to Android SDK version.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
@@ -17,6 +17,7 @@ package com.squareup.picasso;
 
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
 import android.telephony.TelephonyManager;
 
 import java.util.concurrent.Future;

--- a/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
@@ -78,7 +78,7 @@ class PicassoExecutorService extends ThreadPoolExecutor {
   }
 
   private void setThreadCount(int threadCount) {
-    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+    if (Build.VERSION.SDK_INT > 23) {
       setMaximumPoolSize(threadCount);
       setCorePoolSize(threadCount);
     } else {

--- a/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoExecutorService.java
@@ -78,8 +78,13 @@ class PicassoExecutorService extends ThreadPoolExecutor {
   }
 
   private void setThreadCount(int threadCount) {
-    setMaximumPoolSize(threadCount);
-    setCorePoolSize(threadCount);
+    if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M) {
+      setMaximumPoolSize(threadCount);
+      setCorePoolSize(threadCount);
+    } else {
+      setCorePoolSize(threadCount);
+      setMaximumPoolSize(threadCount);
+    }
   }
 
   @Override


### PR DESCRIPTION
Fix in #1323 introduces a new bug related to #1319. There's a check in `ThreadPoolExecutor` that makes the new `setCorePoolSize(N)` `setMaxPoolSize(N)` order crash on Android < N:
```java
public void setMaximumPoolSize(int maximumPoolSize) {
    if (maximumPoolSize <= 0 || maximumPoolSize < corePoolSize)
        throw new IllegalArgumentException();
    this.maximumPoolSize = maximumPoolSize;
    if (workerCountOf(ctl.get()) > maximumPoolSize)
        interruptIdleWorkers();
    }
```
It causes an exception:
```
FATAL EXCEPTION: Picasso-Dispatcher
    Process: com.directed.ubi, PID: 12406
    java.lang.IllegalArgumentException
    at java.util.concurrent.ThreadPoolExecutor.setMaximumPoolSize(ThreadPoolExecutor.java:1633)
    at com.squareup.picasso.PicassoExecutorService.setThreadCount(PicassoExecutorService.java:81)
    at com.squareup.picasso.PicassoExecutorService.adjustThreadCount(PicassoExecutorService.java:44)
    at com.squareup.picasso.Dispatcher.performNetworkStateChange(Dispatcher.java:401)
    at com.squareup.picasso.Dispatcher$DispatcherHandler.handleMessage(Dispatcher.java:521)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:148)
    at android.os.HandlerThread.run(HandlerThread.java:61)
```
To get it thrown, get the phone offline while loading an image.
I added a check for the Android version. Not sure it's the best way to do it, so feel free to suggest better solutions.
