### PR TITLE
Fix regression in BitmapHunter

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
@@ -138,8 +138,7 @@ internal class BitmapHunter(
       }
     }
 
-    val result = resultReference.get() as? Bitmap
-      ?: throw AssertionError("Request handler neither returned a result nor an exception.")
+    val result = resultReference.get() as? Bitmap ?: return null
     val bitmap = result.bitmap
     if (picasso.loggingEnabled) {
       log(OWNER_HUNTER, VERB_DECODED, data.logId())


### PR DESCRIPTION
Introduced here: https://github.com/square/picasso/commit/466781f8feca2418e5d36eb45aa0cc0a7d8e1b62

Previous behavior would return the null Bitmap from a custom RequestHandler and consider it a dispatchFailure