### PR TITLE
Fixed implementation line on website

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -123,7 +123,7 @@ Picasso.get().load(new File(...)).into(imageView3);</pre>
 &lt;/dependency></pre>
 
             <h4>Gradle</h4>
-            <pre class="prettyprint">implementation 'com.squareup.picasso3:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
+            <pre class="prettyprint">implementation 'com.squareup.picasso:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
 
             <h3 id="contributing">Contributing</h3>
             <p>If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request.</p>


### PR DESCRIPTION
The website has it as `com.squareup.picasso3:picasso:2.71828` instead of `com.squareup.picasso:picasso:2.71828`
This almost got me. I spent quite some time figuring out why gradle cant resolve picasso suddenly until I saw that the github readme (which had it correct!)
