### PR TITLE
Formalize minSdk bump to API 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ or Maven:
 
 Snapshots of the development version are available in [Sonatype's `snapshots` repository][snap].
 
+Picasso requires at minimum Java 8 and API 21.
 
 
 ProGuard

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.versions = [
     'compileSdk': 31,
-    'minSdk': 14,
+    'minSdk': 21,
     'targetSdk': 31,
     'sourceCompatibility': JavaVersion.VERSION_1_8,
     'targetCompatibility': JavaVersion.VERSION_1_8,

--- a/picasso-pollexor/src/main/java/com/squareup/picasso3/pollexor/PollexorRequestTransformer.kt
+++ b/picasso-pollexor/src/main/java/com/squareup/picasso3/pollexor/PollexorRequestTransformer.kt
@@ -16,8 +16,6 @@
 package com.squareup.picasso3.pollexor
 
 import android.net.Uri
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import com.squareup.picasso3.Picasso.RequestTransformer
 import com.squareup.picasso3.Request
 import com.squareup.picasso3.pollexor.PollexorRequestTransformer.Callback
@@ -73,10 +71,8 @@ class PollexorRequestTransformer @JvmOverloads constructor(
       newRequest.clearCenterInside()
     }
 
-    // If the Android version is modern enough use WebP for downloading.
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR2) {
-      urlBuilder.filter(ThumborUrlBuilder.format(WEBP))
-    }
+    // Use WebP for downloading.
+    urlBuilder.filter(ThumborUrlBuilder.format(WEBP))
 
     // Update the request with the completed Thumbor URL.
     newRequest.setUri(Uri.parse(urlBuilder.toUrl()))

--- a/picasso-pollexor/src/test/java/com/squareup/picasso3/pollexor/PollexorRequestTransformerTest.kt
+++ b/picasso-pollexor/src/test/java/com/squareup/picasso3/pollexor/PollexorRequestTransformerTest.kt
@@ -24,10 +24,8 @@ import com.squareup.pollexor.ThumborUrlBuilder.ImageFormat.WEBP
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [17], manifest = Config.NONE)
 class PollexorRequestTransformerTest {
   private val transformer = PollexorRequestTransformer(Thumbor.create(HOST))
   private val secureTransformer = PollexorRequestTransformer(Thumbor.create(HOST, KEY))
@@ -67,22 +65,15 @@ class PollexorRequestTransformerTest {
     val output = alwaysResizeTransformer.transformRequest(input)
     assertThat(output).isNotSameInstanceAs(input)
     assertThat(output.hasSize()).isFalse()
-    val expected = Thumbor.create(HOST).buildImage(IMAGE).toUrl()
+
+    val expected = Thumbor.create(HOST)
+      .buildImage(IMAGE)
+      .filter(ThumborUrlBuilder.format(WEBP))
+      .toUrl()
     assertThat(output.uri.toString()).isEqualTo(expected)
   }
 
   @Test fun simpleResize() {
-    val input = Builder(IMAGE_URI).resize(50, 50).build()
-    val output = transformer.transformRequest(input)
-    assertThat(output).isNotSameInstanceAs(input)
-    assertThat(output.hasSize()).isFalse()
-
-    val expected = Thumbor.create(HOST).buildImage(IMAGE).resize(50, 50).toUrl()
-    assertThat(output.uri.toString()).isEqualTo(expected)
-  }
-
-  @Config(sdk = [18])
-  @Test fun simpleResizeOnJbMr2UsesWebP() {
     val input = Builder(IMAGE_URI).resize(50, 50).build()
     val output = transformer.transformRequest(input)
     assertThat(output).isNotSameInstanceAs(input)
@@ -103,7 +94,11 @@ class PollexorRequestTransformerTest {
     assertThat(output.hasSize()).isFalse()
     assertThat(output.centerCrop).isFalse()
 
-    val expected = Thumbor.create(HOST).buildImage(IMAGE).resize(50, 50).toUrl()
+    val expected = Thumbor.create(HOST)
+      .buildImage(IMAGE)
+      .resize(50, 50)
+      .filter(ThumborUrlBuilder.format(WEBP))
+      .toUrl()
     assertThat(output.uri.toString()).isEqualTo(expected)
   }
 
@@ -114,7 +109,12 @@ class PollexorRequestTransformerTest {
     assertThat(output.hasSize()).isFalse()
     assertThat(output.centerInside).isFalse()
 
-    val expected = Thumbor.create(HOST).buildImage(IMAGE).resize(50, 50).fitIn().toUrl()
+    val expected = Thumbor.create(HOST)
+      .buildImage(IMAGE)
+      .resize(50, 50)
+      .filter(ThumborUrlBuilder.format(WEBP))
+      .fitIn()
+      .toUrl()
     assertThat(output.uri.toString()).isEqualTo(expected)
   }
 
@@ -124,7 +124,11 @@ class PollexorRequestTransformerTest {
     assertThat(output).isNotSameInstanceAs(input)
     assertThat(output.hasSize()).isFalse()
 
-    val expected = Thumbor.create(HOST, KEY).buildImage(IMAGE).resize(50, 50).toUrl()
+    val expected = Thumbor.create(HOST, KEY)
+      .buildImage(IMAGE)
+      .resize(50, 50)
+      .filter(ThumborUrlBuilder.format(WEBP))
+      .toUrl()
     assertThat(output.uri.toString()).isEqualTo(expected)
   }
 
@@ -135,7 +139,12 @@ class PollexorRequestTransformerTest {
     assertThat(output.hasSize()).isFalse()
     assertThat(output.centerInside).isFalse()
 
-    val expected = Thumbor.create(HOST, KEY).buildImage(IMAGE).resize(50, 50).fitIn().toUrl()
+    val expected = Thumbor.create(HOST, KEY)
+      .buildImage(IMAGE)
+      .resize(50, 50)
+      .filter(ThumborUrlBuilder.format(WEBP))
+      .fitIn()
+      .toUrl()
     assertThat(output.uri.toString()).isEqualTo(expected)
   }
 
@@ -148,6 +157,7 @@ class PollexorRequestTransformerTest {
       .buildImage(IMAGE)
       .resize(50, 50)
       .filter("custom")
+      .filter(ThumborUrlBuilder.format(WEBP))
       .toUrl()
     assertThat(output.uri.toString()).isEqualTo(expected)
   }

--- a/picasso/api/picasso.api
+++ b/picasso/api/picasso.api
@@ -155,7 +155,6 @@ public final class com/squareup/picasso3/Request {
 	public final field networkPolicy I
 	public final field onlyScaleDown Z
 	public final field priority Lcom/squareup/picasso3/Picasso$Priority;
-	public final field purgeable Z
 	public final field resourceId I
 	public final field rotationDegrees F
 	public final field rotationPivotX F
@@ -200,7 +199,6 @@ public final class com/squareup/picasso3/Request$Builder {
 	public final fun getNetworkPolicy ()I
 	public final fun getOnlyScaleDown ()Z
 	public final fun getPriority ()Lcom/squareup/picasso3/Picasso$Priority;
-	public final fun getPurgeable ()Z
 	public final fun getResourceId ()I
 	public final fun getRotationDegrees ()F
 	public final fun getRotationPivotX ()F
@@ -218,7 +216,6 @@ public final class com/squareup/picasso3/Request$Builder {
 	public final fun networkPolicy (Lcom/squareup/picasso3/NetworkPolicy;[Lcom/squareup/picasso3/NetworkPolicy;)Lcom/squareup/picasso3/Request$Builder;
 	public final fun onlyScaleDown ()Lcom/squareup/picasso3/Request$Builder;
 	public final fun priority (Lcom/squareup/picasso3/Picasso$Priority;)Lcom/squareup/picasso3/Request$Builder;
-	public final fun purgeable ()Lcom/squareup/picasso3/Request$Builder;
 	public final fun resize (II)Lcom/squareup/picasso3/Request$Builder;
 	public final fun rotate (F)Lcom/squareup/picasso3/Request$Builder;
 	public final fun rotate (FFF)Lcom/squareup/picasso3/Request$Builder;
@@ -231,7 +228,6 @@ public final class com/squareup/picasso3/Request$Builder {
 	public final fun setNetworkPolicy (I)V
 	public final fun setOnlyScaleDown (Z)V
 	public final fun setPriority (Lcom/squareup/picasso3/Picasso$Priority;)V
-	public final fun setPurgeable (Z)V
 	public final fun setResourceId (I)Lcom/squareup/picasso3/Request$Builder;
 	public final fun setResourceId (I)V
 	public final fun setRotationDegrees (F)V
@@ -283,7 +279,6 @@ public final class com/squareup/picasso3/RequestCreator {
 	public final fun placeholder (I)Lcom/squareup/picasso3/RequestCreator;
 	public final fun placeholder (Landroid/graphics/drawable/Drawable;)Lcom/squareup/picasso3/RequestCreator;
 	public final fun priority (Lcom/squareup/picasso3/Picasso$Priority;)Lcom/squareup/picasso3/RequestCreator;
-	public final fun purgeable ()Lcom/squareup/picasso3/RequestCreator;
 	public final fun resize (II)Lcom/squareup/picasso3/RequestCreator;
 	public final fun resizeDimen (II)Lcom/squareup/picasso3/RequestCreator;
 	public final fun rotate (F)Lcom/squareup/picasso3/RequestCreator;

--- a/picasso/src/main/java/com/squareup/picasso3/BitmapUtils.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapUtils.kt
@@ -21,7 +21,6 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.ImageDecoder
-import android.os.Build
 import android.os.Build.VERSION
 import android.util.TypedValue
 import androidx.annotation.DrawableRes
@@ -43,11 +42,9 @@ internal object BitmapUtils {
    */
   fun createBitmapOptions(data: Request): BitmapFactory.Options? {
     val justBounds = data.hasSize()
-    return if (justBounds || data.config != null || data.purgeable) {
+    return if (justBounds || data.config != null) {
       BitmapFactory.Options().apply {
         inJustDecodeBounds = justBounds
-        inInputShareable = data.purgeable
-        inPurgeable = data.purgeable
         if (data.config != null) {
           inPreferredConfig = data.config
         }
@@ -121,13 +118,11 @@ internal object BitmapUtils {
 
   private fun decodeStreamPreP(request: Request, bufferedSource: BufferedSource): Bitmap {
     val isWebPFile = Utils.isWebPFile(bufferedSource)
-    val isPurgeable = request.purgeable && VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
     val options = createBitmapOptions(request)
     val calculateSize = requiresInSampleSize(options)
-    // We decode from a byte array because, a) when decoding a WebP network stream, BitmapFactory
-    // throws a JNI Exception, so we workaround by decoding a byte array, or b) user requested
-    // purgeable, which only affects bitmaps decoded from byte arrays.
-    val bitmap = if (isWebPFile || isPurgeable) {
+    // We decode from a byte array because, when decoding a WebP network stream, BitmapFactory
+    // throws a JNI Exception, so we workaround by decoding a byte array.
+    val bitmap = if (isWebPFile) {
       val bytes = bufferedSource.readByteArray()
       if (calculateSize) {
         BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)

--- a/picasso/src/main/java/com/squareup/picasso3/Request.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.kt
@@ -106,9 +106,6 @@ class Request internal constructor(builder: Builder) {
   /** Whether or not [.rotationPivotX] and [.rotationPivotY] are set. */
   @JvmField val hasRotationPivot: Boolean = builder.hasRotationPivot
 
-  /** True if image should be decoded with inPurgeable and inInputShareable. */
-  @JvmField val purgeable: Boolean = builder.purgeable
-
   /** Target image config for decoding. */
   @JvmField val config: Config? = builder.config
 
@@ -166,9 +163,6 @@ class Request internal constructor(builder: Builder) {
           append(rotationPivotY)
         }
         append(')')
-      }
-      if (purgeable) {
-        append(" purgeable")
       }
       if (config != null) {
         append(' ')
@@ -284,7 +278,6 @@ class Request internal constructor(builder: Builder) {
     var rotationPivotX = 0f
     var rotationPivotY = 0f
     var hasRotationPivot = false
-    var purgeable = false
     var transformations: MutableList<Transformation>? = null
     var config: Config? = null
     var priority: Priority? = null
@@ -326,7 +319,6 @@ class Request internal constructor(builder: Builder) {
       rotationPivotX = request.rotationPivotX
       rotationPivotY = request.rotationPivotY
       hasRotationPivot = request.hasRotationPivot
-      purgeable = request.purgeable
       onlyScaleDown = request.onlyScaleDown
       transformations = request.transformations.toMutableList()
       config = request.config
@@ -482,10 +474,6 @@ class Request internal constructor(builder: Builder) {
       rotationPivotX = 0f
       rotationPivotY = 0f
       hasRotationPivot = false
-    }
-
-    fun purgeable() = apply {
-      purgeable = true
     }
 
     /** Decode the image using the specified config.  */

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.kt
@@ -324,18 +324,6 @@ class RequestCreator internal constructor(
     return this
   }
 
-  /**
-   * Set inPurgeable and inInputShareable when decoding. This will force the bitmap to be decoded
-   * from a byte array instead of a stream, since inPurgeable only affects the former.
-   *
-   * *Note*: as of API level 21 (Lollipop), the inPurgeable field is deprecated and will be
-   * ignored.
-   */
-  fun purgeable(): RequestCreator {
-    data.purgeable()
-    return this
-  }
-
   /** Disable brief fade in of images loaded from the disk cache or network.  */
   fun noFade(): RequestCreator {
     noFade = true

--- a/picasso/src/main/java/com/squareup/picasso3/Utils.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Utils.kt
@@ -21,14 +21,11 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
 import android.content.res.Resources
-import android.os.Build.VERSION
-import android.os.Build.VERSION_CODES
 import android.os.Handler
 import android.os.Looper
 import android.os.Message
 import android.os.StatFs
 import android.provider.Settings.Global
-import android.provider.Settings.System
 import android.util.Log
 import androidx.core.content.ContextCompat
 import okio.BufferedSource
@@ -138,16 +135,8 @@ internal object Utils {
 
     try {
       val statFs = StatFs(dir.absolutePath)
-      val blockCount = if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR2) {
-        statFs.blockCount.toLong()
-      } else {
-        statFs.blockCountLong
-      }
-      val blockSize = if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR2) {
-        statFs.blockSize.toLong()
-      } else {
-        statFs.blockSizeLong
-      }
+      val blockCount = statFs.blockCountLong
+      val blockSize = statFs.blockSizeLong
       val available = blockCount * blockSize
       // Target 2% of the total space.
       size = available / 50
@@ -169,11 +158,7 @@ internal object Utils {
   fun isAirplaneModeOn(context: Context): Boolean {
     return try {
       val contentResolver = context.contentResolver
-      if (VERSION.SDK_INT < VERSION_CODES.JELLY_BEAN_MR1) {
-        System.getInt(contentResolver, System.AIRPLANE_MODE_ON, 0) != 0
-      } else {
-        Global.getInt(contentResolver, Global.AIRPLANE_MODE_ON, 0) != 0
-      }
+      Global.getInt(contentResolver, Global.AIRPLANE_MODE_ON, 0) != 0
     } catch (e: NullPointerException) {
       // https://github.com/square/picasso/issues/761, some devices might crash here, assume that
       // airplane mode is off.

--- a/picasso/src/test/java/com/squareup/picasso3/BitmapTargetActionTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/BitmapTargetActionTest.kt
@@ -16,7 +16,6 @@
 package com.squareup.picasso3
 
 import android.content.Context
-import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.Bitmap.Config.ARGB_8888
 import android.graphics.drawable.Drawable
@@ -83,7 +82,6 @@ class BitmapTargetActionTest {
       context, dispatcher, UNUSED_CALL_FACTORY, null, cache, null,
       NO_TRANSFORMERS, NO_HANDLERS, NO_EVENT_LISTENERS, ARGB_8888, false, false
     )
-    val res = mock(Resources::class.java)
     val request = BitmapTargetAction(
       picasso = picasso,
       target = target,
@@ -92,8 +90,7 @@ class BitmapTargetActionTest {
       errorResId = RESOURCE_ID_1
     )
 
-    `when`(context.resources).thenReturn(res)
-    `when`(res.getDrawable(RESOURCE_ID_1)).thenReturn(errorDrawable)
+    `when`(context.getDrawable(RESOURCE_ID_1)).thenReturn(errorDrawable)
     val e = RuntimeException()
 
     request.error(e)

--- a/picasso/src/test/java/com/squareup/picasso3/BitmapUtilsTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/BitmapUtilsTest.kt
@@ -85,7 +85,7 @@ class BitmapUtilsTest {
     assertThat(options.inSampleSize).isEqualTo(2)
   }
 
-  @Test fun nullBitmapOptionsIfNoResizingOrPurgeable() {
+  @Test fun nullBitmapOptionsIfNoResizing() {
     // No resize must return no bitmap options
     val noResize = Request.Builder(URI_1).build()
     val noResizeOptions = createBitmapOptions(noResize)
@@ -98,26 +98,13 @@ class BitmapUtilsTest {
     val resizeOptions = createBitmapOptions(requiresResize)
     assertThat(resizeOptions).isNotNull()
     assertThat(resizeOptions!!.inJustDecodeBounds).isTrue()
-    assertThat(resizeOptions.inPurgeable).isFalse()
-    assertThat(resizeOptions.inInputShareable).isFalse()
   }
 
-  @Test fun inPurgeableIfInPurgeable() {
-    val request = Request.Builder(URI_1).purgeable().build()
-    val options = createBitmapOptions(request)
-    assertThat(options).isNotNull()
-    assertThat(options!!.inPurgeable).isTrue()
-    assertThat(options.inInputShareable).isTrue()
-    assertThat(options.inJustDecodeBounds).isFalse()
-  }
-
-  @Test fun createWithConfigAndNotInJustDecodeBoundsOrInPurgeable() {
-    // Given a config, must return bitmap options and false inJustDecodeBounds/inPurgeable
+  @Test fun createWithConfigAndNotInJustDecodeBounds() {
+    // Given a config, must return bitmap options and false inJustDecodeBounds
     val config = Request.Builder(URI_1).config(RGB_565).build()
     val configOptions = createBitmapOptions(config)
     assertThat(configOptions).isNotNull()
     assertThat(configOptions!!.inJustDecodeBounds).isFalse()
-    assertThat(configOptions.inPurgeable).isFalse()
-    assertThat(configOptions.inInputShareable).isFalse()
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
@@ -57,11 +57,9 @@ import org.mockito.Mockito.verifyZeroInteractions
 import org.mockito.MockitoAnnotations.initMocks
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 import java.io.File
 
 @RunWith(RobolectricTestRunner::class)
-@Config(sdk = [23]) // Works around https://github.com/robolectric/robolectric/issues/2566.
 class PicassoTest {
   @get:Rule
   val temporaryFolder = TemporaryFolder()
@@ -305,11 +303,10 @@ class PicassoTest {
     verify(dispatcher).dispatchCancel(action)
   }
 
-  @Config(sdk = [16]) // This test fails on 23 so restore the default level.
   @Test fun cancelExistingRequestWithRemoteViewTarget() {
     val layoutId = 0
     val viewId = 1
-    val remoteViews = RemoteViews("packageName", layoutId)
+    val remoteViews = RemoteViews("com.squareup.picasso3.test", layoutId)
     val target = RemoteViewsTarget(remoteViews, viewId)
     val action = mockAction(picasso, URI_KEY_1, URI_1, target)
     picasso.enqueueAndSubmit(action)

--- a/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.kt
@@ -649,16 +649,4 @@ class RequestCreatorTest {
     verify(picasso).enqueueAndSubmit(actionCaptor.capture())
     assertThat(actionCaptor.value.request.key).isEqualTo(STABLE_URI_KEY_1)
   }
-
-  @Test fun notPurgeable() {
-    RequestCreator(picasso, URI_1, 0).into(mockImageViewTarget())
-    verify(picasso).enqueueAndSubmit(actionCaptor.capture())
-    assertThat(actionCaptor.value.request.purgeable).isFalse()
-  }
-
-  @Test fun purgeable() {
-    RequestCreator(picasso, URI_1, 0).purgeable().into(mockImageViewTarget())
-    verify(picasso).enqueueAndSubmit(actionCaptor.capture())
-    assertThat(actionCaptor.value.request.purgeable).isTrue()
-  }
 }

--- a/picasso/src/test/resources/robolectric.properties
+++ b/picasso/src/test/resources/robolectric.properties
@@ -1,3 +1,3 @@
-sdk: 18
+sdk: 21
 constants: com.squareup.picasso3.BuildConfig
 manifest: --default


### PR DESCRIPTION
Technically already was, since those are OkHttp 4.x's minimum requirements
per: https://code.cash.app/okhttp-4-goes-kotlin

Closes #2172