### PR TITLE
Remove reference to old request creation.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/NetworkPolicy.java
+++ b/picasso/src/main/java/com/squareup/picasso/NetworkPolicy.java
@@ -24,8 +24,6 @@ public enum NetworkPolicy {
 
   /**
    * Skips storing the result into the disk cache.
-   * <p>
-   * <em>Note</em>: At this time this is only supported if you are using OkHttp.
    */
   NO_STORE(1 << 1),
 


### PR DESCRIPTION
If you write a custom Downloader, it's your responsibility to check things like `shouldWriteToDiskCache`, anyway.