### PR TITLE
Ignore case for http(s) scheme

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
@@ -48,7 +48,7 @@ final class NetworkRequestHandler extends RequestHandler {
     if (uri == null) return false;
 
     String scheme = uri.getScheme();
-    return (SCHEME_HTTP.equals(scheme) || SCHEME_HTTPS.equals(scheme));
+    return (SCHEME_HTTP.equalsIgnoreCase(scheme) || SCHEME_HTTPS.equalsIgnoreCase(scheme));
   }
 
   @Override public void load(@NonNull Picasso picasso, @NonNull final Request request, @NonNull

--- a/picasso/src/test/java/com/squareup/picasso3/NetworkRequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/NetworkRequestHandlerTest.java
@@ -214,12 +214,8 @@ public class NetworkRequestHandlerTest {
     };
 
     for (String scheme : schemes) {
-      final Uri uri = URI_1.buildUpon().scheme(scheme).build();
-      final Boolean shouldHandle = networkHandler.canHandleRequest(
-              TestUtils.mockRequest(uri)
-      );
-
-      assertThat(shouldHandle).isTrue();
+      Uri uri = URI_1.buildUpon().scheme(scheme).build();
+      assertThat(networkHandler.canHandleRequest(TestUtils.mockRequest(uri))).isTrue();
     }
   }
 

--- a/picasso/src/test/java/com/squareup/picasso3/NetworkRequestHandlerTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/NetworkRequestHandlerTest.java
@@ -16,6 +16,7 @@
 package com.squareup.picasso3;
 
 import android.net.NetworkInfo;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import com.squareup.picasso3.RequestHandler.Result;
 import com.squareup.picasso3.TestUtils.PremadeCall;
@@ -202,6 +203,26 @@ public class NetworkRequestHandlerTest {
     });
     assertThat(latch.await(10, SECONDS)).isTrue();
   }
+
+  @Test public void shouldHandleSchemeInsensitiveCase() {
+    String[] schemes = {
+            "http",
+            "https",
+            "HTTP",
+            "HTTPS",
+            "HTtP",
+    };
+
+    for (String scheme : schemes) {
+      final Uri uri = URI_1.buildUpon().scheme(scheme).build();
+      final Boolean shouldHandle = networkHandler.canHandleRequest(
+              TestUtils.mockRequest(uri)
+      );
+
+      assertThat(shouldHandle).isTrue();
+    }
+  }
+
 
   private static Response responseOf(ResponseBody body) {
     return new Response.Builder()

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
@@ -133,6 +133,10 @@ class TestUtils {
     return resources;
   }
 
+  static Request mockRequest(Uri uri) {
+    return new Request.Builder(uri).build();
+  }
+
   static Action mockAction(String key, Uri uri) {
     return mockAction(key, uri, null, 0, null, null);
   }


### PR DESCRIPTION
Could not use [normalizeScheme](https://developer.android.com/reference/android/net/Uri.html#normalizeScheme()) due to api level