### PR TITLE
Fix non-Bitmap results not continuing transforms.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.java
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.java
@@ -418,29 +418,13 @@ class BitmapHunter implements Runnable {
         return null;
       }
 
-      Bitmap bitmap = result.getBitmap();
-      if (bitmap == null) return result;
-
-      if (newResult == result && bitmap.isRecycled()) {
+      Bitmap bitmap = newResult.getBitmap();
+      if (bitmap != null && bitmap.isRecycled()) {
         Picasso.HANDLER.post(new Runnable() {
           @Override public void run() {
             throw new IllegalStateException("Transformation "
                 + transformation.key()
-                + " returned input Bitmap but recycled it.");
-          }
-        });
-        return null;
-      }
-
-      // If the transformation returned a new bitmap ensure they recycled the original.
-      if (newResult != result
-          && newResult.getBitmap() != bitmap
-          && !bitmap.isRecycled()) {
-        Picasso.HANDLER.post(new Runnable() {
-          @Override public void run() {
-            throw new IllegalStateException("Transformation "
-                + transformation.key()
-                + " mutated input Bitmap but failed to recycle the original.");
+                + " returned a recycled Bitmap.");
           }
         });
         return null;


### PR DESCRIPTION
Also fixes allowing recycled Bitmaps to be returned in transformations and removes unnecessary check for recycling old Bitmaps.

Closes #2055.