### PR TITLE
Revert "Fix fit() deferred loading for re-sized views (#1447)"

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/DeferredRequestCreator.java
@@ -64,7 +64,7 @@ class DeferredRequestCreator implements OnPreDrawListener, OnAttachStateChangeLi
     int width = target.getWidth();
     int height = target.getHeight();
 
-    if (width <= 0 || height <= 0 || target.isLayoutRequested()) {
+    if (width <= 0 || height <= 0) {
       return true;
     }
 

--- a/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso/RequestCreator.java
@@ -696,7 +696,7 @@ public class RequestCreator {
       }
       int width = target.getWidth();
       int height = target.getHeight();
-      if (width == 0 || height == 0 || target.isLayoutRequested()) {
+      if (width == 0 || height == 0) {
         if (setPlaceholder) {
           setPlaceholder(target, getPlaceholderDrawable());
         }

--- a/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/DeferredRequestCreatorTest.java
@@ -144,18 +144,6 @@ public class DeferredRequestCreatorTest {
     verifyZeroInteractions(creator);
   }
 
-  @Test public void waitsForAnotherLayoutIfLayoutRequested() {
-    ImageView target = mockFitImageViewTarget(true);
-    when(target.getWidth()).thenReturn(100);
-    when(target.getHeight()).thenReturn(100);
-    when(target.isLayoutRequested()).thenReturn(true);
-    RequestCreator creator = mock(RequestCreator.class);
-    DeferredRequestCreator request = new DeferredRequestCreator(creator, target, null);
-    request.onPreDraw();
-    verify(target.getViewTreeObserver(), never()).removeOnPreDrawListener(request);
-    verifyZeroInteractions(creator);
-  }
-
   @Test public void cancelSkipsWithNullTarget() {
     ImageView target = mockFitImageViewTarget(true);
     RequestCreator creator = mock(RequestCreator.class);

--- a/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/RequestCreatorTest.java
@@ -374,17 +374,6 @@ public class RequestCreatorTest {
   }
 
   @Test
-  public void intoImageViewWithFitAndRequestedLayoutQueuesDeferredImageViewRequest() {
-    ImageView target = mockFitImageViewTarget(true);
-    when(target.getWidth()).thenReturn(100);
-    when(target.getHeight()).thenReturn(100);
-    when(target.isLayoutRequested()).thenReturn(true);
-    new RequestCreator(picasso, URI_1, 0).fit().into(target);
-    verify(picasso, never()).enqueueAndSubmit(any(Action.class));
-    verify(picasso).defer(eq(target), any(DeferredRequestCreator.class));
-  }
-
-  @Test
   public void intoImageViewWithFitAndDimensionsQueuesImageViewRequest() {
     ImageView target = mockFitImageViewTarget(true);
     when(target.getWidth()).thenReturn(100);


### PR DESCRIPTION
This reverts commit ed2ff2be1e262be15d5a0c8d187be2b221aec2ff.
https://github.com/square/picasso/pull/1447

Once we get this behavior working with `fit()` we should restore this change.