### PR TITLE
Reduce multiple getLooper calls

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Dispatcher.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Dispatcher.java
@@ -95,14 +95,15 @@ class Dispatcher {
       PlatformLruCache cache, Stats stats) {
     this.dispatcherThread = new DispatcherThread();
     this.dispatcherThread.start();
-    Utils.flushStackLocalLeaks(dispatcherThread.getLooper());
+    Looper dispatcherThreadLooper = dispatcherThread.getLooper();
+    Utils.flushStackLocalLeaks(dispatcherThreadLooper);
     this.context = context;
     this.service = service;
     this.hunterMap = new LinkedHashMap<>();
     this.failedActions = new LinkedHashMap<>();
     this.pausedActions = new LinkedHashMap<>();
     this.pausedTags = new LinkedHashSet<>();
-    this.handler = new DispatcherHandler(dispatcherThread.getLooper(), this);
+    this.handler = new DispatcherHandler(dispatcherThreadLooper, this);
     this.mainThreadHandler = mainThreadHandler;
     this.cache = cache;
     this.stats = stats;

--- a/picasso/src/main/java/com/squareup/picasso3/Stats.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Stats.java
@@ -53,8 +53,9 @@ class Stats {
     this.cache = cache;
     this.statsThread = new HandlerThread(STATS_THREAD_NAME, THREAD_PRIORITY_BACKGROUND);
     this.statsThread.start();
-    Utils.flushStackLocalLeaks(statsThread.getLooper());
-    this.handler = new StatsHandler(statsThread.getLooper(), this);
+    Looper statsThreadLooper = statsThread.getLooper();
+    Utils.flushStackLocalLeaks(statsThreadLooper);
+    this.handler = new StatsHandler(statsThreadLooper, this);
   }
 
   void dispatchBitmapDecoded(Bitmap bitmap) {


### PR DESCRIPTION
This is less of a micro-optimization than a simple workaround to what appears to be a bug in layoutlib, which results in Picasso crashing on creation in Paparazzi tests.  The issue: subsequent calls to `HandlerThread.getLooper()` fail, due to change in `Thread.isAlive()`'s return value.

See https://github.com/cashapp/paparazzi/compare/1524f4c...jrod/2019-09-30/handler-thread-bug for an example test comparison.

as paparazzi test:
```
state: RUNNABLE
isAlive: true
looper: Looper (testThread, tid 17) {121314f7}
state: TERMINATED
isAlive: false
looper: null
state: TERMINATED
isAlive: false
```

as instrumentation test:
```
state: RUNNABLE
isAlive: true
looper: Looper (testThread, tid 612) {9d4c42b}
state: RUNNABLE
isAlive: true
looper: Looper (testThread, tid 612) {9d4c42b}
state: RUNNABLE
isAlive: true
```

Filed as https://issuetracker.google.com/issues/141925961