### PR TITLE
Empty string & 'null' check for image path in load()

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -27,6 +27,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
 import java.io.File;
@@ -308,12 +309,17 @@ public class Picasso {
    */
   @NonNull
   public RequestCreator load(@Nullable String path) {
-    if (path == null) {
+    // if (path == null) {
+    if (TextUtils.isEmpty(path)) {
       return new RequestCreator(this, null, 0);
     }
+    // Technically 'IllegalArgumentException' could never be thrown, so commenting
+    // TODO | Please remove it while merging
+    /*
     if (path.trim().length() == 0) {
       throw new IllegalArgumentException("Path must not be empty.");
     }
+    */
     return load(Uri.parse(path));
   }
 


### PR DESCRIPTION
This update contains the empty string & 'null' check for image path provided as a parameter to the load() method.
'TextUtils.isEmpty(stringVar)' will check the whether the provided string object is null or is of length '0' (zero).
This will help us avoid throwing of 'IllegalArgumentException' in case of image path is empty.