### PR TITLE
Lazy load on AssetManager

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/AssetRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/AssetRequestHandler.java
@@ -29,10 +29,12 @@ class AssetRequestHandler extends RequestHandler {
   private static final int ASSET_PREFIX_LENGTH =
       (SCHEME_FILE + ":///" + ANDROID_ASSET + "/").length();
 
-  private final AssetManager assetManager;
+  private final Context context;
+  private final Object lock = new Object();
+  private AssetManager assetManager;
 
   public AssetRequestHandler(Context context) {
-    assetManager = context.getAssets();
+    this.context = context;
   }
 
   @Override public boolean canHandleRequest(Request data) {
@@ -42,6 +44,13 @@ class AssetRequestHandler extends RequestHandler {
   }
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
+    if (assetManager == null) {
+      synchronized (lock) {
+        if (assetManager == null) {
+          assetManager = context.getAssets();
+        }
+      }
+    }
     InputStream is = assetManager.open(getFilePath(request));
     return new Result(is, DISK);
   }


### PR DESCRIPTION
AssetManager need to be load on demand. Below is a stack trace from the crash report

Caused by java.lang.NullPointerException
> android.app.ContextImpl.getAssets (ContextImpl.java:980)
> android.content.ContextWrapper.getAssets (ContextWrapper.java:88)
> com.squareup.picasso.AssetRequestHandler.<init> (AssetRequestHandler.java:35)
> com.squareup.picasso.Picasso.<init> (Picasso.java:189)
> com.squareup.picasso.Picasso$Builder.build (Picasso.java:848)
> com.myapp.App.onCreate (App.java:72)
> android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1013)

It happens so far on several Android version 4.x.x devices.
Interestingly it only happen on **sync service**, it seems they try to create the App instance but somehow when `ContextImpl.getAssets() `the resources are still null.
see https://android.googlesource.com/platform/frameworks/base/+/android-4.4.2_r2.0.1/core/java/android/app/ContextImpl.java#607

My app are using `Picasso.setSingletonInstance` on `App.onCreate()`, and this is the one which cause the App instantiation failed and lead the NPE.
> Picasso.setSingletonInstance(new Picasso.Builder(this)
>             .downloader(new OkHttpDownloader(picassoOkHttpClient))
>             .build());
> 

It logs
> Fatal Exception: java.lang.RuntimeException
> Unable to create service com.myapp.syncadapter.TopStoriesSyncService: java.lang.RuntimeException: Unable to create application com.myapp.App: java.lang.NullPointerException
