### PR TITLE
Updated gradle

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ Picasso.with(context).load(new File(...)).into(imageView3);</pre>
 &lt;/dependency></pre>
 
             <h4>Gradle</h4>
-            <pre class="prettyprint">compile 'com.squareup.picasso:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
+            <pre class="prettyprint">implementation 'com.squareup.picasso:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
 
             <h3 id="contributing">Contributing</h3>
             <p>If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request.</p>


### PR DESCRIPTION
Starting from Gradle 3.0, `compile` has been replaced by `implementation`