### PR TITLE
Fix 3.0 resource loading crash

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
@@ -45,7 +45,6 @@ import com.squareup.picasso3.Utils.VERB_RESUMED
 import com.squareup.picasso3.Utils.calculateDiskCacheSize
 import com.squareup.picasso3.Utils.calculateMemoryCacheSize
 import com.squareup.picasso3.Utils.checkMain
-import com.squareup.picasso3.Utils.checkNotNull
 import com.squareup.picasso3.Utils.createDefaultCacheDir
 import com.squareup.picasso3.Utils.log
 import okhttp3.Cache
@@ -435,7 +434,6 @@ class Picasso internal constructor(
       return
     }
 
-    val uri = checkNotNull(hunter.data.uri, "uri == null")
     val exception = hunter.exception
     val result = hunter.result
 
@@ -448,7 +446,7 @@ class Picasso internal constructor(
     }
 
     if (listener != null && exception != null) {
-      listener.onImageLoadFailed(this, uri, exception)
+      listener.onImageLoadFailed(this, hunter.data.uri, exception)
     }
   }
 
@@ -742,7 +740,7 @@ class Picasso internal constructor(
      * Invoked when an image has failed to load. This is useful for reporting image failures to a
      * remote analytics service, for example.
      */
-    fun onImageLoadFailed(picasso: Picasso, uri: Uri, exception: Exception)
+    fun onImageLoadFailed(picasso: Picasso, uri: Uri?, exception: Exception)
   }
 
   /**

--- a/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
@@ -156,6 +156,23 @@ class PicassoTest {
     verify(listener).onImageLoadFailed(picasso, URI_1, action1.errorException!!)
   }
 
+  @Test fun completeInvokesErrorOnFailedResourceRequests() {
+    val action = mockAction(
+      picasso = picasso,
+      key = URI_KEY_1,
+      uri = null,
+      resourceId = 123,
+      target = mockImageViewTarget()
+    )
+    val exception = mock(Exception::class.java)
+    val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap, MEMORY), action, exception)
+    hunter.run()
+    picasso.complete(hunter)
+
+    assertThat(action.errorException).hasCauseThat().isEqualTo(exception)
+    verify(listener).onImageLoadFailed(picasso, null, action.errorException!!)
+  }
+
   @Test fun completeDeliversToSingle() {
     val action = mockAction(picasso, URI_KEY_1, URI_1, mockImageViewTarget())
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap, MEMORY), action)

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.kt
@@ -272,7 +272,7 @@ internal object TestUtils {
     override fun load(picasso: Picasso, request: Request, callback: Callback) = Unit
   }
   val NOOP_TRANSFORMER = RequestTransformer { Request.Builder(0).build() }
-  private val NOOP_LISTENER = Picasso.Listener { _: Picasso, _: Uri, _: Exception -> }
+  private val NOOP_LISTENER = Picasso.Listener { _: Picasso, _: Uri?, _: Exception -> }
   val NO_TRANSFORMERS: List<RequestTransformer> = emptyList()
   val NO_HANDLERS: List<RequestHandler> = emptyList()
   val NO_EVENT_LISTENERS: List<EventListener> = emptyList()


### PR DESCRIPTION
Version 2.8 of Picasso did not require, at hunt completion time, that the request’s uri was non-null (it was always null for resource requests). During Kotlinization we seem to have mistakenly required it to be non-null.

References:
[Picasso 2.8 in Java reading hunter.data.uri without enforcing non-nullability](https://github.com/square/picasso/blob/2.8/picasso/src/main/java/com/squareup/picasso/Picasso.java#L522)
[Picasso 2.8 in Java not requiring non-null values in Listener callback](https://github.com/square/picasso/blob/2.8/picasso/src/main/java/com/squareup/picasso/Picasso.java#L73)