### PR TITLE
Fix invoking on a nullable exception object in Picasso#deliverAction

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -623,7 +623,7 @@ public class Picasso implements LifecycleObserver {
         log(OWNER_MAIN, VERB_COMPLETED, action.request.logId(), "from " + result.loadedFrom);
       }
     } else {
-      Exception exception = checkNotNull(e, "e == null");
+      Exception exception = (e != null) ? e : new RuntimeException("e == null");
       action.error(exception);
       if (loggingEnabled) {
         log(OWNER_MAIN, VERB_ERRORED, action.request.logId(), exception.getMessage());


### PR DESCRIPTION
I did not reproduce this crash #2158 , but found the code at `Picasso#deliverAction(Exception e)` which `e` is a **Nullable** parameter and use `checkNotNull` to check the parameter `e` , it is the main cause.

This PR create new RuntimeException when parameter `e` is a null value.