### PR TITLE
Let high priority images render sooner.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Dispatcher.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Dispatcher.java
@@ -421,7 +421,12 @@ class Dispatcher {
       }
     }
 
-    mainThreadHandler.sendMessage(mainThreadHandler.obtainMessage(HUNTER_COMPLETE, hunter));
+    Message message = mainThreadHandler.obtainMessage(HUNTER_COMPLETE, hunter);
+    if (hunter.priority == Picasso.Priority.HIGH) {
+      mainThreadHandler.sendMessageAtFrontOfQueue(message);
+    } else {
+      mainThreadHandler.sendMessage(message);
+    }
     logDelivery(hunter);
   }
 


### PR DESCRIPTION
High priority images get complete messages sent at the front of the Handler message queue.
Closes #2026