### PR TITLE
Remove ViewAnimator from SampleGalleryActivity

### DIFF
--- a/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.kt
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.kt
@@ -20,14 +20,16 @@ import android.content.Intent
 import android.os.Bundle
 import android.provider.MediaStore.Images.Media
 import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
 import android.widget.ImageView
-import android.widget.ViewAnimator
+import android.widget.ProgressBar
 import com.example.picasso.provider.PicassoProvider
 import com.squareup.picasso3.Callback.EmptyCallback
 
 class SampleGalleryActivity : PicassoSampleActivity() {
   private lateinit var imageView: ImageView
-  lateinit var animator: ViewAnimator
+  private lateinit var progressBar: ProgressBar
 
   private var image: String? = null
 
@@ -35,8 +37,8 @@ class SampleGalleryActivity : PicassoSampleActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.sample_gallery_activity)
 
-    animator = findViewById(R.id.animator)
     imageView = findViewById(R.id.image)
+    progressBar = findViewById(R.id.progress)
 
     findViewById<View>(R.id.go).setOnClickListener {
       val gallery = Intent(Intent.ACTION_PICK, Media.EXTERNAL_CONTENT_URI)
@@ -70,9 +72,7 @@ class SampleGalleryActivity : PicassoSampleActivity() {
   }
 
   private fun loadImage() {
-    // Index 1 is the progress bar. Show it while we're loading the image.
-    animator.displayedChild = 1
-
+    progressBar.visibility = VISIBLE
     PicassoProvider.get()
       .load(image)
       .fit()
@@ -81,8 +81,7 @@ class SampleGalleryActivity : PicassoSampleActivity() {
         imageView,
         object : EmptyCallback() {
           override fun onSuccess() {
-            // Index 0 is the image view.
-            animator.displayedChild = 0
+            progressBar.visibility = GONE
           }
         }
       )

--- a/picasso-sample/src/main/res/layout/sample_gallery_activity.xml
+++ b/picasso-sample/src/main/res/layout/sample_gallery_activity.xml
@@ -4,26 +4,19 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-  <ViewAnimator
-      android:id="@+id/animator"
+  <ImageView
+      android:id="@+id/image"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:background="#ffc0c0c0"
-      android:animateFirstView="false"
-      >
-    <ImageView
-        android:id="@+id/image"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:contentDescription="@string/sample_gallery"
-        />
-    <ProgressBar
-        android:id="@+id/progress"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        />
-  </ViewAnimator>
+      android:contentDescription="@string/sample_gallery"
+      />
+  <ProgressBar
+      android:id="@+id/progress"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:visibility="gone"
+      />
 
   <Button
       android:id="@+id/go"


### PR DESCRIPTION
ViewAnimator sets non-visible children to GONE which when used with ImageView causes Picasso's DeferredRequestCreator to never continue with the request because the ImageView never gets laid out.