### PR TITLE
Fix incorrect cache size reporting after Bitmap is recycled.

### DIFF
--- a/picasso/src/test/java/com/squareup/picasso/LruCacheTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/LruCacheTest.java
@@ -218,9 +218,9 @@ public class LruCacheTest {
 
   private void assertSnapshot(LruCache cache, Object... keysAndValues) {
     List<Object> actualKeysAndValues = new ArrayList<>();
-    for (Map.Entry<String, Bitmap> entry : cache.map.entrySet()) {
+    for (Map.Entry<String, LruCache.BitmapAndSize> entry : cache.map.entrySet()) {
       actualKeysAndValues.add(entry.getKey());
-      actualKeysAndValues.add(entry.getValue());
+      actualKeysAndValues.add(entry.getValue().bitmap);
     }
 
     // assert using lists because order is important for LRUs


### PR DESCRIPTION
Previously, if a user called recycle on a Bitmap in the cache, the allocation size would not be subtracted correctly (on SDK 25+) when the Bitmap was evicted from the cache.

I'm not sure that anyone should ever call recycle on a Bitmap in the cache, but it'd be difficult to communicate the error.

Closes #1693