### PR TITLE
Explicitly publish to Maven Central

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
           java-version: 11
 
       - name: Publish Artifacts
-        run: ./gradlew publish
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
Since we also now have an 'internal' repository defined