### PR TITLE
Fix crashing from missing exception for 504s.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.java
@@ -110,11 +110,6 @@ class BitmapHunter implements Runnable {
       } else {
         dispatcher.dispatchComplete(this);
       }
-    } catch (NetworkRequestHandler.ResponseException e) {
-      if (!NetworkPolicy.isOfflineOnly(e.networkPolicy) || e.code != 504) {
-        exception = e;
-      }
-      dispatcher.dispatchFailed(this);
     } catch (IOException e) {
       exception = e;
       dispatcher.dispatchRetry(this);


### PR DESCRIPTION
The BitmapHunter must have either an exception or a result.
Closes #2021
This is handled in the `catch(Exception)` block below.