### PR TITLE
Removing empty image path string check test

### DIFF
--- a/picasso/src/test/java/com/squareup/picasso3/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/PicassoTest.java
@@ -423,11 +423,6 @@ public final class PicassoTest {
 
   @Test public void loadThrowsWithInvalidInput() {
     try {
-      picasso.load("");
-      fail("Empty URL should throw exception.");
-    } catch (IllegalArgumentException expected) {
-    }
-    try {
       picasso.load("      ");
       fail("Empty URL should throw exception.");
     } catch (IllegalArgumentException expected) {


### PR DESCRIPTION
Removing empty image path string check test, as ```Picasso.java``` will be having ```TestUtils.isEmpty(imagePath)``` to validate the empty image path check.