### PR TITLE
Remove threadFactory, expose internal ExecutorService

### DIFF
--- a/picasso/api/picasso.api
+++ b/picasso/api/picasso.api
@@ -121,7 +121,6 @@ public class com/squareup/picasso3/Picasso$Builder {
 	public fun indicatorsEnabled (Z)Lcom/squareup/picasso3/Picasso$Builder;
 	public fun listener (Lcom/squareup/picasso3/Picasso$Listener;)Lcom/squareup/picasso3/Picasso$Builder;
 	public fun loggingEnabled (Z)Lcom/squareup/picasso3/Picasso$Builder;
-	public fun threadFactory (Ljava/util/concurrent/ThreadFactory;)Lcom/squareup/picasso3/Picasso$Builder;
 	public fun withCacheSize (I)Lcom/squareup/picasso3/Picasso$Builder;
 }
 
@@ -147,6 +146,13 @@ public final class com/squareup/picasso3/Picasso$Priority : java/lang/Enum {
 
 public abstract interface class com/squareup/picasso3/Picasso$RequestTransformer {
 	public abstract fun transformRequest (Lcom/squareup/picasso3/Request;)Lcom/squareup/picasso3/Request;
+}
+
+public final class com/squareup/picasso3/PicassoExecutorService : java/util/concurrent/ThreadPoolExecutor {
+	public fun <init> ()V
+	public fun <init> (ILjava/util/concurrent/ThreadFactory;)V
+	public synthetic fun <init> (ILjava/util/concurrent/ThreadFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun submit (Ljava/lang/Runnable;)Ljava/util/concurrent/Future;
 }
 
 public final class com/squareup/picasso3/Request {

--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -32,7 +32,6 @@ import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.OnLifecycleEvent;
 import com.squareup.picasso3.RequestHandler.Result;
-import com.squareup.picasso3.Utils.PicassoThreadFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -41,7 +40,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadFactory;
 import okhttp3.Call;
 import okhttp3.OkHttpClient;
 
@@ -731,24 +729,11 @@ public class Picasso implements LifecycleObserver {
      * Specify the executor service for loading images in the background.
      * <p>
      * Note: Calling {@link Picasso#shutdown() shutdown()} will not shutdown supplied executors.
-     * Note: Calling {@link #threadFactory(ThreadFactory)} overwrites this value.
      */
     @NonNull
     public Builder executor(@NonNull ExecutorService executorService) {
       checkNotNull(executorService, "executorService == null");
       this.service = executorService;
-      return this;
-    }
-
-    /**
-     * Specify the the thread factory for loading images in the background.
-     * <p>
-     * Note: Calling {@link #executor(ExecutorService)} overwrites this value.
-     */
-    @NonNull
-    public Builder threadFactory(@NonNull ThreadFactory threadFactory) {
-      checkNotNull(threadFactory, "threadFactory == null");
-      service = new PicassoExecutorService(threadFactory);
       return this;
     }
 
@@ -834,7 +819,7 @@ public class Picasso implements LifecycleObserver {
         cache = new PlatformLruCache(Utils.calculateMemoryCacheSize(context));
       }
       if (service == null) {
-        service = new PicassoExecutorService(new PicassoThreadFactory());
+        service = new PicassoExecutorService();
       }
 
       Dispatcher dispatcher = new Dispatcher(context, service, HANDLER, cache);

--- a/picasso/src/main/java/com/squareup/picasso3/Utils.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Utils.java
@@ -23,7 +23,6 @@ import android.content.res.Resources;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.os.Process;
 import android.os.StatFs;
 import android.provider.Settings;
 import android.util.Log;
@@ -34,7 +33,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ThreadFactory;
 import okio.BufferedSource;
 import okio.ByteString;
 
@@ -42,7 +40,6 @@ import static android.content.pm.ApplicationInfo.FLAG_LARGE_HEAP;
 import static android.os.Build.VERSION.SDK_INT;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR1;
 import static android.os.Build.VERSION_CODES.JELLY_BEAN_MR2;
-import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
 import static com.squareup.picasso3.Picasso.TAG;
 import static java.lang.String.format;
 
@@ -272,22 +269,5 @@ final class Utils {
       }
     };
     handler.sendMessageDelayed(handler.obtainMessage(), THREAD_LEAK_CLEANING_MS);
-  }
-
-  static class PicassoThreadFactory implements ThreadFactory {
-    @Override public Thread newThread(@NonNull Runnable r) {
-      return new PicassoThread(r);
-    }
-  }
-
-  private static class PicassoThread extends Thread {
-    PicassoThread(Runnable r) {
-      super(r);
-    }
-
-    @Override public void run() {
-      Process.setThreadPriority(THREAD_PRIORITY_BACKGROUND);
-      super.run();
-    }
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.java
+++ b/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.java
@@ -25,7 +25,6 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import com.squareup.picasso3.NetworkRequestHandler.ContentLengthException;
 import com.squareup.picasso3.TestUtils.TestDelegatingService;
-import com.squareup.picasso3.Utils.PicassoThreadFactory;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.FutureTask;
 import org.junit.Before;
@@ -71,8 +70,7 @@ public class DispatcherTest {
   @Mock ConnectivityManager connectivityManager;
   @Mock ExecutorService serviceMock;
   final PlatformLruCache cache = new PlatformLruCache(2048);
-  final TestDelegatingService service =
-      new TestDelegatingService(new PicassoExecutorService(new PicassoThreadFactory()));
+  final TestDelegatingService service = new TestDelegatingService(new PicassoExecutorService());
   private Dispatcher dispatcher;
 
   final Bitmap bitmap1 = makeBitmap();
@@ -84,7 +82,7 @@ public class DispatcherTest {
   }
 
   @Test public void shutdownStopsService() {
-    PicassoExecutorService service = new PicassoExecutorService(new PicassoThreadFactory());
+    PicassoExecutorService service = new PicassoExecutorService();
     dispatcher = createDispatcher(service);
     dispatcher.shutdown();
     assertThat(service.isShutdown()).isEqualTo(true);

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.java
@@ -30,7 +30,6 @@ import android.widget.ImageView;
 import android.widget.RemoteViews;
 import androidx.annotation.NonNull;
 import com.squareup.picasso3.Picasso.RequestTransformer;
-import com.squareup.picasso3.Utils.PicassoThreadFactory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
@@ -355,7 +354,7 @@ class TestUtils {
     return builder
         .callFactory(UNUSED_CALL_FACTORY)
         .defaultBitmapConfig(DEFAULT_CONFIG)
-        .executor(new PicassoExecutorService(new PicassoThreadFactory()))
+        .executor(new PicassoExecutorService())
         .indicatorsEnabled(true)
         .listener(NOOP_LISTENER)
         .loggingEnabled(true)


### PR DESCRIPTION
Allows for tweaking thread count and thread priority, which helps in Paparazzi tests.  Also, sets up later refactoring to coroutine based execution.

Closes #2064, #2065, #2068