### PR TITLE
Use AppStartup to initialize Picasso

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
     androidxExifInterface: 'androidx.exifinterface:exifinterface:1.1.0',
     androidxFragment: 'androidx.fragment:fragment:1.0.0',
     androidxLifecycle: 'androidx.lifecycle:lifecycle-common:2.0.0',
+    androidxStartup: "androidx.startup:startup-runtime:1.0.0",
     errorProne: 'com.google.errorprone:error_prone_core:2.3.2',
     junit: 'junit:junit:4.12',
     truth: 'com.google.truth:truth:0.42',

--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   implementation deps.androidxCore
   implementation deps.androidxExifInterface
   implementation deps.kotlinStdlibJdk8
+  implementation "androidx.startup:startup-runtime:1.0.0"
 
   testImplementation deps.junit
   testImplementation deps.truth

--- a/picasso/src/main/AndroidManifest.xml
+++ b/picasso/src/main/AndroidManifest.xml
@@ -1,1 +1,17 @@
-<manifest package="com.squareup.picasso3"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
+  package="com.squareup.picasso3">
+
+  <application>
+    <provider
+      android:name="androidx.startup.InitializationProvider"
+      android:authorities="${applicationId}.androidx-startup"
+      android:exported="false"
+      tools:node="merge">
+
+      <meta-data
+        android:name="com.squareup.picasso3.PicassoInitializer"
+        android:value="androidx.startup" />
+    </provider>
+  </application>
+</manifest>

--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -191,6 +191,11 @@ public class Picasso implements LifecycleObserver {
     this.loggingEnabled = loggingEnabled;
   }
 
+  @NonNull
+  public static Picasso get() {
+    return PicassoProvider.get();
+  }
+
   @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
   void cancelAll() {
     checkMain();

--- a/picasso/src/main/java/com/squareup/picasso3/PicassoInitializer.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/PicassoInitializer.kt
@@ -1,0 +1,20 @@
+package com.squareup.picasso3
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.startup.Initializer
+
+internal class PicassoInitializer : Initializer<Unit> {
+
+  override fun create(context: Context) {
+    appContext = context
+  }
+
+  override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+
+  companion object {
+    @SuppressLint("StaticFieldLeak")
+    @JvmField
+    var appContext: Context? = null
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso3/PicassoProvider.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/PicassoProvider.kt
@@ -1,0 +1,11 @@
+package com.squareup.picasso3
+
+internal object PicassoProvider {
+
+  private val instance: Picasso by lazy {
+    Picasso.Builder(checkNotNull(PicassoInitializer.appContext)).build()
+  }
+
+  @JvmStatic
+  fun get() = instance
+}


### PR DESCRIPTION
I noticed that Picasso has used ContentProvider to get the application context, but it is removed from the library now. As this issue #2189 said, it may be a nice thing to use AppStartup now.

This PR uses AppStartup to save the application context object, which is used when creating a static singleton Picasso.

Note:
Although AppStartup reduces the costs when initializing the ContentProvider one by one, but it uses reflection to create the Initializer object (PicassoInitializer), so it worth to discuss the risks and benefits of this PR.