### PR TITLE
Updated Readme and website with new gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Download
 
 Download [the latest JAR][2] or grab via Gradle:
 ```groovy
-compile 'com.squareup.picasso:picasso:2.5.2'
+implementation 'com.squareup.picasso:picasso:2.5.2'
 ```
 or Maven:
 ```xml

--- a/website/index.html
+++ b/website/index.html
@@ -123,7 +123,7 @@ Picasso.get().load(new File(...)).into(imageView3);</pre>
 &lt;/dependency></pre>
 
             <h4>Gradle</h4>
-            <pre class="prettyprint">compile 'com.squareup.picasso:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
+            <pre class="prettyprint">implementation 'com.squareup.picasso:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
 
             <h3 id="contributing">Contributing</h3>
             <p>If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request.</p>


### PR DESCRIPTION
Starting from Gradle 3.0, `compile` has been replaced by `implementation`