### PR TITLE
fix when get bitmap from memory cache but the bitmap is recycled

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/PlatformLruCache.java
+++ b/picasso/src/main/java/com/squareup/picasso3/PlatformLruCache.java
@@ -38,7 +38,7 @@ final class PlatformLruCache {
 
   @Nullable public Bitmap get(@NonNull String key) {
     BitmapAndSize bitmapAndSize = cache.get(key);
-    return bitmapAndSize != null ? bitmapAndSize.bitmap : null;
+    return bitmapAndSize != null && !bitmapAndSize.bitmap.isRecycled() ? bitmapAndSize.bitmap : null;
   }
 
   void set(@NonNull String key, @NonNull Bitmap bitmap) {


### PR DESCRIPTION
  in my project i use picasso to load image,and i use the api Bitmap.recycle() somewhere.but i don't notice this bitmap is also used in memory cache.so next time i took same bitmap from memory cache to use it,but it is recycled and cause some crash.
  so i fix it when get it from memory cache and check if the bitmap is recycled.then this "error" bitmap will be delete from cache in the future. 