### PR TITLE
Allow placeholder resIds in remote views

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
@@ -640,7 +640,7 @@ public class RequestCreator {
     if (deferred) {
       throw new IllegalStateException("Fit cannot be used with remote views.");
     }
-    if (placeholderDrawable != null || placeholderResId != 0 || errorDrawable != null) {
+    if (placeholderDrawable != null || errorDrawable != null) {
       throw new IllegalArgumentException(
           "Cannot use placeholder or error drawables with remote views.");
     }


### PR DESCRIPTION
Currently, adding the sample widget crashes due to this superfluous check.