### PR TITLE
Update builder doc for cache size.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso/Picasso.java
@@ -719,7 +719,10 @@ public class Picasso {
       return this;
     }
 
-    /** Specify the memory cache used for the most recent images. */
+    /**
+     * Specify the memory cache size in bytes to use for the most recent images,
+     * or 0 for no memory caching.
+     */
     public Builder withCacheSize(int maxByteCount) {
       if (maxByteCount < 0) {
         throw new IllegalArgumentException("maxByteCount < 0: " + maxByteCount);


### PR DESCRIPTION
i'm thinking it should maybe be `cacheSize` cuz we don't prefix the other setters like `client` with `with`.
nitpicks for a later time.