### PR TITLE
Migrate from Fest to Truth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-26.0.1
+    - build-tools-26.0.2
     - android-26
 
 jdk:

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
   compileSdkVersion = 26
-  buildToolsVersion = '26.0.1'
+  buildToolsVersion = '26.0.2'
   minSdkVersion = 14
   targetSdkVersion = 26
   sourceCompatibilityVersion = JavaVersion.VERSION_1_7
@@ -9,15 +9,14 @@ ext {
   supportLibrariesVersion = '26.0.1'
 
   dep = [
-      androidPlugin      : 'com.android.tools.build:gradle:3.0.0-beta2',
+      androidPlugin      : 'com.android.tools.build:gradle:3.0.0-beta7',
       okhttp             : "com.squareup.okhttp3:okhttp:$okhttpVersion",
       mockWebServer      : "com.squareup.okhttp3:mockwebserver:$okhttpVersion",
       pollexor           : 'com.squareup:pollexor:2.0.4',
       supportV4          : "com.android.support:support-v4:$supportLibrariesVersion",
       supportAnnotations : "com.android.support:support-annotations:$supportLibrariesVersion",
       junit              : 'junit:junit:4.12',
-      fest               : 'org.easytesting:fest-assert-core:2.0M10',
-      festAndroid        : 'com.squareup:fest-android:1.0.6',
+      truth              : 'com.google.truth:truth:0.36',
       robolectric        : 'org.robolectric:robolectric:3.1',
       mockito            : 'org.mockito:mockito-core:1.9.5'
   ]

--- a/picasso-pollexor/build.gradle
+++ b/picasso-pollexor/build.gradle
@@ -36,8 +36,7 @@ dependencies {
   compileOnly dep.supportAnnotations
   testImplementation dep.junit
   testImplementation dep.robolectric
-  testImplementation dep.fest
-  testImplementation dep.festAndroid
+  testImplementation dep.truth
   testImplementation dep.pollexor
 }
 

--- a/picasso-pollexor/src/test/java/com/squareup/picasso/pollexor/PollexorRequestTransformerTest.java
+++ b/picasso-pollexor/src/test/java/com/squareup/picasso/pollexor/PollexorRequestTransformerTest.java
@@ -3,16 +3,15 @@ package com.squareup.picasso.pollexor;
 import android.net.Uri;
 import com.squareup.picasso.Request;
 import com.squareup.pollexor.Thumbor;
-import com.squareup.pollexor.ThumborUrlBuilder;
 import com.squareup.pollexor.ThumborUrlBuilder.ImageFormat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Picasso.RequestTransformer;
 import static com.squareup.pollexor.ThumborUrlBuilder.format;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.robolectric.annotation.Config.NONE;
 
 @RunWith(RobolectricGradleTestRunner.class)

--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -36,8 +36,7 @@ dependencies {
   api dep.okhttp
   compileOnly dep.supportAnnotations
   testImplementation dep.junit
-  testImplementation dep.fest
-  testImplementation dep.festAndroid
+  testImplementation dep.truth
   testImplementation dep.supportV4
   testImplementation dep.robolectric
   testImplementation dep.mockito

--- a/picasso/src/test/java/com/squareup/picasso/AssetRequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/AssetRequestHandlerTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricGradleTestRunner;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 @RunWith(RobolectricGradleTestRunner.class)

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -389,8 +389,7 @@ public class BitmapHunterTest {
         dispatcher, cache, stats, action1);
     hunter.attach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);
-    assertThat(hunter.getActions()).hasSize(1);
-    assertThat(hunter.getActions()).contains(action2);
+    assertThat(hunter.getActions()).containsExactly(action2);
     assertThat(hunter.getPriority()).isEqualTo(HIGH);
   }
 
@@ -401,8 +400,7 @@ public class BitmapHunterTest {
         dispatcher, cache, stats, action1);
     hunter.attach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);
-    assertThat(hunter.getActions()).hasSize(1);
-    assertThat(hunter.getActions()).contains(action2);
+    assertThat(hunter.getActions()).containsExactly(action2);
     assertThat(hunter.getPriority()).isEqualTo(HIGH);
     hunter.detach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);

--- a/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/BitmapHunterTest.java
@@ -39,6 +39,7 @@ import static android.media.ExifInterface.ORIENTATION_FLIP_VERTICAL;
 import static android.media.ExifInterface.ORIENTATION_ROTATE_90;
 import static android.media.ExifInterface.ORIENTATION_TRANSPOSE;
 import static android.media.ExifInterface.ORIENTATION_TRANSVERSE;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.BitmapHunter.forRequest;
 import static com.squareup.picasso.BitmapHunter.transformResult;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
@@ -71,10 +72,7 @@ import static com.squareup.picasso.TestUtils.makeBitmap;
 import static com.squareup.picasso.TestUtils.mockAction;
 import static com.squareup.picasso.TestUtils.mockImageViewTarget;
 import static com.squareup.picasso.TestUtils.mockPicasso;
-import static org.fest.assertions.api.ANDROID.assertThat;
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.entry;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -210,7 +208,8 @@ public class BitmapHunterTest {
     BitmapHunter hunter = new TestableBitmapHunter(picasso, dispatcher, cache, stats, action1);
     assertThat(hunter.actions).isNull();
     hunter.attach(action2);
-    assertThat(hunter.actions).isNotNull().hasSize(1);
+    assertThat(hunter.actions).isNotNull();
+    assertThat(hunter.actions).hasSize(1);
   }
 
   @Test public void detachSingleRequest() {
@@ -228,7 +227,8 @@ public class BitmapHunterTest {
     hunter.attach(action2);
     hunter.detach(action2);
     assertThat(hunter.action).isNotNull();
-    assertThat(hunter.actions).isNotNull().isEmpty();
+    assertThat(hunter.actions).isNotNull();
+    assertThat(hunter.actions).isEmpty();
     hunter.detach(action);
     assertThat(hunter.action).isNull();
   }
@@ -389,7 +389,8 @@ public class BitmapHunterTest {
         dispatcher, cache, stats, action1);
     hunter.attach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);
-    assertThat(hunter.getActions()).hasSize(1).contains(action2);
+    assertThat(hunter.getActions()).hasSize(1);
+    assertThat(hunter.getActions()).contains(action2);
     assertThat(hunter.getPriority()).isEqualTo(HIGH);
   }
 
@@ -400,7 +401,8 @@ public class BitmapHunterTest {
         dispatcher, cache, stats, action1);
     hunter.attach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);
-    assertThat(hunter.getActions()).hasSize(1).contains(action2);
+    assertThat(hunter.getActions()).hasSize(1);
+    assertThat(hunter.getActions()).contains(action2);
     assertThat(hunter.getPriority()).isEqualTo(HIGH);
     hunter.detach(action2);
     assertThat(hunter.getAction()).isEqualTo(action1);
@@ -417,7 +419,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("rotate 90.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("rotate 90.0");
   }
 
  @Test public void exifRotationSizing() throws Exception {
@@ -489,8 +491,8 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPostOperations()).containsOnly("scale -1.0 1.0");
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("rotate 180.0");
+    assertThat(shadowMatrix.getPostOperations()).containsExactly("scale -1.0 1.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("rotate 180.0");
   }
 
   @Test public void exifHorizontalFlip() {
@@ -502,7 +504,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPostOperations()).containsOnly("scale -1.0 1.0");
+    assertThat(shadowMatrix.getPostOperations()).containsExactly("scale -1.0 1.0");
     assertThat(shadowMatrix.getPreOperations()).doesNotContain("rotate 180.0");
     assertThat(shadowMatrix.getPreOperations()).doesNotContain("rotate 90.0");
     assertThat(shadowMatrix.getPreOperations()).doesNotContain("rotate 270.0");
@@ -517,8 +519,8 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPostOperations()).containsOnly("scale -1.0 1.0");
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("rotate 90.0");
+    assertThat(shadowMatrix.getPostOperations()).containsExactly("scale -1.0 1.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("rotate 90.0");
   }
 
   @Test public void exifTransverse() {
@@ -530,8 +532,8 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPostOperations()).containsOnly("scale -1.0 1.0");
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("rotate 270.0");
+    assertThat(shadowMatrix.getPostOperations()).containsExactly("scale -1.0 1.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("rotate 270.0");
   }
 
   @Test public void keepsAspectRationWhileResizingWhenDesiredWidthIs0() {
@@ -543,7 +545,7 @@ public class BitmapHunterTest {
     ShadowBitmap shadowBitmap = shadowOf(result);
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.5 0.5");
   }
 
   @Test public void keepsAspectRationWhileResizingWhenDesiredHeightIs0() {
@@ -555,7 +557,7 @@ public class BitmapHunterTest {
     ShadowBitmap shadowBitmap = shadowOf(result);
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.5 0.5");
   }
 
   @Test public void centerCropResultMatchesTargetSize() {
@@ -674,8 +676,8 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("rotate 90.0");
-    assertThat(shadowMatrix.getSetOperations()).contains(entry("rotate", "-45.0"));
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("rotate 90.0");
+    assertThat(shadowMatrix.getSetOperations()).containsEntry("rotate", "-45.0");
   }
 
   @Test public void rotation() {
@@ -689,7 +691,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getSetOperations()).contains(entry("rotate", "-45.0"));
+    assertThat(shadowMatrix.getSetOperations()).containsEntry("rotate", "-45.0");
   }
 
   @Test public void pivotRotation() {
@@ -703,7 +705,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getSetOperations()).contains(entry("rotate", "-45.0 10.0 10.0"));
+    assertThat(shadowMatrix.getSetOperations()).containsEntry("rotate", "-45.0 10.0 10.0");
   }
 
   @Test public void resize() {
@@ -717,7 +719,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.0 1.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 2.0 1.5");
   }
 
   @Test public void centerCropTallTooSmall() {
@@ -735,7 +737,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 4.0 4.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 4.0 4.0");
   }
 
   @Test public void centerCropTallTooLarge() {
@@ -753,7 +755,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.5 0.5");
   }
 
   @Test public void centerCropWideTooSmall() {
@@ -771,7 +773,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 4.0 4.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 4.0 4.0");
   }
 
   @Test public void centerCropWithGravityHorizontalLeft() {
@@ -789,7 +791,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 4.0 4.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 4.0 4.0");
   }
 
   @Test public void centerCropWithGravityHorizontalRight() {
@@ -807,7 +809,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 4.0 4.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 4.0 4.0");
   }
 
   @Test public void centerCropWithGravityVerticalTop() {
@@ -825,7 +827,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 4.0 4.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 4.0 4.0");
   }
 
   @Test public void centerCropWithGravityVerticalBottom() {
@@ -843,7 +845,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 4.0 4.0");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 4.0 4.0");
   }
 
   @Test public void centerCropWideTooLarge() {
@@ -861,7 +863,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.5 0.5");
   }
 
   @Test public void centerInsideTallTooSmall() {
@@ -875,7 +877,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.5 2.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 2.5 2.5");
   }
 
   @Test public void centerInsideTallTooLarge() {
@@ -889,7 +891,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.5 0.5");
   }
 
   @Test public void centerInsideWideTooSmall() {
@@ -903,7 +905,7 @@ public class BitmapHunterTest {
 
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 2.5 2.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 2.5 2.5");
   }
 
   @Test public void centerInsideWideTooLarge() {
@@ -918,7 +920,7 @@ public class BitmapHunterTest {
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
 
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.5 0.5");
   }
 
   @Test public void onlyScaleDownOriginalBigger() {
@@ -932,7 +934,7 @@ public class BitmapHunterTest {
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
 
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.5 0.5");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.5 0.5");
   }
 
   @Test public void onlyScaleDownOriginalSmaller() {
@@ -977,7 +979,7 @@ public class BitmapHunterTest {
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
 
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.8 0.8");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.8 0.8");
   }
 
   @Test public void onlyScaleDownOriginalBiggerHeightIs0() {
@@ -991,14 +993,15 @@ public class BitmapHunterTest {
     Matrix matrix = shadowBitmap.getCreatedFromMatrix();
     ShadowMatrix shadowMatrix = shadowOf(matrix);
 
-    assertThat(shadowMatrix.getPreOperations()).containsOnly("scale 0.8 0.8");
+    assertThat(shadowMatrix.getPreOperations()).containsExactly("scale 0.8 0.8");
   }
 
   @Test public void reusedBitmapIsNotRecycled() {
     Request data = new Request.Builder(URI_1).build();
     Bitmap source = Bitmap.createBitmap(10, 10, ARGB_8888);
     Bitmap result = transformResult(data, source, 0);
-    assertThat(result).isSameAs(source).isNotRecycled();
+    assertThat(result).isSameAs(source);
+    assertThat(result.isRecycled()).isFalse();
   }
 
   @Test public void crashingOnTransformationThrows() {
@@ -1017,7 +1020,7 @@ public class BitmapHunterTest {
       BitmapHunter.applyCustomTransformations(transformations, original);
       fail("Expected exception to be thrown.");
     } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Transformation " + badTransformation.key() + " crashed with exception.");
+      assertThat(e).hasMessageThat().isEqualTo("Transformation " + badTransformation.key() + " crashed with exception.");
     }
   }
 
@@ -1037,7 +1040,7 @@ public class BitmapHunterTest {
       BitmapHunter.applyCustomTransformations(transformations, original);
       fail("Expected exception to be thrown.");
     } catch (RuntimeException e) {
-      assertThat(e).hasMessageContaining(
+      assertThat(e).hasMessageThat().contains(
           "Transformation " + badTransformation.key() + " returned null");
     }
   }
@@ -1059,7 +1062,7 @@ public class BitmapHunterTest {
       BitmapHunter.applyCustomTransformations(transformations, original);
       fail("Expected exception to be thrown.");
     } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Transformation "
+      assertThat(e).hasMessageThat().isEqualTo("Transformation "
           + badTransformation.key()
           + " mutated input Bitmap but failed to recycle the original.");
     }
@@ -1082,7 +1085,7 @@ public class BitmapHunterTest {
       BitmapHunter.applyCustomTransformations(transformations, original);
       fail("Expected exception to be thrown.");
     } catch (RuntimeException e) {
-      assertThat(e).hasMessage("Transformation "
+      assertThat(e).hasMessageThat().isEqualTo("Transformation "
           + badTransformation.key()
           + " returned input Bitmap but recycled it.");
     }

--- a/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
@@ -24,11 +24,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.robolectric.RobolectricTestRunner;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.TestUtils.TRANSFORM_REQUEST_ANSWER;
 import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.mockCallback;
 import static com.squareup.picasso.TestUtils.mockFitImageViewTarget;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -235,8 +235,7 @@ public class DispatcherTest {
     dispatcher.pausedTags.add("tag");
     dispatcher.pausedActions.put(action.getTarget(), action);
     dispatcher.performCancel(action);
-    assertThat(dispatcher.pausedTags).hasSize(1);
-    assertThat(dispatcher.pausedTags).contains("tag");
+    assertThat(dispatcher.pausedTags).containsExactly("tag");
     assertThat(dispatcher.pausedActions).isEmpty();
     verify(hunter).detach(action);
   }
@@ -441,8 +440,7 @@ public class DispatcherTest {
 
   @Test public void performPauseAndResumeUpdatesListOfPausedTags() {
     dispatcher.performPauseTag("tag");
-    assertThat(dispatcher.pausedTags).hasSize(1);
-    assertThat(dispatcher.pausedTags).contains("tag");
+    assertThat(dispatcher.pausedTags).containsExactly("tag");
     dispatcher.performResumeTag("tag");
     assertThat(dispatcher.pausedTags).isEmpty();
   }

--- a/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DispatcherTest.java
@@ -36,6 +36,7 @@ import static android.content.Intent.ACTION_AIRPLANE_MODE_CHANGED;
 import static android.content.pm.PackageManager.PERMISSION_DENIED;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.net.ConnectivityManager.CONNECTIVITY_ACTION;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Dispatcher.NetworkBroadcastReceiver;
 import static com.squareup.picasso.Dispatcher.NetworkBroadcastReceiver.EXTRA_AIRPLANE_STATE;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
@@ -50,7 +51,6 @@ import static com.squareup.picasso.TestUtils.mockHunter;
 import static com.squareup.picasso.TestUtils.mockNetworkInfo;
 import static com.squareup.picasso.TestUtils.mockPicasso;
 import static com.squareup.picasso.TestUtils.mockTarget;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
@@ -235,7 +235,8 @@ public class DispatcherTest {
     dispatcher.pausedTags.add("tag");
     dispatcher.pausedActions.put(action.getTarget(), action);
     dispatcher.performCancel(action);
-    assertThat(dispatcher.pausedTags).hasSize(1).contains("tag");
+    assertThat(dispatcher.pausedTags).hasSize(1);
+    assertThat(dispatcher.pausedTags).contains("tag");
     assertThat(dispatcher.pausedActions).isEmpty();
     verify(hunter).detach(action);
   }
@@ -440,7 +441,8 @@ public class DispatcherTest {
 
   @Test public void performPauseAndResumeUpdatesListOfPausedTags() {
     dispatcher.performPauseTag("tag");
-    assertThat(dispatcher.pausedTags).hasSize(1).contains("tag");
+    assertThat(dispatcher.pausedTags).hasSize(1);
+    assertThat(dispatcher.pausedTags).contains("tag");
     dispatcher.performResumeTag("tag");
     assertThat(dispatcher.pausedTags).isEmpty();
   }
@@ -459,7 +461,8 @@ public class DispatcherTest {
     Action action = mockAction(URI_KEY_1, URI_1, "tag");
     dispatcher.performSubmit(action);
     assertThat(dispatcher.hunterMap).isEmpty();
-    assertThat(dispatcher.pausedActions).hasSize(1).containsValue(action);
+    assertThat(dispatcher.pausedActions).hasSize(1);
+    assertThat(dispatcher.pausedActions.containsValue(action)).isTrue();
     verify(service, never()).submit(any(BitmapHunter.class));
   }
 
@@ -479,7 +482,8 @@ public class DispatcherTest {
     dispatcher.hunterMap.put(URI_KEY_1, hunter);
     dispatcher.performPauseTag("tag");
     assertThat(dispatcher.hunterMap).isEmpty();
-    assertThat(dispatcher.pausedActions).hasSize(1).containsValue(action);
+    assertThat(dispatcher.pausedActions).hasSize(1);
+    assertThat(dispatcher.pausedActions.containsValue(action)).isTrue();
     verify(hunter).detach(action);
     verify(hunter).cancel();
   }
@@ -491,8 +495,10 @@ public class DispatcherTest {
     when(hunter.getActions()).thenReturn(Arrays.asList(action1, action2));
     dispatcher.hunterMap.put(URI_KEY_1, hunter);
     dispatcher.performPauseTag("tag1");
-    assertThat(dispatcher.hunterMap).hasSize(1).containsValue(hunter);
-    assertThat(dispatcher.pausedActions).hasSize(1).containsValue(action1);
+    assertThat(dispatcher.hunterMap).hasSize(1);
+    assertThat(dispatcher.hunterMap.containsValue(hunter)).isTrue();
+    assertThat(dispatcher.pausedActions).hasSize(1);
+    assertThat(dispatcher.pausedActions.containsValue(action1)).isTrue();
     verify(hunter).detach(action1);
     verify(hunter, never()).detach(action2);
   }

--- a/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/ImageViewActionTest.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
@@ -31,7 +32,6 @@ import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.makeBitmap;
 import static com.squareup.picasso.TestUtils.mockCallback;
 import static com.squareup.picasso.TestUtils.mockImageViewTarget;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/picasso/src/test/java/com/squareup/picasso/LruCacheTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/LruCacheTest.java
@@ -26,9 +26,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 
 import static android.graphics.Bitmap.Config.ALPHA_8;
+import static com.google.common.truth.Truth.assertThat;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.fail;
-import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 public class LruCacheTest {
@@ -166,7 +166,8 @@ public class LruCacheTest {
     cache.set("Hellos\nWorld!", D);
 
     cache.clearKeyUri("Hello");
-    assertThat(cache.map).hasSize(1).containsKey("Hellos\nWorld!");
+    assertThat(cache.map).hasSize(1);
+    assertThat(cache.map).containsKey("Hellos\nWorld!");
   }
 
   @Test public void invalidate() {
@@ -174,7 +175,7 @@ public class LruCacheTest {
     cache.set("Hello\nAlice!", A);
     assertThat(cache.size()).isEqualTo(1);
     cache.clearKeyUri("Hello");
-    assertThat(cache.size()).isZero();
+    assertThat(cache.size()).isEqualTo(0);
   }
 
   @Test public void overMaxSizeDoesNotClear() {

--- a/picasso/src/test/java/com/squareup/picasso/MarkableInputStreamTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/MarkableInputStreamTest.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.nio.charset.Charset;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 public class MarkableInputStreamTest {

--- a/picasso/src/test/java/com/squareup/picasso/MediaStoreRequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/MediaStoreRequestHandlerTest.java
@@ -13,6 +13,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowBitmap;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.MediaStoreRequestHandler.PicassoKind.FULL;
 import static com.squareup.picasso.MediaStoreRequestHandler.PicassoKind.MICRO;
 import static com.squareup.picasso.MediaStoreRequestHandler.PicassoKind.MINI;
@@ -21,7 +22,6 @@ import static com.squareup.picasso.TestUtils.MEDIA_STORE_CONTENT_1_URL;
 import static com.squareup.picasso.TestUtils.MEDIA_STORE_CONTENT_KEY_1;
 import static com.squareup.picasso.TestUtils.makeBitmap;
 import static com.squareup.picasso.TestUtils.mockAction;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;

--- a/picasso/src/test/java/com/squareup/picasso/MemoryPolicyTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/MemoryPolicyTest.java
@@ -2,7 +2,7 @@ package com.squareup.picasso;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 public class MemoryPolicyTest {
 

--- a/picasso/src/test/java/com/squareup/picasso/NetworkRequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/NetworkRequestHandlerTest.java
@@ -36,11 +36,11 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.robolectric.RobolectricGradleTestRunner;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.mockNetworkInfo;
 import static okhttp3.Protocol.HTTP_1_1;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;

--- a/picasso/src/test/java/com/squareup/picasso/OkHttp3DownloaderTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/OkHttp3DownloaderTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.annotation.Config;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(

--- a/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoDrawableTest.java
@@ -25,10 +25,10 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static android.graphics.Color.RED;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Picasso.LoadedFrom.DISK;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 import static com.squareup.picasso.TestUtils.makeBitmap;
-import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 public class PicassoDrawableTest {

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -33,6 +33,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Picasso.Listener;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 import static com.squareup.picasso.RemoteViewsAction.RemoteViewsTarget;
@@ -45,8 +46,7 @@ import static com.squareup.picasso.TestUtils.mockDeferredRequestCreator;
 import static com.squareup.picasso.TestUtils.mockHunter;
 import static com.squareup.picasso.TestUtils.mockImageViewTarget;
 import static com.squareup.picasso.TestUtils.mockTarget;
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.fail;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -98,7 +98,8 @@ public class PicassoTest {
     Action action = mockAction(URI_KEY_1, URI_1, mockImageViewTarget());
     picasso.enqueueAndSubmit(action);
     verify(dispatcher).dispatchSubmit(action);
-    assertThat(picasso.targetToAction).hasSize(1).containsValue(action);
+    assertThat(picasso.targetToAction).hasSize(1);
+    assertThat(picasso.targetToAction.containsValue(action)).isTrue();
     picasso.enqueueAndSubmit(action);
     verify(action, never()).cancel();
     verify(dispatcher, never()).dispatchCancel(action);
@@ -547,13 +548,16 @@ public class PicassoTest {
 
   @Test public void builderWithoutRequestHandler() {
     Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application).build();
-    assertThat(picasso.getRequestHandlers()).isNotEmpty().doesNotContain(requestHandler);
+    assertThat(picasso.getRequestHandlers()).isNotEmpty();
+    assertThat(picasso.getRequestHandlers()).doesNotContain(requestHandler);
   }
 
   @Test public void builderWithRequestHandler() {
     Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application)
         .addRequestHandler(requestHandler).build();
-    assertThat(picasso.getRequestHandlers()).isNotNull().isNotEmpty().contains(requestHandler);
+    assertThat(picasso.getRequestHandlers()).isNotNull();
+    assertThat(picasso.getRequestHandlers()).isNotEmpty();
+    assertThat(picasso.getRequestHandlers()).contains(requestHandler);
   }
 
   @Test public void builderInvalidContext() {

--- a/picasso/src/test/java/com/squareup/picasso/RemoteViewsActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RemoteViewsActionTest.java
@@ -25,13 +25,13 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Picasso.LoadedFrom.NETWORK;
 import static com.squareup.picasso.Picasso.RequestTransformer.IDENTITY;
 import static com.squareup.picasso.TestUtils.URI_KEY_1;
 import static com.squareup.picasso.TestUtils.makeBitmap;
 import static com.squareup.picasso.TestUtils.mockCallback;
 import static com.squareup.picasso.TestUtils.mockImageViewTarget;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -34,6 +34,7 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static android.graphics.Bitmap.Config.ARGB_8888;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Picasso.LoadedFrom.MEMORY;
 import static com.squareup.picasso.Picasso.Priority.HIGH;
 import static com.squareup.picasso.Picasso.Priority.LOW;
@@ -53,7 +54,6 @@ import static com.squareup.picasso.TestUtils.mockImageViewTarget;
 import static com.squareup.picasso.TestUtils.mockNotification;
 import static com.squareup.picasso.TestUtils.mockRemoteViews;
 import static com.squareup.picasso.TestUtils.mockTarget;
-import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;

--- a/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestHandlerTest.java
@@ -22,11 +22,11 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 
 import static android.graphics.Bitmap.Config.RGB_565;
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.RequestHandler.calculateInSampleSize;
 import static com.squareup.picasso.RequestHandler.createBitmapOptions;
 import static com.squareup.picasso.RequestHandler.requiresInSampleSize;
 import static com.squareup.picasso.TestUtils.URI_1;
-import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 public class RequestHandlerTest {

--- a/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/UtilsTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso.TestUtils.RESOURCE_ID_URI;
 import static com.squareup.picasso.TestUtils.RESOURCE_TYPE_URI;
@@ -29,7 +30,6 @@ import static com.squareup.picasso.TestUtils.URI_1;
 import static com.squareup.picasso.TestUtils.mockPackageResourceContext;
 import static com.squareup.picasso.Utils.createKey;
 import static com.squareup.picasso.Utils.isWebPFile;
-import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricGradleTestRunner.class)
 public class UtilsTest {


### PR DESCRIPTION
Fixes #1592.

They are very similar APIs. For the most part, only import changes and minor substitution of equivalent methods were needed (e.g. `containsOnly` for `containsExactly`, `contains(entry())` for `containsEntry()`).

Some notable bits:

- Assertions cannot be chained in Truth (design decision from the Truth team). Thus, chained assertions were split in multiple individual assertions.
- Fest's `Assertions.fail` was substituted with JUnit's `Assert.fail`.
- Truth’s `MapSubject` doesn’t have a `containsValue` method so I used `Map.containsValue` to assert its value.

**Note**: I had to upgrade the AGP from version 3.0-beta2 to 3.0-beta7 in order to work in AS 3.0 beta7 (current). Moreover, using this version of the AGP also required upgrading build tools from version 26.0.1 to 26.0.2.

