### PR TITLE
Clean up varargs warnings.

### DIFF
--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -54,7 +54,7 @@ import static com.squareup.picasso.TestUtils.mockNotification;
 import static com.squareup.picasso.TestUtils.mockRemoteViews;
 import static com.squareup.picasso.TestUtils.mockTarget;
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -633,7 +633,7 @@ public class RequestCreatorTest {
 
   @Test public void nullAdditionalMemoryPolicy() {
     try {
-      new RequestCreator().memoryPolicy(MemoryPolicy.NO_CACHE, null);
+      new RequestCreator().memoryPolicy(MemoryPolicy.NO_CACHE, (MemoryPolicy[]) null);
       fail("Null additional memory policy should throw exception.");
     } catch (IllegalArgumentException ignored) {
     }
@@ -657,7 +657,7 @@ public class RequestCreatorTest {
 
   @Test public void nullAdditionalNetworkPolicy() {
     try {
-      new RequestCreator().networkPolicy(NetworkPolicy.NO_CACHE, null);
+      new RequestCreator().networkPolicy(NetworkPolicy.NO_CACHE, (NetworkPolicy[]) null);
       fail("Null additional network policy should throw exception.");
     } catch (IllegalArgumentException ignored) {
     }


### PR DESCRIPTION
We were already doing the right thing, but this makes it more explicit.

Closes #1463.