### PR TITLE
Temporarily downgrade androidx.core to 1.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     mockWebServer: "com.squareup.okhttp3:mockwebserver:${versions.okhttp}",
     pollexor: 'com.squareup:pollexor:2.0.4',
     androidxAnnotations: 'androidx.annotation:annotation:1.3.0',
-    androidxCore: 'androidx.core:core:1.7.0',
+    androidxCore: 'androidx.core:core:1.6.0',
     androidxCursorAdapter: 'androidx.cursoradapter:cursoradapter:1.0.0',
     androidxExifInterface: 'androidx.exifinterface:exifinterface:1.3.3',
     androidxFragment: 'androidx.fragment:fragment:1.4.0',


### PR DESCRIPTION
1.7.0 implements S-related APIs which interferes with Paparazzi, which awaits the Bumblebee release of LayoutLib.