### PR TITLE
Only run CleanupThread under Lollipop (#1894)

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -615,7 +616,8 @@ public class Picasso {
 
     @Override public void run() {
       Process.setThreadPriority(THREAD_PRIORITY_BACKGROUND);
-      while (true) {
+      boolean beforeLollipop = Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
+      while (beforeLollipop) {
         try {
           // Prior to Android 5.0, even when there is no local variable, the result from
           // remove() & obtainMessage() is kept as a stack local variable.

--- a/picasso/src/main/java/com/squareup/picasso3/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Utils.java
@@ -20,6 +20,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -262,6 +263,10 @@ final class Utils {
    * for too long by sending new messages to it every second.
    */
   static void flushStackLocalLeaks(Looper looper) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      return;
+    }
+
     Handler handler = new Handler(looper) {
       @Override public void handleMessage(Message msg) {
         sendMessageDelayed(obtainMessage(), THREAD_LEAK_CLEANING_MS);


### PR DESCRIPTION
It's better to avoid redundant threads running after Android Lollipop (5.0)