### PR TITLE
Dispatch fail immediately if there's no retries.

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
@@ -77,7 +77,11 @@ internal class BitmapHunter(
       dispatcher.dispatchComplete(this)
     } catch (e: IOException) {
       exception = e
-      dispatcher.dispatchRetry(this)
+      if (retryCount > 0) {
+        dispatcher.dispatchRetry(this)
+      } else {
+        dispatcher.dispatchFailed(this)
+      }
     } catch (e: Exception) {
       exception = e
       dispatcher.dispatchFailed(this)


### PR DESCRIPTION
Removes unnecessary 500ms delay for requests that has no retries.

Fixes issue #2167