### PR TITLE
Eliminate executor thread scaling.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Dispatcher.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Dispatcher.java
@@ -380,9 +380,6 @@ class Dispatcher {
   }
 
   void performNetworkStateChange(NetworkInfo info) {
-    if (service instanceof PicassoExecutorService) {
-      ((PicassoExecutorService) service).adjustThreadCount(info);
-    }
     // Intentionally check only if isConnected() here before we flush out failed actions.
     if (info != null && info.isConnected()) {
       flushFailedActions();

--- a/picasso/src/main/java/com/squareup/picasso3/PicassoExecutorService.java
+++ b/picasso/src/main/java/com/squareup/picasso3/PicassoExecutorService.java
@@ -15,9 +15,6 @@
  */
 package com.squareup.picasso3;
 
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.telephony.TelephonyManager;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.PriorityBlockingQueue;
@@ -36,49 +33,6 @@ class PicassoExecutorService extends ThreadPoolExecutor {
   PicassoExecutorService() {
     super(DEFAULT_THREAD_COUNT, DEFAULT_THREAD_COUNT, 0, TimeUnit.MILLISECONDS,
         new PriorityBlockingQueue<Runnable>(), new Utils.PicassoThreadFactory());
-  }
-
-  void adjustThreadCount(NetworkInfo info) {
-    if (info == null || !info.isConnectedOrConnecting()) {
-      setThreadCount(DEFAULT_THREAD_COUNT);
-      return;
-    }
-    switch (info.getType()) {
-      case ConnectivityManager.TYPE_WIFI:
-      case ConnectivityManager.TYPE_WIMAX:
-      case ConnectivityManager.TYPE_ETHERNET:
-        setThreadCount(4);
-        break;
-      case ConnectivityManager.TYPE_MOBILE:
-        switch (info.getSubtype()) {
-          case TelephonyManager.NETWORK_TYPE_LTE:  // 4G
-          case TelephonyManager.NETWORK_TYPE_HSPAP:
-          case TelephonyManager.NETWORK_TYPE_EHRPD:
-            setThreadCount(3);
-            break;
-          case TelephonyManager.NETWORK_TYPE_UMTS: // 3G
-          case TelephonyManager.NETWORK_TYPE_CDMA:
-          case TelephonyManager.NETWORK_TYPE_EVDO_0:
-          case TelephonyManager.NETWORK_TYPE_EVDO_A:
-          case TelephonyManager.NETWORK_TYPE_EVDO_B:
-            setThreadCount(2);
-            break;
-          case TelephonyManager.NETWORK_TYPE_GPRS: // 2G
-          case TelephonyManager.NETWORK_TYPE_EDGE:
-            setThreadCount(1);
-            break;
-          default:
-            setThreadCount(DEFAULT_THREAD_COUNT);
-        }
-        break;
-      default:
-        setThreadCount(DEFAULT_THREAD_COUNT);
-    }
-  }
-
-  private void setThreadCount(int threadCount) {
-    setCorePoolSize(threadCount);
-    setMaximumPoolSize(threadCount);
   }
 
   @Override

--- a/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.java
@@ -392,24 +392,6 @@ public class DispatcherTest {
     assertThat(dispatcher.airplaneMode).isFalse();
   }
 
-  @Test public void performNetworkStateChangeWithNullInfo() {
-    dispatcher.performNetworkStateChange(null);
-    verify(service, times(1)).adjustThreadCount(null);
-  }
-
-  @Test public void performNetworkStateChangeWithDisconnectedInfo() {
-    NetworkInfo info = mockNetworkInfo();
-    when(info.isConnectedOrConnecting()).thenReturn(false);
-    dispatcher.performNetworkStateChange(info);
-    verify(service, times(1)).adjustThreadCount(info);
-  }
-
-  @Test public void performNetworkStateChangeWithConnectedInfoDifferentInstance() {
-    NetworkInfo info = mockNetworkInfo(true);
-    dispatcher.performNetworkStateChange(info);
-    verify(service, times(1)).adjustThreadCount(info);
-  }
-
   @Test public void performNetworkStateChangeWithNullInfoIgnores() {
     Dispatcher dispatcher = createDispatcher(serviceMock);
     dispatcher.performNetworkStateChange(null);
@@ -497,16 +479,6 @@ public class DispatcherTest {
   @Test public void performResumeTagIsIdempotent() {
     dispatcher.performResumeTag("tag");
     verify(mainThreadHandler, never()).sendMessage(any(Message.class));
-  }
-
-  @Test
-  public void performNetworkStateChangeWithConnectedInfoAndPicassoExecutorServiceAdjustsThreads() {
-    PicassoExecutorService service = mock(PicassoExecutorService.class);
-    NetworkInfo info = mockNetworkInfo(true);
-    Dispatcher dispatcher = createDispatcher(service);
-    dispatcher.performNetworkStateChange(info);
-    verify(service).adjustThreadCount(info);
-    verifyZeroInteractions(service);
   }
 
   @Test public void performNetworkStateChangeFlushesFailedHunters() {


### PR DESCRIPTION
We're moving to using OkHttp's asynchronous calls and threads and so Picasso will only be responsible for Bitmap decoding. This means that the load is not correlated to the network anymore.