### PR TITLE
Use https in one-liner intro example

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -44,7 +44,7 @@
           <div class="span9">
             <h3 id="introduction">Introduction</h3>
             <p>Images add much-needed context and visual flair to Android applications. Picasso allows for hassle-free image loading in your application&mdash;often in one line of code!</p>
-            <pre class="prettyprint">Picasso.get().load("http://i.imgur.com/DvpvklR.png").into(imageView);</pre>
+            <pre class="prettyprint">Picasso.get().load("https://i.imgur.com/DvpvklR.png").into(imageView);</pre>
             <p>Many common pitfalls of image loading on Android are handled automatically by Picasso:</p>
             <ul>
               <li>Handling <code>ImageView</code> recycling and download cancelation in an adapter.</li>


### PR DESCRIPTION
The http example won't load on Android 9 using the default network security configuration.
https://developer.android.com/training/articles/security-config.html#CleartextTrafficPermitted