### PR TITLE
Fix sample targetSdkVersion

### DIFF
--- a/picasso-sample/build.gradle
+++ b/picasso-sample/build.gradle
@@ -37,7 +37,7 @@ android {
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
-    minSdkVersion rootProject.ext.targetSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
     applicationId 'com.example.picasso'
 
     versionCode 1


### PR DESCRIPTION
There's a small mistake with the sample build.gradle. 
It mistakenly wrote minSdkVersion twice and no targetSdkVersion.