### PR TITLE
Update builtInHandlers count 7 -> 8

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -170,7 +170,7 @@ public class Picasso {
     this.requestTransformers = Collections.unmodifiableList(new ArrayList<>(requestTransformers));
     this.defaultBitmapConfig = defaultBitmapConfig;
 
-    int builtInHandlers = 7; // Adjust this as internal handlers are added or removed.
+    int builtInHandlers = 8; // Adjust this as internal handlers are added or removed.
     int extraCount = extraRequestHandlers.size();
     List<RequestHandler> allRequestHandlers = new ArrayList<>(builtInHandlers + extraCount);
 


### PR DESCRIPTION
If I am not wrong the number of the built-in handlers is 8, so I updated it.

```java
    allRequestHandlers.add(ResourceDrawableRequestHandler.create(context)); // 1
    allRequestHandlers.add(new ResourceRequestHandler(context));            // 2
    allRequestHandlers.add(new ContactsPhotoRequestHandler(context));       // 3
    allRequestHandlers.add(new MediaStoreRequestHandler(context));          // 4
    allRequestHandlers.add(new ContentStreamRequestHandler(context));       // 5
    allRequestHandlers.add(new AssetRequestHandler(context));               // 6
    allRequestHandlers.add(new FileRequestHandler(context));                // 7
    allRequestHandlers.add(new NetworkRequestHandler(callFactory, stats));  // 8
```