### PR TITLE
Add Picasso.evictAll.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -366,6 +366,13 @@ public class Picasso {
   }
 
   /**
+   * Clear all the bitmaps from the memory cache.
+   */
+  public void evictAll() {
+    cache.clear();
+  }
+
+  /**
    * Invalidate all memory cached images for the specified {@code uri}.
    *
    * @see #invalidate(String)

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -32,6 +32,7 @@ import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
+import static android.graphics.Bitmap.Config.ALPHA_8;
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.google.common.truth.Truth.assertThat;
 import static com.squareup.picasso.Picasso.Listener;
@@ -504,6 +505,14 @@ public class PicassoTest {
   @Test public void builderWithDebugIndicators() {
     Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application).indicatorsEnabled(true).build();
     assertThat(picasso.areIndicatorsEnabled()).isTrue();
+  }
+
+  @Test public void evictAll() {
+    Picasso picasso = new Picasso.Builder(RuntimeEnvironment.application).indicatorsEnabled(true).build();
+    picasso.cache.set("key", Bitmap.createBitmap(1, 1, ALPHA_8));
+    assertThat(picasso.cache.size()).isEqualTo(1);
+    picasso.evictAll();
+    assertThat(picasso.cache.size()).isEqualTo(0);
   }
 
   @Test public void invalidateString() {


### PR DESCRIPTION
Since the cache is not public anymore, this is the only way to clear the memory cache.

the test is pretty graybox, but i don't think the machinery for adding a blockbox test is worth it right now for something that's so unlikely to break.