### PR TITLE
Fix fit() deferred loading for re-sized views

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
@@ -66,7 +66,7 @@ class DeferredRequestCreator implements ViewTreeObserver.OnPreDrawListener {
     int width = target.getWidth();
     int height = target.getHeight();
 
-    if (width <= 0 || height <= 0) {
+    if (width <= 0 || height <= 0 || target.isLayoutRequested()) {
       return true;
     }
 

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -685,7 +685,7 @@ public class RequestCreator {
       }
       int width = target.getWidth();
       int height = target.getHeight();
-      if (width == 0 || height == 0) {
+      if (width == 0 || height == 0 || target.isLayoutRequested()) {
         if (setPlaceholder) {
           setPlaceholder(target, getPlaceholderDrawable());
         }

--- a/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
@@ -150,6 +150,18 @@ public class DeferredRequestCreatorTest {
     verifyZeroInteractions(creator);
   }
 
+  @Test public void waitsForAnotherLayoutIfLayoutRequested() {
+    ImageView target = mockFitImageViewTarget(true);
+    when(target.getWidth()).thenReturn(100);
+    when(target.getHeight()).thenReturn(100);
+    when(target.isLayoutRequested()).thenReturn(true);
+    RequestCreator creator = mock(RequestCreator.class);
+    DeferredRequestCreator request = new DeferredRequestCreator(creator, target);
+    request.onPreDraw();
+    verify(target.getViewTreeObserver(), never()).removeOnPreDrawListener(request);
+    verifyZeroInteractions(creator);
+  }
+
   @Test public void cancelSkipsWithNullTarget() {
     ImageView target = mockFitImageViewTarget(true);
     RequestCreator creator = mock(RequestCreator.class);

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -381,6 +381,17 @@ public class RequestCreatorTest {
   }
 
   @Test
+  public void intoImageViewWithFitAndRequestedLayoutQueuesDeferredImageViewRequest() {
+    ImageView target = mockFitImageViewTarget(true);
+    when(target.getWidth()).thenReturn(100);
+    when(target.getHeight()).thenReturn(100);
+    when(target.isLayoutRequested()).thenReturn(true);
+    new RequestCreator(picasso, URI_1, 0).fit().into(target);
+    verify(picasso, never()).enqueueAndSubmit(any(Action.class));
+    verify(picasso).defer(eq(target), any(DeferredRequestCreator.class));
+  }
+
+  @Test
   public void intoImageViewWithFitAndDimensionsQueuesImageViewRequest() {
     ImageView target = mockFitImageViewTarget(true);
     when(target.getWidth()).thenReturn(100);


### PR DESCRIPTION
Fix issue: https://github.com/square/picasso/issues/1446

Picassos fit() will only defer loading when either the height or the width is 0, this does not work well with re-used and re-measured Views.
This fix additionally checks if a layout has been requested for the given ImageView when deferring and also will not start loading until layout has been done.