### PR TITLE
Avoid unnecessary call to trimToSize when invalidating cache

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/LruCache.java
+++ b/picasso/src/main/java/com/squareup/picasso/LruCache.java
@@ -132,7 +132,6 @@ public class LruCache implements Cache {
   }
 
   @Override public final synchronized void clearKeyUri(String uri) {
-    boolean sizeChanged = false;
     int uriLength = uri.length();
     for (Iterator<Map.Entry<String, Bitmap>> i = map.entrySet().iterator(); i.hasNext();) {
       Map.Entry<String, Bitmap> entry = i.next();
@@ -142,11 +141,7 @@ public class LruCache implements Cache {
       if (newlineIndex == uriLength && key.substring(0, newlineIndex).equals(uri)) {
         i.remove();
         size -= Utils.getBitmapBytes(value);
-        sizeChanged = true;
       }
-    }
-    if (sizeChanged) {
-      trimToSize(maxSize);
     }
   }
 


### PR DESCRIPTION
Invalidating cached bitmaps doesn't increase the cache size, so I believe we don't need to call trimToSize.