### PR TITLE
Allow onlyScaleDown() with fit() method

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso/Request.java
@@ -390,9 +390,6 @@ public final class Request {
      * specified by {@link #resize(int, int)}.
      */
     public Builder onlyScaleDown() {
-      if (targetHeight == 0 && targetWidth == 0) {
-        throw new IllegalStateException("onlyScaleDown can not be applied without resize");
-      }
       onlyScaleDown = true;
       return this;
     }
@@ -499,6 +496,10 @@ public final class Request {
       if (centerInside && (targetWidth == 0 && targetHeight == 0)) {
         throw new IllegalStateException(
             "Center inside requires calling resize with positive width and height.");
+      }
+      if (onlyScaleDown && (targetWidth == 0 && targetHeight == 0)) {
+        throw new IllegalStateException(
+            "onlyScaleDown requires calling resize with positive width and height.");
       }
       if (priority == null) {
         priority = Priority.NORMAL;

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -402,6 +402,16 @@ public class RequestCreatorTest {
   }
 
   @Test
+  public void intoImageViewWithFitAndOnlyScaleDown() {
+    ImageView target = mockFitImageViewTarget(true);
+    when(target.getWidth()).thenReturn(100);
+    when(target.getHeight()).thenReturn(100);
+    new RequestCreator(picasso, URI_1, 0).fit().onlyScaleDown().into(target);
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().getRequest().onlyScaleDown).isTrue();
+  }
+
+  @Test
   public void intoImageViewWithFitAndResizeThrows() {
     try {
       ImageView target = mockImageViewTarget();
@@ -544,7 +554,7 @@ public class RequestCreatorTest {
   }
 
   @Test
-  public void intoTargetNoResizeWithCenterInsideOrCenterCropThrows() {
+  public void intoTargetNoResizeWithCenterInsideOrCenterCropOrOnlyScaleDownThrows() {
     try {
       new RequestCreator(picasso, URI_1, 0).centerInside().into(mockTarget());
       fail("Center inside with unknown width should throw exception.");
@@ -553,6 +563,11 @@ public class RequestCreatorTest {
     try {
       new RequestCreator(picasso, URI_1, 0).centerCrop().into(mockTarget());
       fail("Center inside with unknown height should throw exception.");
+    } catch (IllegalStateException ignored) {
+    }
+    try {
+      new RequestCreator(picasso, URI_1, 0).onlyScaleDown().into(mockTarget());
+      fail("onlyScaleDown with unknown height should throw exception.");
     } catch (IllegalStateException ignored) {
     }
   }


### PR DESCRIPTION
onlyScaleDown() method is so useful to avoid useless bitmap scale up for memory usage and performance.

This PR allows that onlyScaleDown() works with fit() method like centerCrop()/centerInside().

Refer to #941 