### PR TITLE
Avoiding the reboot issue of Samsung Android 4.4

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RemoteViewsAction.java
+++ b/picasso/src/main/java/com/squareup/picasso/RemoteViewsAction.java
@@ -19,6 +19,7 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.appwidget.AppWidgetManager;
 import android.graphics.Bitmap;
+import android.os.Build;
 import android.widget.RemoteViews;
 
 import static android.content.Context.NOTIFICATION_SERVICE;
@@ -134,7 +135,17 @@ abstract class RemoteViewsAction extends Action<RemoteViewsAction.RemoteViewsTar
 
     @Override void update() {
       NotificationManager manager = getService(picasso.context, NOTIFICATION_SERVICE);
-      manager.notify(notificationTag, notificationId, notification);
+      try {
+        manager.notify(notificationTag, notificationId, notification);
+      } catch (RuntimeException e) {
+        if ((Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT)
+            && (Build.MANUFACTURER.equalsIgnoreCase("samsung"))
+            && ("bad array lengths".equalsIgnoreCase(e.getMessage()))) {
+          // Avoiding the reboot issue of Samsung Android 4.4
+        } else {
+          throw e;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Resolved #1511 

According to the following references, Samsung Android 4.4 only applies exception handling.
 
https://github.com/wordpress-mobile/WordPress-Android/pull/2895
http://stackoverflow.com/questions/25415069/bad-array-lengths-notification-manager-causes-phone-crash-on-4-4
https://code.google.com/p/android/issues/detail?id=75096

