### PR TITLE
Expose PicassoExecutorService.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -31,7 +31,6 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
-import com.squareup.picasso3.Utils.PicassoThreadFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +39,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadFactory;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 
@@ -736,24 +734,11 @@ public class Picasso implements LifecycleObserver {
      * Specify the executor service for loading images in the background.
      * <p>
      * Note: Calling {@link Picasso#shutdown() shutdown()} will not shutdown supplied executors.
-     * Note: Calling {@link #threadFactory(ThreadFactory)} overwrites this value.
      */
     @NonNull
     public Builder executor(@NonNull ExecutorService executorService) {
       checkNotNull(executorService, "executorService == null");
       this.service = executorService;
-      return this;
-    }
-
-    /**
-     * Specify the the thread factory for loading images in the background.
-     * <p>
-     * Note: Calling {@link #executor(ExecutorService)} overwrites this value.
-     */
-    @NonNull
-    public Builder threadFactory(@NonNull ThreadFactory threadFactory) {
-      checkNotNull(threadFactory, "threadFactory == null");
-      service = new PicassoExecutorService(threadFactory);
       return this;
     }
 
@@ -831,7 +816,7 @@ public class Picasso implements LifecycleObserver {
         cache = new PlatformLruCache(Utils.calculateMemoryCacheSize(context));
       }
       if (service == null) {
-        service = new PicassoExecutorService(new PicassoThreadFactory());
+        service = new PicassoExecutorService();
       }
 
       Stats stats = new Stats(cache);

--- a/picasso/src/main/java/com/squareup/picasso3/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Utils.java
@@ -23,7 +23,6 @@ import android.content.res.Resources;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.os.Process;
 import android.os.StatFs;
 import android.provider.Settings;
 import android.util.Log;
@@ -34,7 +33,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ThreadFactory;
 import okio.BufferedSource;
 import okio.ByteString;
 
@@ -42,7 +40,6 @@ import static android.content.pm.ApplicationInfo.FLAG_LARGE_HEAP;
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
-import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
 import static com.squareup.picasso3.Picasso.TAG;
 import static java.lang.String.format;
 
@@ -272,22 +269,5 @@ final class Utils {
       }
     };
     handler.sendMessageDelayed(handler.obtainMessage(), THREAD_LEAK_CLEANING_MS);
-  }
-
-  static class PicassoThreadFactory implements ThreadFactory {
-    @Override public Thread newThread(@NonNull Runnable r) {
-      return new PicassoThread(r);
-    }
-  }
-
-  private static class PicassoThread extends Thread {
-    PicassoThread(Runnable r) {
-      super(r);
-    }
-
-    @Override public void run() {
-      Process.setThreadPriority(THREAD_PRIORITY_BACKGROUND);
-      super.run();
-    }
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
@@ -30,7 +30,6 @@ import android.widget.ImageView;
 import android.widget.RemoteViews;
 import androidx.annotation.NonNull;
 import com.squareup.picasso3.Picasso.RequestTransformer;
-import com.squareup.picasso3.Utils.PicassoThreadFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -353,7 +352,7 @@ class TestUtils {
     return builder
         .callFactory(UNUSED_CALL_FACTORY)
         .defaultBitmapConfig(DEFAULT_CONFIG)
-        .executor(new PicassoExecutorService(new PicassoThreadFactory()))
+        .executor(new PicassoExecutorService())
         .indicatorsEnabled(true)
         .listener(NOOP_LISTENER)
         .loggingEnabled(true)


### PR DESCRIPTION
Supplying a custom executor currently means not being able to use Request priority, since there is currently no way to get that information from the internal BitmapHunter in a custom executor.
Exposing PicassoExecutorService lets users tweak settings like the thread count and thread priority easily.
Closes #2064 and #2065.