### PR TITLE
Bump Pollexor dep to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     okhttp: "com.squareup.okhttp3:okhttp:${versions.okhttp}",
     okio: "com.squareup.okio:okio:${versions.okio}",
     mockWebServer: "com.squareup.okhttp3:mockwebserver:${versions.okhttp}",
-    pollexor: 'com.squareup:pollexor:2.0.4',
+    pollexor: 'com.squareup:pollexor:3.0.0',
     androidxAnnotations: 'androidx.annotation:annotation:1.3.0',
     androidxCore: 'androidx.core:core:1.6.0',
     androidxCursorAdapter: 'androidx.cursoradapter:cursoradapter:1.0.0',


### PR DESCRIPTION
Pollexor [removed](https://github.com/square/pollexor/blob/3.0.0/CHANGELOG.md) a function with vulnerable code that isn't being used, so bumping it shouldn't affect anything in terms of functionality/usage.