### PR TITLE
Prevent potential integer overflow on devices with 2048MB available heap

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso/Utils.java
@@ -293,7 +293,7 @@ final class Utils {
       memoryClass = ActivityManagerHoneycomb.getLargeMemoryClass(am);
     }
     // Target ~15% of the available heap.
-    return 1024 * 1024 * memoryClass / 7;
+    return (int) (1024L * 1024L * memoryClass / 7);
   }
 
   static boolean isAirplaneModeOn(Context context) {


### PR DESCRIPTION
If device would return 2048MB or more as its large available heap, integer overflow will occur in memory cache size calculation, leading to negative cache size, which could be an unpleasant surprise.
`1024 * 1024 * 2048 == -21...`

There is probably no such device yet. However, `ActivityManager.getLargeMemoryClass()` is often 1/4 of total RAM and since we have already devices with 4GB memory, I believe getting this value in near future is not total sci-fi.

This change moves the overflow heap value threshold up to 14GB, which I think is enough.