### PR TITLE
Fix test Bitmap.Config.

### DIFF
--- a/picasso/src/test/java/com/squareup/picasso/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso/TestUtils.java
@@ -34,6 +34,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static android.content.ContentResolver.SCHEME_ANDROID_RESOURCE;
+import static android.graphics.Bitmap.Config.ALPHA_8;
 import static android.graphics.Bitmap.Config.ARGB_8888;
 import static android.provider.ContactsContract.Contacts.CONTENT_URI;
 import static android.provider.ContactsContract.Contacts.Photo.CONTENT_DIRECTORY;
@@ -267,7 +268,7 @@ class TestUtils {
   }
 
   static Bitmap makeBitmap(int width, int height) {
-    return Bitmap.createBitmap(width, height, null);
+    return Bitmap.createBitmap(width, height, ALPHA_8);
   }
 
   private TestUtils() {


### PR DESCRIPTION
This parameter is not nullable.

It's for a change to yank out the Cache abstraction.
Surprisingly, it doesn't look the Android SDK checks for a null input and would only fail later. I'll file a bug when I get a minute.