### PR TITLE
Remove Cache from public API.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Cache.java
+++ b/picasso/src/main/java/com/squareup/picasso/Cache.java
@@ -24,7 +24,7 @@ import android.graphics.Bitmap;
  * your {@link Cache} implementation is thread safe when {@link Cache#get(String)} or {@link
  * Cache#set(String, android.graphics.Bitmap)} is called.
  */
-public interface Cache {
+interface Cache {
   /** Retrieve an image for the specified {@code key} or {@code null}. */
   Bitmap get(String key);
 

--- a/picasso/src/main/java/com/squareup/picasso/LruCache.java
+++ b/picasso/src/main/java/com/squareup/picasso/LruCache.java
@@ -23,16 +23,16 @@ import android.support.annotation.Nullable;
 import static com.squareup.picasso.Utils.KEY_SEPARATOR;
 
 /** A memory cache which uses a least-recently used eviction policy. */
-public final class LruCache implements Cache {
+final class LruCache implements Cache {
   final android.util.LruCache<String, LruCache.BitmapAndSize> cache;
 
   /** Create a cache using an appropriate portion of the available RAM as the maximum size. */
-  public LruCache(@NonNull Context context) {
+  LruCache(@NonNull Context context) {
     this(Utils.calculateMemoryCacheSize(context));
   }
 
   /** Create a cache with a given maximum size in bytes. */
-  public LruCache(int maxByteCount) {
+  LruCache(int maxByteCount) {
     cache = new android.util.LruCache<String, LruCache.BitmapAndSize>(maxByteCount) {
       @Override protected int sizeOf(String key, BitmapAndSize value) {
         return value.byteCount;
@@ -87,22 +87,22 @@ public final class LruCache implements Cache {
   }
 
   /** Returns the number of times {@link #get} returned a value. */
-  public int hitCount() {
+  int hitCount() {
     return cache.hitCount();
   }
 
   /** Returns the number of times {@link #get} returned {@code null}. */
-  public int missCount() {
+  int missCount() {
     return cache.missCount();
   }
 
   /** Returns the number of times {@link #set(String, Bitmap)} was called. */
-  public int putCount() {
+  int putCount() {
     return cache.putCount();
   }
 
   /** Returns the number of values that have been evicted. */
-  public int evictionCount() {
+  int evictionCount() {
     return cache.evictionCount();
   }
 

--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -768,14 +768,18 @@ public class Picasso {
     }
 
     /** Specify the memory cache used for the most recent images. */
-    public Builder memoryCache(@NonNull Cache memoryCache) {
-      if (memoryCache == null) {
-        throw new IllegalArgumentException("Memory cache must not be null.");
+    public Builder withCacheSize(int maxByteCount) {
+      if (maxByteCount < 0) {
+        throw new IllegalArgumentException("maxByteCount < 0: " + maxByteCount);
       }
-      if (this.cache != null) {
+      if (cache != null) {
         throw new IllegalStateException("Memory cache already set.");
       }
-      this.cache = memoryCache;
+      if (maxByteCount == 0) {
+        cache = Cache.NONE;
+      } else {
+        cache = new LruCache(maxByteCount);
+      }
       return this;
     }
 

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -508,14 +508,16 @@ public class PicassoTest {
 
   @Test public void builderInvalidCache() {
     try {
-      new Picasso.Builder(context).memoryCache(null);
-      fail("Null Cache should throw exception.");
+      new Picasso.Builder(context).withCacheSize(-1);
+      fail();
     } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("maxByteCount < 0: -1");
     }
     try {
-      new Picasso.Builder(context).memoryCache(cache).memoryCache(cache);
-      fail("Setting Cache twice should throw exception.");
+      new Picasso.Builder(context).withCacheSize(0).withCacheSize(1);
+      fail();
     } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("Memory cache already set.");
     }
   }
 


### PR DESCRIPTION
Users can set the max byte count, use the default, or specify no memory caching.

Here's a proposal for an API change. If this sounds good, an implementation follow-up might be removing `Cache` in favor of passing around a nullable Cache/LruCache.