### PR TITLE
suppress warning: drawable has unresolved theme attributes.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -21,11 +21,13 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.TypedValue;
 import android.view.Gravity;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
@@ -735,7 +737,17 @@ public class RequestCreator {
 
   private Drawable getPlaceholderDrawable() {
     if (placeholderResId != 0) {
-      return picasso.context.getResources().getDrawable(placeholderResId);
+      if (Build.VERSION.SDK_INT >= 21) {
+        return picasso.context.getDrawable(placeholderResId);
+      } else if (Build.VERSION.SDK_INT >= 16) {
+        return picasso.context.getResources().getDrawable(placeholderResId);
+      } else {
+        final int resolvedId;
+        TypedValue sTempValue = new TypedValue();
+        picasso.context.getResources().getValue(placeholderResId, sTempValue, true);
+        resolvedId = sTempValue.resourceId;
+        return picasso.context.getResources().getDrawable(resolvedId);
+      }
     } else {
       return placeholderDrawable; // This may be null which is expected and desired behavior.
     }

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -742,11 +742,9 @@ public class RequestCreator {
       } else if (Build.VERSION.SDK_INT >= 16) {
         return picasso.context.getResources().getDrawable(placeholderResId);
       } else {
-        final int resolvedId;
-        TypedValue sTempValue = new TypedValue();
-        picasso.context.getResources().getValue(placeholderResId, sTempValue, true);
-        resolvedId = sTempValue.resourceId;
-        return picasso.context.getResources().getDrawable(resolvedId);
+        TypedValue value = new TypedValue();
+        picasso.context.getResources().getValue(placeholderResId, value, true);
+        return picasso.context.getResources().getDrawable(value.resourceId);
       }
     } else {
       return placeholderDrawable; // This may be null which is expected and desired behavior.


### PR DESCRIPTION
Fixed warning on adding `animated-vector` as a placeholder. Following is warning shows up due to `context.getResources().getDrawable(placeholderResId)` in **RequestCreator**.

```
12-06 13:46:57.057 17455-17455/com.example.debug W/Resources: Drawable com.example.debug:drawable/circular_animation has unresolved theme attributes! Consider using Resources.getDrawable(int, Theme) or Context.getDrawable(int).
                                                            java.lang.RuntimeException
                                                                at android.content.res.Resources.getDrawable(Resources.java:797)
                                                                at com.squareup.picasso.RequestCreator.getPlaceholderDrawable(RequestCreator.java:741)
                                                                at com.squareup.picasso.RequestCreator.into(RequestCreator.java:729)
                                                                at com.squareup.picasso.RequestCreator.into(RequestCreator.java:666)
                                                                at com.example.app.dashboard.home.adapter.TrendingProductsAdapter.onBindViewHolder(TrendingProductsAdapter.java:51)
                                                                at com.example.app.dashboard.home.adapter.TrendingProductsAdapter.onBindViewHolder(TrendingProductsAdapter.java:28)
                                                                at android.support.v7.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:6508)
                                                                at android.support.v7.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:6541)
                                                                at android.support.v7.widget.RecyclerView$Recycler.tryBindViewHolderByDeadline(RecyclerView.java:5484)
                                                                at android.support.v7.widget.RecyclerView$Recycler.tryGetViewHolderForPositionByDeadline(RecyclerView.java:5750)
                                                                at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5589)
                                                                at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5585)
                                                                at android.support.v7.widget.LinearLayoutManager$LayoutState.next(LinearLayoutManager.java:2231)
                                                                at android.support.v7.widget.LinearLayoutManager.layoutChunk(LinearLayoutManager.java:1558)
                                                                at android.support.v7.widget.LinearLayoutManager.fill(LinearLayoutManager.java:1518)
                                                                at android.support.v7.widget.LinearLayoutManager.onLayoutChildren(LinearLayoutManager.java:610)
                                                                at android.support.v7.widget.RecyclerView.dispatchLayoutStep2(RecyclerView.java:3719)
                                                                at android.support.v7.widget.RecyclerView.onMeasure(RecyclerView.java:3135)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6580)
                                                                at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1514)
                                                                at android.widget.LinearLayout.measureVertical(LinearLayout.java:806)
                                                                at android.widget.LinearLayout.onMeasure(LinearLayout.java:685)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.widget.RelativeLayout.measureChildHorizontal(RelativeLayout.java:715)
                                                                at android.widget.RelativeLayout.onMeasure(RelativeLayout.java:461)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6580)
                                                                at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
                                                                at android.support.v7.widget.ContentFrameLayout.onMeasure(ContentFrameLayout.java:139)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6580)
                                                                at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1514)
                                                                at android.widget.LinearLayout.measureVertical(LinearLayout.java:806)
                                                                at android.widget.LinearLayout.onMeasure(LinearLayout.java:685)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6580)
                                                                at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6580)
                                                                at android.widget.LinearLayout.measureChildBeforeLayout(LinearLayout.java:1514)
                                                                at android.widget.LinearLayout.measureVertical(LinearLayout.java:806)
                                                                at android.widget.LinearLayout.onMeasure(LinearLayout.java:685)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.view.ViewGroup.measureChildWithMargins(ViewGroup.java:6580)
                                                                at android.widget.FrameLayout.onMeasure(FrameLayout.java:185)
                                                                at com.android.internal.policy.DecorView.onMeasure(DecorView.java:721)
                                                                at android.view.View.measure(View.java:22002)
                                                                at android.view.ViewRootImpl.performMeasure(ViewRootImpl.java:2410)
                                                                at android.view.ViewRootImpl.measureHierarchy(ViewRootImpl.java:1498)
                                                                at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1751)
12-06 13:46:57.057 17455-17455/com.example.debug W/Resources:     at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1386)
                                                                at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:6733)
                                                                at android.view.Choreographer$CallbackRecord.run(Choreographer.java:911)
                                                                at android.view.Choreographer.doCallbacks(Choreographer.java:723)
                                                                at android.view.Choreographer.doFrame(Choreographer.java:658)
                                                                at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:897)
                                                                at android.os.Handler.handleCallback(Handler.java:789)
                                                                at android.os.Handler.dispatchMessage(Handler.java:98)
                                                                at android.os.Looper.loop(Looper.java:164)
                                                                at android.app.ActivityThread.main(ActivityThread.java:6541)
                                                                at java.lang.reflect.Method.invoke(Native Method)
                                                                at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
                                                                at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```