### PR TITLE
Fix regression in deliverAction when result is null

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.java
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.java
@@ -620,11 +620,10 @@ public class Picasso implements LifecycleObserver {
       if (loggingEnabled) {
         log(OWNER_MAIN, VERB_COMPLETED, action.request.logId(), "from " + result.loadedFrom);
       }
-    } else {
-      Exception exception = checkNotNull(e, "e == null");
-      action.error(exception);
+    } else if (e != null) {
+      action.error(e);
       if (loggingEnabled) {
-        log(OWNER_MAIN, VERB_ERRORED, action.request.logId(), exception.getMessage());
+        log(OWNER_MAIN, VERB_ERRORED, action.request.logId(), e.getMessage());
       }
     }
   }


### PR DESCRIPTION
For now, RequestHandler.Callback allows for null results
https://github.com/square/picasso/blob/master/picasso/src/main/java/com/squareup/picasso3/RequestHandler.kt#L69

Regression here:
https://github.com/square/picasso/commit/466781f8feca2418e5d36eb45aa0cc0a7d8e1b62#diff-e61c6cbb5e6fb101dd974f62a248c45cba113daf5d887a01b6df3485b967d31d

Long-term, presence of result or exception should be mutally exclusive.