### PR TITLE
Set network and memory policy on Request.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Action.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Action.java
@@ -46,14 +46,14 @@ abstract class Action<T> {
   boolean willReplay;
   boolean cancelled;
 
-  Action(Picasso picasso, T target, Request request, int memoryPolicy, int networkPolicy,
-      int errorResId, Drawable errorDrawable, String key, Object tag, boolean noFade) {
+  Action(Picasso picasso, T target, Request request, int errorResId, Drawable errorDrawable,
+      String key, Object tag, boolean noFade) {
     this.picasso = picasso;
     this.request = request;
     this.target =
         target == null ? null : new RequestWeakReference<>(this, target, picasso.referenceQueue);
-    this.memoryPolicy = memoryPolicy;
-    this.networkPolicy = networkPolicy;
+    this.memoryPolicy = request.memoryPolicy;
+    this.networkPolicy = request.networkPolicy;
     this.noFade = noFade;
     this.errorResId = errorResId;
     this.errorDrawable = errorDrawable;

--- a/picasso/src/main/java/com/squareup/picasso3/FetchAction.java
+++ b/picasso/src/main/java/com/squareup/picasso3/FetchAction.java
@@ -22,9 +22,8 @@ class FetchAction extends Action<Object> {
   private final Object fetchTarget;
   private Callback callback;
 
-  FetchAction(Picasso picasso, Request data, int memoryPolicy, int networkPolicy, Object tag,
-      String key, Callback callback) {
-    super(picasso, null, data, memoryPolicy, networkPolicy, 0, null, key, tag, false);
+  FetchAction(Picasso picasso, Request data, Object tag, String key, Callback callback) {
+    super(picasso, null, data, 0, null, key, tag, false);
     this.fetchTarget = new Object();
     this.callback = callback;
   }

--- a/picasso/src/main/java/com/squareup/picasso3/GetAction.java
+++ b/picasso/src/main/java/com/squareup/picasso3/GetAction.java
@@ -18,9 +18,8 @@ package com.squareup.picasso3;
 import android.graphics.Bitmap;
 
 class GetAction extends Action<Void> {
-  GetAction(Picasso picasso, Request data, int memoryPolicy, int networkPolicy, Object tag,
-      String key) {
-    super(picasso, null, data, memoryPolicy, networkPolicy, 0, null, key, tag, false);
+  GetAction(Picasso picasso, Request data, Object tag, String key) {
+    super(picasso, null, data, 0, null, key, tag, false);
   }
 
   @Override void complete(Bitmap result, Picasso.LoadedFrom from) {

--- a/picasso/src/main/java/com/squareup/picasso3/ImageViewAction.java
+++ b/picasso/src/main/java/com/squareup/picasso3/ImageViewAction.java
@@ -25,11 +25,9 @@ class ImageViewAction extends Action<ImageView> {
 
   Callback callback;
 
-  ImageViewAction(Picasso picasso, ImageView imageView, Request data, int memoryPolicy,
-      int networkPolicy, int errorResId, Drawable errorDrawable, String key, Object tag,
-      Callback callback, boolean noFade) {
-    super(picasso, imageView, data, memoryPolicy, networkPolicy, errorResId, errorDrawable, key,
-        tag, noFade);
+  ImageViewAction(Picasso picasso, ImageView imageView, Request data, int errorResId,
+      Drawable errorDrawable, String key, Object tag, Callback callback, boolean noFade) {
+    super(picasso, imageView, data, errorResId, errorDrawable, key, tag, noFade);
     this.callback = callback;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso3/RemoteViewsAction.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RemoteViewsAction.java
@@ -32,9 +32,9 @@ abstract class RemoteViewsAction extends Action<RemoteViewsAction.RemoteViewsTar
   private RemoteViewsTarget remoteTarget;
 
   RemoteViewsAction(Picasso picasso, Request data, RemoteViews remoteViews, int viewId,
-      int errorResId, int memoryPolicy, int networkPolicy, Object tag, String key,
+      int errorResId, Object tag, String key,
       Callback callback) {
-    super(picasso, null, data, memoryPolicy, networkPolicy, errorResId, null, key, tag, false);
+    super(picasso, null, data, errorResId, null, key, tag, false);
     this.remoteViews = remoteViews;
     this.viewId = viewId;
     this.callback = callback;
@@ -104,10 +104,9 @@ abstract class RemoteViewsAction extends Action<RemoteViewsAction.RemoteViewsTar
     private final int[] appWidgetIds;
 
     AppWidgetAction(Picasso picasso, Request data, RemoteViews remoteViews, int viewId,
-        int[] appWidgetIds, int memoryPolicy, int networkPolicy, String key, Object tag,
+        int[] appWidgetIds, String key, Object tag,
         int errorResId, Callback callback) {
-      super(picasso, data, remoteViews, viewId, errorResId, memoryPolicy, networkPolicy, tag, key,
-          callback);
+      super(picasso, data, remoteViews, viewId, errorResId, tag, key, callback);
       this.appWidgetIds = appWidgetIds;
     }
 
@@ -123,10 +122,9 @@ abstract class RemoteViewsAction extends Action<RemoteViewsAction.RemoteViewsTar
     private final Notification notification;
 
     NotificationAction(Picasso picasso, Request data, RemoteViews remoteViews, int viewId,
-        int notificationId, Notification notification, String notificationTag, int memoryPolicy,
-        int networkPolicy, String key, Object tag, int errorResId, Callback callback) {
-      super(picasso, data, remoteViews, viewId, errorResId, memoryPolicy, networkPolicy, tag, key,
-          callback);
+        int notificationId, Notification notification, String notificationTag, String key,
+        Object tag, int errorResId, Callback callback) {
+      super(picasso, data, remoteViews, viewId, errorResId, tag, key, callback);
       this.notificationId = notificationId;
       this.notificationTag = notificationTag;
       this.notification = notification;

--- a/picasso/src/main/java/com/squareup/picasso3/TargetAction.java
+++ b/picasso/src/main/java/com/squareup/picasso3/TargetAction.java
@@ -20,10 +20,9 @@ import android.graphics.drawable.Drawable;
 
 final class TargetAction extends Action<Target> {
 
-  TargetAction(Picasso picasso, Target target, Request data, int memoryPolicy, int networkPolicy,
-      Drawable errorDrawable, String key, Object tag, int errorResId) {
-    super(picasso, target, data, memoryPolicy, networkPolicy, errorResId, errorDrawable, key, tag,
-        false);
+  TargetAction(Picasso picasso, Target target, Request data, Drawable errorDrawable, String key,
+      Object tag, int errorResId) {
+    super(picasso, target, data, errorResId, errorDrawable, key, tag, false);
   }
 
   @Override void complete(Bitmap result, Picasso.LoadedFrom from) {

--- a/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.java
@@ -141,10 +141,10 @@ public class DispatcherTest {
     assertThat(dispatcher.pausedActions).isEmpty();
 
     FetchAction fetchAction1 =
-        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), 0, 0, pausedTag,
+        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), pausedTag,
             URI_KEY_1, null);
     FetchAction fetchAction2 =
-        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), 0, 0, pausedTag,
+        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), pausedTag,
             URI_KEY_1, null);
     dispatcher.performSubmit(fetchAction1);
     dispatcher.performSubmit(fetchAction2);
@@ -157,7 +157,7 @@ public class DispatcherTest {
     Callback callback = mockCallback();
 
     FetchAction fetchAction =
-        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), 0, 0, pausedTag,
+        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), pausedTag,
             URI_KEY_1, callback);
     dispatcher.performSubmit(fetchAction);
     fetchAction.complete(bitmap1, MEMORY);
@@ -170,7 +170,7 @@ public class DispatcherTest {
     Callback callback = mockCallback();
 
     FetchAction fetchAction =
-        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), 0, 0, pausedTag,
+        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), pausedTag,
             URI_KEY_1, callback);
     dispatcher.performSubmit(fetchAction, false);
     Exception e = new RuntimeException();
@@ -186,7 +186,7 @@ public class DispatcherTest {
     Callback callback = mockCallback();
 
     FetchAction fetchAction1 =
-        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), 0, 0, pausedTag,
+        new FetchAction(mockPicasso(), new Request.Builder(URI_1).build(), pausedTag,
             URI_KEY_1, callback);
     dispatcher.performCancel(fetchAction1);
     fetchAction1.cancel();

--- a/picasso/src/test/java/com/squareup/picasso3/ImageViewActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/ImageViewActionTest.java
@@ -30,6 +30,7 @@ import static com.squareup.picasso3.TestUtils.NO_HANDLERS;
 import static com.squareup.picasso3.TestUtils.NO_TRANSFORMERS;
 import static com.squareup.picasso3.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso3.TestUtils.UNUSED_CALL_FACTORY;
+import static com.squareup.picasso3.TestUtils.URI_1;
 import static com.squareup.picasso3.TestUtils.URI_KEY_1;
 import static com.squareup.picasso3.TestUtils.makeBitmap;
 import static com.squareup.picasso3.TestUtils.mockCallback;
@@ -45,9 +46,8 @@ public class ImageViewActionTest {
 
   @Test(expected = AssertionError.class)
   public void throwsErrorWithNullResult() {
-    ImageViewAction action =
-        new ImageViewAction(mock(Picasso.class), mockImageViewTarget(), null, 0, 0, 0,
-            null, URI_KEY_1, null, null, false);
+    ImageViewAction action = new ImageViewAction(mock(Picasso.class), mockImageViewTarget(),
+        new Request.Builder(URI_1).build(), 0, null, URI_KEY_1, null, null, false);
     action.complete(null, MEMORY);
   }
 
@@ -58,22 +58,21 @@ public class ImageViewActionTest {
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
     ImageViewAction request =
-        new ImageViewAction(picasso, target, null, 0, 0, 0, null, URI_KEY_1, null,
-            callback, false);
+        new ImageViewAction(picasso, target, new Request.Builder(URI_1).build(), 0, null, URI_KEY_1,
+            null, callback, false);
     request.target.clear();
     request.complete(bitmap, MEMORY);
     verifyZeroInteractions(target);
     verifyZeroInteractions(callback);
   }
 
-  @Test
-  public void returnsIfTargetIsNullOnError() {
+  @Test public void returnsIfTargetIsNullOnError() {
     Picasso picasso = mock(Picasso.class);
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
     ImageViewAction request =
-        new ImageViewAction(picasso, target, null, 0, 0, 0, null, URI_KEY_1, null,
-            callback, false);
+        new ImageViewAction(picasso, target, new Request.Builder(URI_1).build(), 0, null, URI_KEY_1,
+            null, callback, false);
     request.target.clear();
     request.error(new RuntimeException());
     verifyZeroInteractions(target);
@@ -92,7 +91,8 @@ public class ImageViewActionTest {
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
     ImageViewAction request =
-        new ImageViewAction(picasso, target, null, 0, 0, 0, null, URI_KEY_1, null, callback, false);
+        new ImageViewAction(picasso, target, new Request.Builder(URI_1).build(), 0, null, URI_KEY_1,
+            null, callback, false);
     request.complete(bitmap, MEMORY);
     verify(target).setImageDrawable(any(PicassoDrawable.class));
     verify(callback).onSuccess();
@@ -104,8 +104,8 @@ public class ImageViewActionTest {
     Callback callback = mockCallback();
     Picasso mock = mock(Picasso.class);
     ImageViewAction request =
-        new ImageViewAction(mock, target, null, 0, 0, RESOURCE_ID_1, null, null, null,
-            callback, false);
+        new ImageViewAction(mock, target, new Request.Builder(URI_1).build(), RESOURCE_ID_1, null,
+            null, null, callback, false);
     Exception e = new RuntimeException();
     request.error(e);
     verify(target).setImageResource(RESOURCE_ID_1);
@@ -118,8 +118,8 @@ public class ImageViewActionTest {
     Callback callback = mockCallback();
     Picasso mock = mock(Picasso.class);
     ImageViewAction request =
-        new ImageViewAction(mock, target, null, 0, 0, RESOURCE_ID_1, null, null, null,
-            callback, false);
+        new ImageViewAction(mock, target, new Request.Builder(URI_1).build(), RESOURCE_ID_1, null,
+            null, null, callback, false);
     Exception e = new RuntimeException();
     request.error(e);
     verify(target).setImageResource(RESOURCE_ID_1);
@@ -133,8 +133,8 @@ public class ImageViewActionTest {
     Callback callback = mockCallback();
     Picasso mock = mock(Picasso.class);
     ImageViewAction request =
-        new ImageViewAction(mock, target, null, 0, 0, 0, errorDrawable, URI_KEY_1, null,
-            callback, false);
+        new ImageViewAction(mock, target, new Request.Builder(URI_1).build(), 0, errorDrawable,
+            URI_KEY_1, null, callback, false);
     Exception e = new RuntimeException();
     request.error(e);
     verify(target).setImageDrawable(errorDrawable);
@@ -147,8 +147,8 @@ public class ImageViewActionTest {
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
     ImageViewAction request =
-        new ImageViewAction(picasso, target, null, 0, 0, 0, null, URI_KEY_1, null,
-            callback, false);
+        new ImageViewAction(picasso, target, new Request.Builder(URI_1).build(), 0, null, URI_KEY_1,
+            null, callback, false);
     request.cancel();
     assertThat(request.callback).isNull();
   }
@@ -160,8 +160,8 @@ public class ImageViewActionTest {
     ImageView target = mockImageViewTarget();
     when(target.getDrawable()).thenReturn(placeholder);
     ImageViewAction request =
-        new ImageViewAction(picasso, target, null, 0, 0, 0, null, URI_KEY_1, null,
-            null, false);
+        new ImageViewAction(picasso, target, new Request.Builder(URI_1).build(), 0, null, URI_KEY_1,
+            null, null, false);
     request.error(new RuntimeException());
     verify(placeholder).stop();
   }

--- a/picasso/src/test/java/com/squareup/picasso3/RemoteViewsActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/RemoteViewsActionTest.java
@@ -30,6 +30,7 @@ import static com.squareup.picasso3.Picasso.LoadedFrom.NETWORK;
 import static com.squareup.picasso3.TestUtils.NO_HANDLERS;
 import static com.squareup.picasso3.TestUtils.NO_TRANSFORMERS;
 import static com.squareup.picasso3.TestUtils.UNUSED_CALL_FACTORY;
+import static com.squareup.picasso3.TestUtils.URI_1;
 import static com.squareup.picasso3.TestUtils.URI_KEY_1;
 import static com.squareup.picasso3.TestUtils.makeBitmap;
 import static com.squareup.picasso3.TestUtils.mockCallback;
@@ -83,7 +84,8 @@ public class RemoteViewsActionTest {
     ImageView target = mockImageViewTarget();
     Callback callback = mockCallback();
     ImageViewAction request =
-        new ImageViewAction(picasso, target, null, 0, 0, 0, null, URI_KEY_1, null, callback, false);
+        new ImageViewAction(picasso, target, new Request.Builder(URI_1).build(), 0, null, URI_KEY_1,
+            null, callback, false);
     request.cancel();
     assertThat(request.callback).isNull();
   }
@@ -93,8 +95,8 @@ public class RemoteViewsActionTest {
   }
 
   private TestableRemoteViewsAction createAction(int errorResId, Callback callback) {
-    return new TestableRemoteViewsAction(picasso, null, remoteViews, 1, errorResId, 0, 0, null,
-        URI_KEY_1, callback);
+    return new TestableRemoteViewsAction(picasso, new Request.Builder(URI_1).build(), remoteViews,
+        1, errorResId, null, URI_KEY_1, callback);
   }
 
   private Picasso createPicasso() {
@@ -104,12 +106,10 @@ public class RemoteViewsActionTest {
         null, NO_TRANSFORMERS, NO_HANDLERS, mock(Stats.class), ARGB_8888, false, false);
   }
 
-  static class TestableRemoteViewsAction extends RemoteViewsAction {
+  static final class TestableRemoteViewsAction extends RemoteViewsAction {
     TestableRemoteViewsAction(Picasso picasso, Request data, RemoteViews remoteViews, int viewId,
-        int errorResId, int memoryPolicy, int networkPolicy, String tag, String key,
-        Callback callback) {
-      super(picasso, data, remoteViews, viewId, errorResId, memoryPolicy, networkPolicy, tag, key,
-          callback);
+        int errorResId, String tag, String key, Callback callback) {
+      super(picasso, data, remoteViews, viewId, errorResId, tag, key, callback);
     }
 
     @Override void update() {

--- a/picasso/src/test/java/com/squareup/picasso3/TargetActionTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TargetActionTest.java
@@ -29,6 +29,7 @@ import static com.squareup.picasso3.TestUtils.NO_HANDLERS;
 import static com.squareup.picasso3.TestUtils.NO_TRANSFORMERS;
 import static com.squareup.picasso3.TestUtils.RESOURCE_ID_1;
 import static com.squareup.picasso3.TestUtils.UNUSED_CALL_FACTORY;
+import static com.squareup.picasso3.TestUtils.URI_1;
 import static com.squareup.picasso3.TestUtils.URI_KEY_1;
 import static com.squareup.picasso3.TestUtils.makeBitmap;
 import static com.squareup.picasso3.TestUtils.mockTarget;
@@ -43,7 +44,8 @@ public class TargetActionTest {
   @Test(expected = AssertionError.class)
   public void throwsErrorWithNullResult() {
     TargetAction request =
-        new TargetAction(mock(Picasso.class), mockTarget(), null, 0, 0, null, URI_KEY_1, null, 0);
+        new TargetAction(mock(Picasso.class), mockTarget(), new Request.Builder(URI_1).build(),
+            null, URI_KEY_1, null, 0);
     request.complete(null, MEMORY);
   }
 
@@ -52,7 +54,8 @@ public class TargetActionTest {
     Bitmap bitmap = makeBitmap();
     Target target = mockTarget();
     TargetAction request =
-        new TargetAction(mock(Picasso.class), target, null, 0, 0, null, URI_KEY_1, null, 0);
+        new TargetAction(mock(Picasso.class), target, new Request.Builder(URI_1).build(), null,
+            URI_KEY_1, null, 0);
     request.complete(bitmap, MEMORY);
     verify(target).onBitmapLoaded(bitmap, MEMORY);
   }
@@ -62,8 +65,8 @@ public class TargetActionTest {
     Drawable errorDrawable = mock(Drawable.class);
     Target target = mockTarget();
     TargetAction request =
-        new TargetAction(mock(Picasso.class), target, null, 0, 0, errorDrawable, URI_KEY_1, null,
-            0);
+        new TargetAction(mock(Picasso.class), target, new Request.Builder(URI_1).build(),
+            errorDrawable, URI_KEY_1, null, 0);
     Exception e = new RuntimeException();
     request.error(e);
     verify(target).onBitmapFailed(e, errorDrawable);
@@ -81,7 +84,8 @@ public class TargetActionTest {
             NO_HANDLERS, mock(Stats.class), ARGB_8888, false, false);
     Resources res = mock(Resources.class);
     TargetAction request =
-        new TargetAction(picasso, target, null, 0, 0, null, URI_KEY_1, null, RESOURCE_ID_1);
+        new TargetAction(picasso, target, new Request.Builder(URI_1).build(), null, URI_KEY_1, null,
+            RESOURCE_ID_1);
 
     when(context.getResources()).thenReturn(res);
     when(res.getDrawable(RESOURCE_ID_1)).thenReturn(errorDrawable);
@@ -107,7 +111,9 @@ public class TargetActionTest {
     Picasso picasso = mock(Picasso.class);
 
     Bitmap bitmap = makeBitmap();
-    TargetAction tr = new TargetAction(picasso, bad, null, 0, 0, null, URI_KEY_1, null, 0);
+    TargetAction tr =
+        new TargetAction(picasso, bad, new Request.Builder(URI_1).build(), null, URI_KEY_1, null,
+            0);
     try {
       tr.complete(bitmap, MEMORY);
       fail();


### PR DESCRIPTION
Not sure how to test this.
https://github.com/square/picasso/issues/1800

Closes https://github.com/square/picasso/issues/1797 but it would be nice to have a test.

note that this lets you set a MemoryPolicy.NO_CACHE in a RequestTransformer which sometimes has an effect and sometimes doesn't.