### PR TITLE
Plumb Okio stream types into request handlers.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ ext {
   targetSdkVersion = 25
   sourceCompatibilityVersion = JavaVersion.VERSION_1_7
   targetCompatibilityVersion = JavaVersion.VERSION_1_7
-  okhttpVersion = '3.0.1'
+  okhttpVersion = '3.6.0'
   supportLibrariesVersion = '25.1.0'
 
   dep = [

--- a/picasso/src/main/java/com/squareup/picasso/AssetRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/AssetRequestHandler.java
@@ -19,7 +19,8 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.net.Uri;
 import java.io.IOException;
-import java.io.InputStream;
+import okio.Okio;
+import okio.Source;
 
 import static android.content.ContentResolver.SCHEME_FILE;
 import static com.squareup.picasso.Picasso.LoadedFrom.DISK;
@@ -51,8 +52,8 @@ class AssetRequestHandler extends RequestHandler {
         }
       }
     }
-    InputStream is = assetManager.open(getFilePath(request));
-    return new Result(is, DISK);
+    Source source = Okio.source(assetManager.open(getFilePath(request)));
+    return new Result(source, DISK);
   }
 
   static String getFilePath(Request request) {

--- a/picasso/src/main/java/com/squareup/picasso/ContactsPhotoRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContactsPhotoRequestHandler.java
@@ -22,6 +22,7 @@ import android.net.Uri;
 import android.provider.ContactsContract;
 import java.io.IOException;
 import java.io.InputStream;
+import okio.Okio;
 
 import static android.content.ContentResolver.SCHEME_CONTENT;
 import static android.provider.ContactsContract.Contacts.openContactPhotoInputStream;
@@ -66,7 +67,10 @@ class ContactsPhotoRequestHandler extends RequestHandler {
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
     InputStream is = getInputStream(request);
-    return is != null ? new Result(is, DISK) : null;
+    if (is == null) {
+      return null;
+    }
+    return new Result(Okio.source(is), DISK);
   }
 
   private InputStream getInputStream(Request data) throws IOException {

--- a/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/ContentStreamRequestHandler.java
@@ -20,6 +20,8 @@ import android.content.Context;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import okio.Okio;
+import okio.Source;
 
 import static android.content.ContentResolver.SCHEME_CONTENT;
 import static com.squareup.picasso.Picasso.LoadedFrom.DISK;
@@ -36,7 +38,8 @@ class ContentStreamRequestHandler extends RequestHandler {
   }
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
-    return new Result(getInputStream(request), DISK);
+    Source source = Okio.source(getInputStream(request));
+    return new Result(source, DISK);
   }
 
   InputStream getInputStream(Request request) throws FileNotFoundException {

--- a/picasso/src/main/java/com/squareup/picasso/FileRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/FileRequestHandler.java
@@ -19,6 +19,8 @@ import android.content.Context;
 import android.media.ExifInterface;
 import android.net.Uri;
 import java.io.IOException;
+import okio.Okio;
+import okio.Source;
 
 import static android.content.ContentResolver.SCHEME_FILE;
 import static android.media.ExifInterface.ORIENTATION_NORMAL;
@@ -36,7 +38,8 @@ class FileRequestHandler extends ContentStreamRequestHandler {
   }
 
   @Override public Result load(Request request, int networkPolicy) throws IOException {
-    return new Result(null, getInputStream(request), DISK, getFileExifRotation(request.uri));
+    Source source = Okio.source(getInputStream(request));
+    return new Result(null, source, DISK, getFileExifRotation(request.uri));
   }
 
   static int getFileExifRotation(Uri uri) throws IOException {

--- a/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/MediaStoreRequestHandler.java
@@ -23,6 +23,8 @@ import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.provider.MediaStore;
 import java.io.IOException;
+import okio.Okio;
+import okio.Source;
 
 import static android.content.ContentResolver.SCHEME_CONTENT;
 import static android.content.ContentUris.parseId;
@@ -61,7 +63,8 @@ class MediaStoreRequestHandler extends ContentStreamRequestHandler {
     if (request.hasSize()) {
       PicassoKind picassoKind = getPicassoKind(request.targetWidth, request.targetHeight);
       if (!isVideo && picassoKind == FULL) {
-        return new Result(null, getInputStream(request), DISK, exifOrientation);
+        Source source = Okio.source(getInputStream(request));
+        return new Result(null, source, DISK, exifOrientation);
       }
 
       long id = parseId(request.uri);
@@ -89,7 +92,8 @@ class MediaStoreRequestHandler extends ContentStreamRequestHandler {
       }
     }
 
-    return new Result(null, getInputStream(request), DISK, exifOrientation);
+    Source source = Okio.source(getInputStream(request));
+    return new Result(null, source, DISK, exifOrientation);
   }
 
   static PicassoKind getPicassoKind(int targetWidth, int targetHeight) {

--- a/picasso/src/main/java/com/squareup/picasso/NetworkRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkRequestHandler.java
@@ -17,7 +17,6 @@ package com.squareup.picasso;
 
 import android.net.NetworkInfo;
 import java.io.IOException;
-import java.io.InputStream;
 import okhttp3.CacheControl;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
@@ -65,8 +64,7 @@ class NetworkRequestHandler extends RequestHandler {
     if (loadedFrom == NETWORK && body.contentLength() > 0) {
       stats.dispatchDownloadFinished(body.contentLength());
     }
-    InputStream is = body.byteStream();
-    return new Result(is, loadedFrom);
+    return new Result(body.source(), loadedFrom);
   }
 
   @Override int getRetryCount() {

--- a/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestHandler.java
@@ -20,9 +20,8 @@ import android.graphics.BitmapFactory;
 import android.net.NetworkInfo;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-
 import java.io.IOException;
-import java.io.InputStream;
+import okio.Source;
 
 import static com.squareup.picasso.Utils.checkNotNull;
 
@@ -54,39 +53,39 @@ public abstract class RequestHandler {
   public static final class Result {
     private final Picasso.LoadedFrom loadedFrom;
     private final Bitmap bitmap;
-    private final InputStream stream;
+    private final Source source;
     private final int exifOrientation;
 
     public Result(@NonNull Bitmap bitmap, @NonNull Picasso.LoadedFrom loadedFrom) {
       this(checkNotNull(bitmap, "bitmap == null"), null, loadedFrom, 0);
     }
 
-    public Result(@NonNull InputStream stream, @NonNull Picasso.LoadedFrom loadedFrom) {
-      this(null, checkNotNull(stream, "stream == null"), loadedFrom, 0);
+    public Result(@NonNull Source source, @NonNull Picasso.LoadedFrom loadedFrom) {
+      this(null, checkNotNull(source, "source == null"), loadedFrom, 0);
     }
 
     Result(
         @Nullable Bitmap bitmap,
-        @Nullable InputStream stream,
+        @Nullable Source source,
         @NonNull Picasso.LoadedFrom loadedFrom,
         int exifOrientation) {
-      if ((bitmap != null) == (stream != null)) {
+      if ((bitmap != null) == (source != null)) {
         throw new AssertionError();
       }
       this.bitmap = bitmap;
-      this.stream = stream;
+      this.source = source;
       this.loadedFrom = checkNotNull(loadedFrom, "loadedFrom == null");
       this.exifOrientation = exifOrientation;
     }
 
-    /** The loaded {@link Bitmap}. Mutually exclusive with {@link #getStream()}. */
+    /** The loaded {@link Bitmap}. Mutually exclusive with {@link #getSource()}. */
     @Nullable public Bitmap getBitmap() {
       return bitmap;
     }
 
     /** A stream of image data. Mutually exclusive with {@link #getBitmap()}. */
-    @Nullable public InputStream getStream() {
-      return stream;
+    @Nullable public Source getSource() {
+      return source;
     }
 
     /**

--- a/picasso/src/test/java/com/squareup/picasso/OkHttp3DownloaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/OkHttp3DownloaderTest.java
@@ -30,7 +30,10 @@ import org.robolectric.annotation.Config;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
-@Config(shadows = { Shadows.ShadowNetwork.class })
+@Config(
+    sdk = 23, // Works around https://github.com/robolectric/robolectric/issues/2566.
+    shadows = { Shadows.ShadowNetwork.class }
+)
 public class OkHttp3DownloaderTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Rule public MockWebServer server = new MockWebServer();

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -30,6 +30,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.picasso.Picasso.Listener;
@@ -57,6 +58,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(RobolectricGradleTestRunner.class)
+@Config(sdk = 23) // Works around https://github.com/robolectric/robolectric/issues/2566.
 public class PicassoTest {
 
   @Mock Context context;
@@ -280,6 +282,7 @@ public class PicassoTest {
     }
   }
 
+  @Config(sdk = 16) // This test fails on 23 so restore the default level.
   @Test public void cancelExistingRequestWithRemoteViewTarget() {
     int layoutId = 0;
     int viewId = 1;

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -16,8 +16,8 @@
 package com.squareup.picasso;
 
 import android.content.res.Resources;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import okio.Buffer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -72,12 +72,11 @@ public class UtilsTest {
   }
 
   @Test public void detectedWebPFile() throws Exception {
-    assertThat(isWebPFile(new ByteArrayInputStream("RIFFxxxxWEBP".getBytes("US-ASCII")))).isTrue();
-    assertThat(
-        isWebPFile(new ByteArrayInputStream("RIFFxxxxxWEBP".getBytes("US-ASCII")))).isFalse();
-    assertThat(isWebPFile(new ByteArrayInputStream("ABCDxxxxWEBP".getBytes("US-ASCII")))).isFalse();
-    assertThat(isWebPFile(new ByteArrayInputStream("RIFFxxxxABCD".getBytes("US-ASCII")))).isFalse();
-    assertThat(isWebPFile(new ByteArrayInputStream("RIFFxxWEBP".getBytes("US-ASCII")))).isFalse();
+    assertThat(isWebPFile(new Buffer().writeUtf8("RIFFxxxxWEBP"))).isTrue();
+    assertThat(isWebPFile(new Buffer().writeUtf8("RIFFxxxxxWEBP"))).isFalse();
+    assertThat(isWebPFile(new Buffer().writeUtf8("ABCDxxxxWEBP"))).isFalse();
+    assertThat(isWebPFile(new Buffer().writeUtf8("RIFFxxxxABCD"))).isFalse();
+    assertThat(isWebPFile(new Buffer().writeUtf8("RIFFxxWEBP"))).isFalse();
   }
 
   @Test public void ensureBuilderIsCleared() throws Exception {


### PR DESCRIPTION
This simplifies a ton of byte-management operations like checking for webp or even converting to a byte[].

@swankjesse 