### PR TITLE
Remove Downloader from API.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Downloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/Downloader.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import okhttp3.Response;
 
 /** A mechanism to load images from external resources such as a disk cache and/or the internet. */
-public interface Downloader {
+interface Downloader {
   /**
    * Download the specified image {@code url} from the internet.
    *

--- a/picasso/src/main/java/com/squareup/picasso/OkHttp3Downloader.java
+++ b/picasso/src/main/java/com/squareup/picasso/OkHttp3Downloader.java
@@ -15,76 +15,25 @@
  */
 package com.squareup.picasso;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import java.io.File;
 import java.io.IOException;
 import okhttp3.Cache;
 import okhttp3.Call;
-import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 
 /** A {@link Downloader} which uses OkHttp to download images. */
-public final class OkHttp3Downloader implements Downloader {
+final class OkHttp3Downloader implements Downloader {
   @VisibleForTesting final Call.Factory client;
-  private final Cache cache;
-  private boolean sharedClient = true;
+  private final @Nullable Cache cache;
+  private final boolean sharedClient;
 
-  /**
-   * Create new downloader that uses OkHttp. This will install an image cache into your application
-   * cache directory.
-   */
-  public OkHttp3Downloader(final Context context) {
-    this(Utils.createDefaultCacheDir(context));
-  }
-
-  /**
-   * Create new downloader that uses OkHttp. This will install an image cache into the specified
-   * directory.
-   *
-   * @param cacheDir The directory in which the cache should be stored
-   */
-  public OkHttp3Downloader(final File cacheDir) {
-    this(cacheDir, Utils.calculateDiskCacheSize(cacheDir));
-  }
-
-  /**
-   * Create new downloader that uses OkHttp. This will install an image cache into your application
-   * cache directory.
-   *
-   * @param maxSize The size limit for the cache.
-   */
-  public OkHttp3Downloader(final Context context, final long maxSize) {
-    this(Utils.createDefaultCacheDir(context), maxSize);
-  }
-
-  /**
-   * Create new downloader that uses OkHttp. This will install an image cache into the specified
-   * directory.
-   *
-   * @param cacheDir The directory in which the cache should be stored
-   * @param maxSize The size limit for the cache.
-   */
-  public OkHttp3Downloader(final File cacheDir, final long maxSize) {
-    this(new OkHttpClient.Builder().cache(new Cache(cacheDir, maxSize)).build());
-    sharedClient = false;
-  }
-
-  /**
-   * Create a new downloader that uses the specified OkHttp instance. A response cache will not be
-   * automatically configured.
-   */
-  public OkHttp3Downloader(OkHttpClient client) {
+  OkHttp3Downloader(Call.Factory client, @Nullable Cache cache, boolean sharedClient) {
     this.client = client;
-    this.cache = client.cache();
-  }
-
-  /** Create a new downloader that uses the specified {@link Call.Factory} instance. */
-  public OkHttp3Downloader(Call.Factory client) {
-    this.client = client;
-    this.cache = null;
+    this.cache = cache;
+    this.sharedClient = sharedClient;
   }
 
   @NonNull @Override public Response load(@NonNull Request request) throws IOException {

--- a/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso/PicassoTest.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -411,16 +413,18 @@ public class PicassoTest {
     }
   }
 
-  @Test public void builderInvalidLoader() {
+  @Test public void builderInvalidClient() {
     try {
-      new Picasso.Builder(context).downloader(null);
-      fail("Null Downloader should throw exception.");
-    } catch (IllegalArgumentException expected) {
+      new Picasso.Builder(context).client(null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("client == null");
     }
     try {
-      new Picasso.Builder(context).downloader(downloader).downloader(downloader);
-      fail("Setting Downloader twice should throw exception.");
-    } catch (IllegalStateException expected) {
+      new Picasso.Builder(context).callFactory(null);
+      fail();
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessageThat().isEqualTo("factory == null");
     }
   }
 


### PR DESCRIPTION
If you can't use OkHttp, wrap your client with a Call.Factory.

just getting the API down.
For an implementation follow-up, I can remove the Downloader abstraction.