### PR TITLE
Image path null & empty check + removing empty image path string check test

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -27,6 +27,7 @@ import android.support.annotation.DrawableRes;
 import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
 import java.io.File;
@@ -308,7 +309,8 @@ public class Picasso {
    */
   @NonNull
   public RequestCreator load(@Nullable String path) {
-    if (path == null) {
+    // if (path == null) {
+    if (TextUtils.isEmpty(path)) {
       return new RequestCreator(this, null, 0);
     }
     if (path.trim().length() == 0) {

--- a/picasso/src/test/java/com/squareup/picasso3/PicassoTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/PicassoTest.java
@@ -423,11 +423,6 @@ public final class PicassoTest {
 
   @Test public void loadThrowsWithInvalidInput() {
     try {
-      picasso.load("");
-      fail("Empty URL should throw exception.");
-    } catch (IllegalArgumentException expected) {
-    }
-    try {
       picasso.load("      ");
       fail("Empty URL should throw exception.");
     } catch (IllegalArgumentException expected) {


### PR DESCRIPTION
* This update contains the empty string & ```null``` check for image path provided as a parameter to the ```load()``` method.
* ```TextUtils.isEmpty(stringVar)``` will check the whether the provided string object is ```null``` or is of length '0' (zero).
* This will help us avoid throwing of ```IllegalArgumentException``` in case of image path is empty.
* Removing empty image path string check test, as ```Picasso.java``` will be having ```TestUtils.isEmpty(imagePath)``` to validate the empty image path check.