### PR TITLE
Recycle trimmed and old bitmaps.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/LruCache.java
+++ b/picasso/src/main/java/com/squareup/picasso/LruCache.java
@@ -85,6 +85,9 @@ public class LruCache implements Cache {
       if (previous != null) {
         size -= Utils.getBitmapBytes(previous);
       }
+      if (previous != null && previous != bitmap) {
+        previous.recycle();
+      }
     }
 
     trimToSize(maxSize);
@@ -109,6 +112,7 @@ public class LruCache implements Cache {
         value = toEvict.getValue();
         map.remove(key);
         size -= Utils.getBitmapBytes(value);
+        value.recycle();
         evictionCount++;
       }
     }
@@ -141,6 +145,7 @@ public class LruCache implements Cache {
       if (newlineIndex == uriLength && key.substring(0, newlineIndex).equals(uri)) {
         i.remove();
         size -= Utils.getBitmapBytes(value);
+        value.recycle();
       }
     }
   }

--- a/picasso/src/test/java/com/squareup/picasso/LruCacheTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/LruCacheTest.java
@@ -27,6 +27,8 @@ import org.robolectric.RobolectricGradleTestRunner;
 
 import static android.graphics.Bitmap.Config.ALPHA_8;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -194,6 +196,27 @@ public class LruCacheTest {
     assertHit(cache, "16", size16);
     assertMiss(cache, "25");
     assertEquals(cache.size(), 16);
+  }
+
+  @Test public void recycleOld() {
+    LruCache cache = new LruCache(36);
+    Bitmap size25 = Bitmap.createBitmap(5, 5, ALPHA_8);
+    Bitmap size36 = Bitmap.createBitmap(6, 6, ALPHA_8);
+
+    cache.set("25", size25);
+    cache.set("36", size36);
+
+    assertTrue(size25.isRecycled());
+  }
+
+  @Test public void notRecycleTheSame() {
+    LruCache cache = new LruCache(25);
+    Bitmap size25 = Bitmap.createBitmap(5, 5, ALPHA_8);
+
+    cache.set("25", size25);
+    cache.set("25", size25);
+
+    assertFalse(size25.isRecycled());
   }
 
   private void assertHit(LruCache cache, String key, Bitmap value) {


### PR DESCRIPTION
This helps eliminate out of memory crashes and exceeded memory consumption.