### PR TITLE
Retrieve Context from a ContentProvider

### DIFF
--- a/picasso-sample/src/main/java/com/example/picasso/PicassoSampleActivity.java
+++ b/picasso-sample/src/main/java/com/example/picasso/PicassoSampleActivity.java
@@ -45,7 +45,7 @@ abstract class PicassoSampleActivity extends FragmentActivity {
   @Override
   protected void onDestroy() {
     super.onDestroy();
-    Picasso.with(this).cancelTag(this);
+    Picasso.with().cancelTag(this);
   }
 
   @Override public void onBackPressed() {

--- a/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.java
@@ -44,7 +44,7 @@ final class PicassoSampleAdapter extends BaseAdapter {
         notificationManager.notify(NOTIFICATION_ID, notification);
 
         // Now load an image for this notification.
-        Picasso.with(activity) //
+        Picasso.with() //
             .load(Data.URLS[new Random().nextInt(Data.URLS.length)]) //
             .resizeDimen(R.dimen.notification_icon_width_height,
                 R.dimen.notification_icon_width_height) //

--- a/picasso-sample/src/main/java/com/example/picasso/SampleContactsAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleContactsAdapter.java
@@ -58,7 +58,7 @@ class SampleContactsAdapter extends CursorAdapter {
     holder.text1.setText(cursor.getString(ContactsQuery.DISPLAY_NAME));
     holder.icon.assignContactUri(contactUri);
 
-    Picasso.with(context)
+    Picasso.with()
         .load(contactUri)
         .placeholder(R.drawable.contact_picture_placeholder)
         .tag(context)

--- a/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.java
@@ -49,7 +49,7 @@ public class SampleGalleryActivity extends PicassoSampleActivity {
       // This ensures that the anonymous callback we have does not prevent the activity from
       // being garbage collected. It also prevents our callback from getting invoked even after the
       // activity has finished.
-      Picasso.with(this).cancelRequest(imageView);
+      Picasso.with().cancelRequest(imageView);
     }
   }
 
@@ -71,7 +71,7 @@ public class SampleGalleryActivity extends PicassoSampleActivity {
     // Index 1 is the progress bar. Show it while we're loading the image.
     animator.setDisplayedChild(1);
 
-    Picasso.with(this).load(image).fit().centerInside().into(imageView, new EmptyCallback() {
+    Picasso.with().load(image).fit().centerInside().into(imageView, new EmptyCallback() {
       @Override public void onSuccess() {
         // Index 0 is the image view.
         animator.setDisplayedChild(0);

--- a/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGridViewAdapter.java
@@ -39,7 +39,7 @@ final class SampleGridViewAdapter extends BaseAdapter {
     String url = getItem(position);
 
     // Trigger the download of the URL asynchronously into the image view.
-    Picasso.with(context) //
+    Picasso.with() //
         .load(url) //
         .placeholder(R.drawable.placeholder) //
         .error(R.drawable.error) //

--- a/picasso-sample/src/main/java/com/example/picasso/SampleListDetailActivity.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleListDetailActivity.java
@@ -81,7 +81,7 @@ public class SampleListDetailActivity extends PicassoSampleActivity {
       String url = arguments.getString(KEY_URL);
 
       urlView.setText(url);
-      Picasso.with(activity)
+      Picasso.with()
           .load(url)
           .fit()
           .tag(activity)

--- a/picasso-sample/src/main/java/com/example/picasso/SampleListDetailAdapter.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleListDetailAdapter.java
@@ -39,7 +39,7 @@ final class SampleListDetailAdapter extends BaseAdapter {
     holder.text.setText(url);
 
     // Trigger the download of the URL asynchronously into the image view.
-    Picasso.with(context)
+    Picasso.with()
         .load(url)
         .placeholder(R.drawable.placeholder)
         .error(R.drawable.error)

--- a/picasso-sample/src/main/java/com/example/picasso/SampleScrollListener.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleScrollListener.java
@@ -14,7 +14,7 @@ public class SampleScrollListener implements AbsListView.OnScrollListener {
 
   @Override
   public void onScrollStateChanged(AbsListView view, int scrollState) {
-    final Picasso picasso = Picasso.with(context);
+    final Picasso picasso = Picasso.with();
     if (scrollState == SCROLL_STATE_IDLE || scrollState == SCROLL_STATE_TOUCH_SCROLL) {
       picasso.resumeTag(context);
     } else {

--- a/picasso-sample/src/main/java/com/example/picasso/SampleWidgetProvider.java
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleWidgetProvider.java
@@ -29,7 +29,7 @@ public class SampleWidgetProvider extends AppWidgetProvider {
       int[] appWidgetIds) {
     RemoteViews updateViews = new RemoteViews(context.getPackageName(), R.layout.sample_widget);
     // Load image for all appWidgetIds.
-    Picasso picasso = Picasso.with(context);
+    Picasso picasso = Picasso.with();
     picasso.load(Data.URLS[new Random().nextInt(Data.URLS.length)]) //
         .placeholder(R.drawable.placeholder) //
         .error(R.drawable.error) //

--- a/picasso/src/main/AndroidManifest.xml
+++ b/picasso/src/main/AndroidManifest.xml
@@ -1,1 +1,10 @@
-<manifest package="com.squareup.picasso"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.squareup.picasso">
+
+  <application>
+    <provider
+        android:name=".PicassoProvider"
+        android:authorities="${applicationId}.com.squareup.picasso"
+        android:exported="false"/>
+  </application>
+</manifest>

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -29,7 +29,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
-
 import java.io.File;
 import java.lang.ref.ReferenceQueue;
 import java.util.ArrayList;
@@ -59,7 +58,7 @@ import static com.squareup.picasso.Utils.log;
 /**
  * Image downloading, transformation, and caching manager.
  * <p>
- * Use {@link #with(android.content.Context)} for the global singleton instance or construct your
+ * Use {@link #with()} for the global singleton instance or construct your
  * own instance with {@link Builder}.
  */
 public class Picasso {
@@ -674,16 +673,9 @@ public class Picasso {
    * {@link Picasso} instance. You can either use this directly or by setting it as the global
    * instance with {@link #setSingletonInstance}.
    */
-  public static Picasso with(@NonNull Context context) {
-    if (context == null) {
-      throw new IllegalArgumentException("context == null");
-    }
+  public static Picasso with() {
     if (singleton == null) {
-      synchronized (Picasso.class) {
-        if (singleton == null) {
-          singleton = new Builder(context).build();
-        }
-      }
+      throw new IllegalStateException("Singleton was not initialized.");
     }
     return singleton;
   }

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -58,8 +58,8 @@ import static com.squareup.picasso.Utils.log;
 /**
  * Image downloading, transformation, and caching manager.
  * <p>
- * Use {@link #with()} for the global singleton instance or construct your
- * own instance with {@link Builder}.
+ * Use {@link #with(android.content.Context)} or {@link #with()} for the global singleton instance
+ * or construct your own instance with {@link Builder}.
  */
 public class Picasso {
 
@@ -673,11 +673,28 @@ public class Picasso {
    * {@link Picasso} instance. You can either use this directly or by setting it as the global
    * instance with {@link #setSingletonInstance}.
    */
-  public static Picasso with() {
+  public static Picasso with(@NonNull Context context) {
+    if (context == null) {
+      throw new IllegalArgumentException("context == null");
+    }
     if (singleton == null) {
-      throw new IllegalStateException("Singleton was not initialized.");
+      synchronized (Picasso.class) {
+        if (singleton == null) {
+          singleton = new Builder(context).build();
+        }
+      }
     }
     return singleton;
+  }
+
+  /**
+   * The global default {@link Picasso} instance.
+   * <p>
+   * This instance is created by passing a global context from startup into {@link #with(Context)}.
+   * </p>
+   */
+  public static Picasso with() {
+    return with(PicassoProvider.context);
   }
 
   /**

--- a/picasso/src/main/java/com/squareup/picasso/PicassoProvider.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2017 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public class PicassoProvider extends ContentProvider {
+  @Override public boolean onCreate() {
+    Picasso.setSingletonInstance(new Picasso.Builder(getContext()).build());
+    return true;
+  }
+
+  @Nullable @Override
+  public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection,
+      @Nullable String[] selectionArgs, @Nullable String sortOrder) {
+    return null;
+  }
+
+  @Nullable @Override public String getType(@NonNull Uri uri) {
+    return null;
+  }
+
+  @Nullable @Override public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
+    return null;
+  }
+
+  @Override public int delete(@NonNull Uri uri, @Nullable String selection,
+      @Nullable String[] selectionArgs) {
+    return 0;
+  }
+
+  @Override
+  public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection,
+      @Nullable String[] selectionArgs) {
+    return 0;
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso/PicassoProvider.java
+++ b/picasso/src/main/java/com/squareup/picasso/PicassoProvider.java
@@ -17,14 +17,22 @@ package com.squareup.picasso;
 
 import android.content.ContentProvider;
 import android.content.ContentValues;
+import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RestrictTo;
 
-public class PicassoProvider extends ContentProvider {
+import static android.support.annotation.RestrictTo.Scope.LIBRARY;
+
+@RestrictTo(LIBRARY)
+public final class PicassoProvider extends ContentProvider {
+
+  static Context context;
+
   @Override public boolean onCreate() {
-    Picasso.setSingletonInstance(new Picasso.Builder(getContext()).build());
+    context = getContext();
     return true;
   }
 

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -352,7 +352,7 @@ public class PicassoTest {
   @Test public void shutdownDisallowedOnSingletonInstance() {
     Picasso.singleton = null;
     try {
-      Picasso picasso = Picasso.with(RuntimeEnvironment.application);
+      Picasso picasso = Picasso.with();
       picasso.shutdown();
       fail("Calling shutdown() on static singleton instance should throw");
     } catch (UnsupportedOperationException expected) {
@@ -399,7 +399,7 @@ public class PicassoTest {
     Picasso.singleton = null;
 
     // Implicitly create the default singleton instance.
-    Picasso.with(RuntimeEnvironment.application);
+    Picasso.with();
 
     Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application).build();
     try {
@@ -414,7 +414,7 @@ public class PicassoTest {
     Picasso.singleton = null;
     Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application).build();
     Picasso.setSingletonInstance(picasso);
-    assertThat(Picasso.with(RuntimeEnvironment.application)).isSameAs(picasso);
+    assertThat(Picasso.with()).isSameAs(picasso);
   }
 
   @Test public void shutdownClearsDeferredRequests() {

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -352,7 +352,7 @@ public class PicassoTest {
   @Test public void shutdownDisallowedOnSingletonInstance() {
     Picasso.singleton = null;
     try {
-      Picasso picasso = Picasso.with();
+      Picasso picasso = Picasso.with(RuntimeEnvironment.application);
       picasso.shutdown();
       fail("Calling shutdown() on static singleton instance should throw");
     } catch (UnsupportedOperationException expected) {
@@ -399,7 +399,7 @@ public class PicassoTest {
     Picasso.singleton = null;
 
     // Implicitly create the default singleton instance.
-    Picasso.with();
+    Picasso.with(RuntimeEnvironment.application);
 
     Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application).build();
     try {
@@ -414,7 +414,7 @@ public class PicassoTest {
     Picasso.singleton = null;
     Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application).build();
     Picasso.setSingletonInstance(picasso);
-    assertThat(Picasso.with()).isSameAs(picasso);
+    assertThat(Picasso.with(RuntimeEnvironment.application)).isSameAs(picasso);
   }
 
   @Test public void shutdownClearsDeferredRequests() {


### PR DESCRIPTION
Remove the need to have the context passed-in on `Picasso.with()`.

https://github.com/square/picasso/issues/1634