### PR TITLE
Fix wrong minSdkVersion in Sample

### DIFF
--- a/picasso-sample/build.gradle
+++ b/picasso-sample/build.gradle
@@ -37,7 +37,7 @@ android {
 
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersion
-    minSdkVersion rootProject.ext.targetSdkVersion
+    targetSdkVersion rootProject.ext.targetSdkVersion
     applicationId 'com.example.picasso'
 
     versionCode 1

--- a/picasso-sample/lint.xml
+++ b/picasso-sample/lint.xml
@@ -2,6 +2,6 @@
 
 <lint>
   <issue id="NewApi">
-    <ignore path="res/values/styles.xml" />
+    <ignore path="src/main/res/values/styles.xml" />
   </issue>
 </lint>


### PR DESCRIPTION
minSdkVersion was defined twice, second definition was in fact the targetSdkVersion
 
With minSdkVersion restored, Lint reported NewApi issue in styles.xml which should have been ignored but path was incorrect. Travis is now happy!