### PR TITLE
Remove static synthetic accessor method.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -586,7 +586,7 @@ public class Picasso {
     }
   }
 
-  private void cancelExistingRequest(Object target) {
+  void cancelExistingRequest(Object target) {
     checkMain();
     Action action = targetToAction.remove(target);
     if (action != null) {


### PR DESCRIPTION
The method is used in an anonymous inner class here:
https://github.com/square/picasso/blob/5351f2f6718788540c18a362eb79cde00aaac5d7/picasso/src/main/java/com/squareup/picasso/Picasso.java#L131