### PR TITLE
Fix groupId typo in website html

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -197,7 +197,7 @@ limitations under the License.</pre>
 
         // Look up the latest version of the library.
         $.fn.artifactVersion({
-          'groupId': 'com.squareup.picasso',
+          'groupId': 'com.squareup.picasso3',
           'artifactId': 'picasso',
           'packaging': 'aar'
         }, function (version, url) {


### PR DESCRIPTION
Follow-up to https://github.com/square/picasso/pull/2040