### PR TITLE
API to add request headers #2007

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
@@ -18,13 +18,14 @@ package com.squareup.picasso3;
 import android.graphics.Bitmap;
 import android.net.NetworkInfo;
 import android.net.Uri;
+
+import java.io.IOException;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import java.io.IOException;
-import java.util.Map;
-
 import okhttp3.CacheControl;
 import okhttp3.Call;
+import okhttp3.Headers;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
@@ -129,11 +130,9 @@ final class NetworkRequestHandler extends RequestHandler {
     if (cacheControl != null) {
       builder.cacheControl(cacheControl);
     }
-    if (request.headers != null) {
-      Map<String, String> headers = request.headers;
-      for (Map.Entry<String, String> entry : headers.entrySet()) {
-        builder.header(entry.getKey(), entry.getValue());
-      }
+    Headers requestHeaders = request.headers;
+    if (requestHeaders != null) {
+      builder.headers(requestHeaders);
     }
     return builder.build();
   }

--- a/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
@@ -18,11 +18,9 @@ package com.squareup.picasso3;
 import android.graphics.Bitmap;
 import android.net.NetworkInfo;
 import android.net.Uri;
-
-import java.io.IOException;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import java.io.IOException;
 import okhttp3.CacheControl;
 import okhttp3.Call;
 import okhttp3.Headers;

--- a/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
+++ b/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.java
@@ -21,6 +21,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import java.io.IOException;
+import java.util.Map;
+
 import okhttp3.CacheControl;
 import okhttp3.Call;
 import okhttp3.Response;
@@ -126,6 +128,12 @@ final class NetworkRequestHandler extends RequestHandler {
     okhttp3.Request.Builder builder = new okhttp3.Request.Builder().url(uri.toString());
     if (cacheControl != null) {
       builder.cacheControl(cacheControl);
+    }
+    if (request.headers != null) {
+      Map<String, String> headers = request.headers;
+      for (Map.Entry<String, String> entry : headers.entrySet()) {
+        builder.header(entry.getKey(), entry.getValue());
+      }
     }
     return builder.build();
   }

--- a/picasso/src/main/java/com/squareup/picasso3/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.java
@@ -19,19 +19,17 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Looper;
 import android.view.Gravity;
-
-import com.squareup.picasso3.Picasso.Priority;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
 import okhttp3.Headers;
+
+import com.squareup.picasso3.Picasso.Priority;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static com.squareup.picasso3.Utils.MAIN_THREAD_KEY_BUILDER;
 import static com.squareup.picasso3.Utils.checkNotNull;

--- a/picasso/src/main/java/com/squareup/picasso3/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.java
@@ -27,6 +27,7 @@ import com.squareup.picasso3.Picasso.Priority;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.squareup.picasso3.Utils.MAIN_THREAD_KEY_BUILDER;
@@ -109,6 +110,9 @@ public final class Request {
   /** User-provided value to track this request. */
   @Nullable
   public final Object tag;
+  /** HTTP headers for the request */
+  @Nullable
+  public Map<String, String> headers;
 
   Request(Builder builder) {
     this.uri = builder.uri;
@@ -142,6 +146,7 @@ public final class Request {
     this.tag = builder.tag;
     this.memoryPolicy = builder.memoryPolicy;
     this.networkPolicy = builder.networkPolicy;
+    this.headers = builder.headers;
   }
 
   @NonNull
@@ -288,6 +293,7 @@ public final class Request {
     @Nullable Object tag;
     int memoryPolicy;
     int networkPolicy;
+    @Nullable Map<String,String> headers;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(@NonNull Uri uri) {
@@ -327,6 +333,7 @@ public final class Request {
       priority = request.priority;
       memoryPolicy = request.memoryPolicy;
       networkPolicy = request.networkPolicy;
+      headers = request.headers;
     }
 
     boolean hasImage() {
@@ -637,6 +644,12 @@ public final class Request {
         }
         this.networkPolicy |= networkPolicy.index;
       }
+      return this;
+    }
+
+    @NonNull
+    public Builder addHeaders(@Nullable Map<String, String> headers) {
+      this.headers = headers;
       return this;
     }
 

--- a/picasso/src/main/java/com/squareup/picasso3/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.java
@@ -293,7 +293,7 @@ public final class Request {
     @Nullable Object tag;
     int memoryPolicy;
     int networkPolicy;
-    @Nullable Map<String,String> headers;
+    @Nullable Map<String, String> headers;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(@NonNull Uri uri) {

--- a/picasso/src/main/java/com/squareup/picasso3/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.java
@@ -648,9 +648,11 @@ public final class Request {
     }
 
     @NonNull
-    public Builder addHeaders(@Nullable Headers headers) {
-      this.headers = headers;
-      return this;
+    public Headers.Builder addHeaders(@NonNull String name, @NonNull String value) {
+      Headers.Builder headers = new Headers.Builder();
+      headers.add(name, value);
+      this.headers = headers.build();
+      return headers;
     }
 
     /** Create the immutable {@link Request} object. */

--- a/picasso/src/main/java/com/squareup/picasso3/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.java
@@ -19,16 +19,19 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Looper;
 import android.view.Gravity;
+
+import com.squareup.picasso3.Picasso.Priority;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
-import com.squareup.picasso3.Picasso.Priority;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import okhttp3.Headers;
 
 import static com.squareup.picasso3.Utils.MAIN_THREAD_KEY_BUILDER;
 import static com.squareup.picasso3.Utils.checkNotNull;
@@ -112,7 +115,7 @@ public final class Request {
   public final Object tag;
   /** HTTP headers for the request */
   @Nullable
-  public Map<String, String> headers;
+  public Headers headers;
 
   Request(Builder builder) {
     this.uri = builder.uri;
@@ -293,7 +296,7 @@ public final class Request {
     @Nullable Object tag;
     int memoryPolicy;
     int networkPolicy;
-    @Nullable Map<String, String> headers;
+    @Nullable Headers headers;
 
     /** Start building a request using the specified {@link Uri}. */
     public Builder(@NonNull Uri uri) {
@@ -648,7 +651,7 @@ public final class Request {
     }
 
     @NonNull
-    public Builder addHeaders(@Nullable Map<String, String> headers) {
+    public Builder addHeaders(@Nullable Headers headers) {
       this.headers = headers;
       return this;
     }

--- a/picasso/src/main/java/com/squareup/picasso3/Request.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.java
@@ -24,7 +24,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.Px;
 import okhttp3.Headers;
-
 import com.squareup.picasso3.Picasso.Priority;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
@@ -402,7 +402,7 @@ public class RequestCreator {
 
   /** Add custom HTTP headers to the image network request if required */
   @NonNull
-  public RequestCreator addHeaders(Map<String, String> headers) {
+  public RequestCreator addHeaders(@Nullable Map<String, String> headers) {
     data.addHeaders(headers);
     return this;
   }

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
@@ -31,7 +31,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import okhttp3.Headers;
-
 import com.squareup.picasso3.RemoteViewsAction.RemoteViewsTarget;
 import java.io.IOException;
 import java.util.List;

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
@@ -24,17 +24,20 @@ import android.net.Uri;
 import android.view.Gravity;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
+
+import com.squareup.picasso3.RemoteViewsAction.RemoteViewsTarget;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
-import com.squareup.picasso3.RemoteViewsAction.RemoteViewsTarget;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
+import okhttp3.Headers;
 
 import static com.squareup.picasso3.BitmapHunter.forRequest;
 import static com.squareup.picasso3.MemoryPolicy.shouldReadFromMemoryCache;
@@ -400,9 +403,11 @@ public class RequestCreator {
     return this;
   }
 
-  /** Add custom HTTP headers to the image network request if required */
+  /**
+   * Add custom HTTP headers to the image network request if required
+   */
   @NonNull
-  public RequestCreator addHeaders(@Nullable Map<String, String> headers) {
+  public RequestCreator addHeaders(@Nullable Headers headers) {
     data.addHeaders(headers);
     return this;
   }

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
@@ -24,13 +24,6 @@ import android.net.Uri;
 import android.view.Gravity;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
-
-import com.squareup.picasso3.RemoteViewsAction.RemoteViewsTarget;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IdRes;
 import androidx.annotation.NonNull;
@@ -38,6 +31,11 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import okhttp3.Headers;
+
+import com.squareup.picasso3.RemoteViewsAction.RemoteViewsTarget;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.squareup.picasso3.BitmapHunter.forRequest;
 import static com.squareup.picasso3.MemoryPolicy.shouldReadFromMemoryCache;

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
@@ -33,6 +33,7 @@ import androidx.core.content.ContextCompat;
 import com.squareup.picasso3.RemoteViewsAction.RemoteViewsTarget;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.squareup.picasso3.BitmapHunter.forRequest;
@@ -396,6 +397,13 @@ public class RequestCreator {
   @NonNull
   public RequestCreator noFade() {
     noFade = true;
+    return this;
+  }
+
+  /** Add custom HTTP headers to the image network request if required */
+  @NonNull
+  public RequestCreator addHeaders(Map<String, String> headers) {
+    data.addHeaders(headers);
     return this;
   }
 

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.java
@@ -404,8 +404,8 @@ public class RequestCreator {
    * Add custom HTTP headers to the image network request if required
    */
   @NonNull
-  public RequestCreator addHeaders(@Nullable Headers headers) {
-    data.addHeaders(headers);
+  public RequestCreator addHeaders(@NonNull String key, @NonNull String value) {
+    data.addHeaders(key, value);
     return this;
   }
 

--- a/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.java
@@ -865,4 +865,18 @@ public class RequestCreatorTest {
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
     assertThat(actionCaptor.getValue().request.purgeable).isTrue();
   }
+
+  @Test public void imageViewActionWithCustomHeaders() {
+    new RequestCreator(picasso, URI_1, 0).addHeaders(TestUtils.makeCustomHearders())
+            .into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().request.headers.get(TestUtils.CUSTOM_HEADER_KEY))
+            .isEqualTo(TestUtils.CUSTOM_HEADER_VALUE);
+  }
+
+  @Test public void imageViewActionWithCustomHeadersNull() {
+    new RequestCreator(picasso, URI_1, 0).addHeaders(null).into(mockImageViewTarget());
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
+    assertThat(actionCaptor.getValue().request.headers).isNull();
+  }
 }

--- a/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.java
@@ -867,16 +867,12 @@ public class RequestCreatorTest {
   }
 
   @Test public void imageViewActionWithCustomHeaders() {
-    new RequestCreator(picasso, URI_1, 0).addHeaders(TestUtils.makeCustomHearders())
+    new RequestCreator(picasso, URI_1, 0).addHeaders(TestUtils.CUSTOM_HEADER_NAME,
+            TestUtils.CUSTOM_HEADER_VALUE)
             .into(mockImageViewTarget());
     verify(picasso).enqueueAndSubmit(actionCaptor.capture());
-    assertThat(actionCaptor.getValue().request.headers.get(TestUtils.CUSTOM_HEADER_KEY))
+    assertThat(actionCaptor.getValue().request.headers.get(TestUtils.CUSTOM_HEADER_NAME))
             .isEqualTo(TestUtils.CUSTOM_HEADER_VALUE);
   }
 
-  @Test public void imageViewActionWithCustomHeadersNull() {
-    new RequestCreator(picasso, URI_1, 0).addHeaders(null).into(mockImageViewTarget());
-    verify(picasso).enqueueAndSubmit(actionCaptor.capture());
-    assertThat(actionCaptor.getValue().request.headers).isNull();
-  }
 }

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
@@ -28,23 +28,19 @@ import android.util.TypedValue;
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
-
+import androidx.annotation.NonNull;
 import com.squareup.picasso3.Picasso.RequestTransformer;
 import com.squareup.picasso3.Utils.PicassoThreadFactory;
-
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 import okhttp3.Call;
 import okhttp3.Headers;
 import okhttp3.Response;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static android.content.ContentResolver.SCHEME_ANDROID_RESOURCE;
 import static android.graphics.Bitmap.Config.ALPHA_8;

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
@@ -108,7 +108,7 @@ class TestUtils {
   static final String XML_RESOURCE_VALUE = "foo.xml";
   static final Bitmap.Config DEFAULT_CONFIG = Bitmap.Config.ARGB_8888;
   static final int DEFAULT_CACHE_SIZE = 123;
-  static final String CUSTOM_HEADER_KEY = "Cache-Control";
+  static final String CUSTOM_HEADER_NAME = "Cache-Control";
   static final String CUSTOM_HEADER_VALUE = "no-cache";
 
   static Context mockPackageResourceContext() {
@@ -311,13 +311,6 @@ class TestUtils {
       }
     };
   }
-
-  static Headers makeCustomHearders() {
-    Headers.Builder builder = new Headers.Builder();
-    builder.add(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE);
-    return builder.build();
-  }
-
   static final Call.Factory UNUSED_CALL_FACTORY = new Call.Factory() {
     @Override public Call newCall(okhttp3.Request request) {
       throw new AssertionError();

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
@@ -35,7 +35,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import okhttp3.Call;
 import okhttp3.Response;
 import org.mockito.invocation.InvocationOnMock;
@@ -107,6 +110,8 @@ class TestUtils {
   static final String XML_RESOURCE_VALUE = "foo.xml";
   static final Bitmap.Config DEFAULT_CONFIG = Bitmap.Config.ARGB_8888;
   static final int DEFAULT_CACHE_SIZE = 123;
+  static final String CUSTOM_HEADER_KEY = "Cache-Control";
+  static final String CUSTOM_HEADER_VALUE = "no-cache";
 
   static Context mockPackageResourceContext() {
     Context context = mock(Context.class);
@@ -307,6 +312,12 @@ class TestUtils {
         return drawable;
       }
     };
+  }
+
+  static Map<String, String> makeCustomHearders() {
+    Map<String, String> customHeaders = new HashMap<>();
+    customHeaders.put(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE);
+    return customHeaders;
   }
 
   static final Call.Factory UNUSED_CALL_FACTORY = new Call.Factory() {

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
@@ -28,21 +28,23 @@ import android.util.TypedValue;
 import android.view.ViewTreeObserver;
 import android.widget.ImageView;
 import android.widget.RemoteViews;
-import androidx.annotation.NonNull;
+
 import com.squareup.picasso3.Picasso.RequestTransformer;
 import com.squareup.picasso3.Utils.PicassoThreadFactory;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
+import androidx.annotation.NonNull;
 import okhttp3.Call;
+import okhttp3.Headers;
 import okhttp3.Response;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import static android.content.ContentResolver.SCHEME_ANDROID_RESOURCE;
 import static android.graphics.Bitmap.Config.ALPHA_8;
@@ -314,10 +316,10 @@ class TestUtils {
     };
   }
 
-  static Map<String, String> makeCustomHearders() {
-    Map<String, String> customHeaders = new HashMap<>();
-    customHeaders.put(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE);
-    return customHeaders;
+  static Headers makeCustomHearders() {
+    Headers.Builder builder = new Headers.Builder();
+    builder.add(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE);
+    return builder.build();
   }
 
   static final Call.Factory UNUSED_CALL_FACTORY = new Call.Factory() {


### PR DESCRIPTION
Implementation of request headers as per the discussion - #2007 

Usage is something like,
```
PicassoProvider.get().load(uri).addHeaders(map).into(view);
```