### PR TITLE
Add Picasso#rememberPainter extension function under new :picasso-compose module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     'targetSdk': 31,
     'sourceCompatibility': JavaVersion.VERSION_1_8,
     'targetCompatibility': JavaVersion.VERSION_1_8,
-    'kotlin': '1.5.21',
+    'kotlin': '1.6.10',
     'okhttp': '4.9.3',
     'okio': '3.0.0',
   ]
@@ -28,6 +28,9 @@ buildscript {
     truth: 'com.google.truth:truth:1.1.3',
     robolectric: 'org.robolectric:robolectric:4.6.1',
     mockito: 'org.mockito:mockito-core:3.0.0',
+    drawablePainter: 'com.google.accompanist:accompanist-drawablepainter:0.23.1',
+    composeUi: 'androidx.compose.ui:ui:1.1.1',
+    foundation: 'androidx.compose.foundation:foundation:1.1.1'
   ]
 
   ext.isCi = "true" == System.getenv('CI')

--- a/picasso-compose/README.md
+++ b/picasso-compose/README.md
@@ -1,0 +1,16 @@
+Picasso Compose Ui
+====================================
+
+A [Painter] which wraps a [RequestCreator]
+
+Usage
+-----
+
+Create a `Painter` using the rememberPainter extension on a Picasso instance.
+
+```kotlin
+val picasso = Picasso.Builder(context).build()
+val painter = picasso.rememberPainter(key = url) {
+  it.load(url).placeholder(placeholderDrawable).error(errorDrawable)
+}
+```

--- a/picasso-compose/api/picasso-compose.api
+++ b/picasso-compose/api/picasso-compose.api
@@ -1,0 +1,4 @@
+public final class com/squareup/picasso3/compose/PicassoPainterKt {
+	public static final fun rememberPainter (Lcom/squareup/picasso3/Picasso;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/graphics/painter/Painter;
+}
+

--- a/picasso-compose/build.gradle
+++ b/picasso-compose/build.gradle
@@ -1,13 +1,12 @@
-apply plugin: 'com.android.application'
+apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.vanniktech.maven.publish'
 
 android {
   compileSdkVersion versions.compileSdk
 
   defaultConfig {
     minSdkVersion versions.minSdk
-    targetSdkVersion versions.targetSdk
-    applicationId 'com.example.picasso'
   }
 
   buildFeatures {
@@ -24,27 +23,18 @@ android {
   }
 
   lintOptions {
-    lintConfig file('lint.xml')
     textOutput 'stdout'
     textReport true
-
-    // https://github.com/square/okhttp/issues/896
-    ignore 'InvalidPackage'
+    lintConfig rootProject.file('lint.xml')
   }
 }
 
 dependencies {
-  compileOnly deps.androidxAnnotations
-  implementation deps.androidxCore
-  implementation deps.androidxCursorAdapter
-  implementation deps.androidxFragment
-  implementation deps.androidxStartup
+  api project(':picasso')
 
   implementation deps.drawablePainter
   implementation deps.composeUi
   implementation deps.foundation
 
-  implementation project(':picasso')
-  implementation project(':picasso-stats')
-  implementation project(':picasso-compose')
+  compileOnly deps.androidxAnnotations
 }

--- a/picasso-compose/gradle.properties
+++ b/picasso-compose/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=picasso-compose
+POM_NAME=Picasso Compose
+POM_DESCRIPTION=Compose UI support for Picasso.
+POM_PACKAGING=aar

--- a/picasso-compose/src/main/AndroidManifest.xml
+++ b/picasso-compose/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.squareup.picasso3.compose" />

--- a/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
+++ b/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso3.compose
+
+import android.graphics.drawable.Drawable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.DefaultAlpha
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.painter.Painter
+import com.google.accompanist.drawablepainter.DrawablePainter
+import com.squareup.picasso3.DrawableTarget
+import com.squareup.picasso3.Picasso
+import com.squareup.picasso3.Picasso.LoadedFrom
+import com.squareup.picasso3.RequestCreator
+
+@Composable
+fun Picasso.rememberPainter(
+  key: Any? = null,
+  onError: ((Exception) -> Unit)? = null,
+  request: (Picasso) -> RequestCreator,
+): Painter {
+  return remember(key) { PicassoPainter(this, request, onError) }
+}
+
+internal class PicassoPainter(
+  private val picasso: Picasso,
+  private val request: (Picasso) -> RequestCreator,
+  private val onError: ((Exception) -> Unit)? = null
+) : Painter(), RememberObserver, DrawableTarget {
+
+  private var painter: Painter by mutableStateOf(EmptyPainter)
+  private var alpha: Float by mutableStateOf(DefaultAlpha)
+  private var colorFilter: ColorFilter? by mutableStateOf(null)
+
+  override val intrinsicSize: Size
+    get() = painter.intrinsicSize
+
+  override fun applyAlpha(alpha: Float): Boolean {
+    this.alpha = alpha
+    return true
+  }
+
+  override fun applyColorFilter(colorFilter: ColorFilter?): Boolean {
+    this.colorFilter = colorFilter
+    return true
+  }
+
+  override fun DrawScope.onDraw() {
+    with(painter) {
+      draw(size, alpha, colorFilter)
+    }
+  }
+
+  override fun onRemembered() {
+    request.invoke(picasso).into(this)
+  }
+
+  override fun onAbandoned() {
+    (painter as? RememberObserver)?.onAbandoned()
+    painter = EmptyPainter
+    picasso.cancelRequest(this)
+  }
+
+  override fun onForgotten() {
+    (painter as? RememberObserver)?.onForgotten()
+    painter = EmptyPainter
+    picasso.cancelRequest(this)
+  }
+
+  override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
+    placeHolderDrawable?.let(::setPainter)
+  }
+
+  override fun onDrawableLoaded(drawable: Drawable, from: LoadedFrom) {
+    setPainter(drawable)
+  }
+
+  override fun onDrawableFailed(e: Exception, errorDrawable: Drawable?) {
+    onError?.invoke(e)
+    errorDrawable?.let(::setPainter)
+  }
+
+  private fun setPainter(drawable: Drawable) {
+    (painter as? RememberObserver)?.onForgotten()
+    painter = DrawablePainter(drawable).apply(DrawablePainter::onRemembered)
+  }
+}
+
+private object EmptyPainter : Painter() {
+  override val intrinsicSize = Size.Zero
+  override fun DrawScope.onDraw() = Unit
+}

--- a/picasso-sample/src/main/AndroidManifest.xml
+++ b/picasso-sample/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
       </intent-filter>
     </activity>
 
+    <activity android:name=".SampleComposeActivity"/>
     <activity android:name=".SampleContactsActivity"/>
     <activity android:name=".SampleGalleryActivity"/>
     <activity android:name=".SampleListDetailActivity"/>

--- a/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.kt
+++ b/picasso-sample/src/main/java/com/example/picasso/PicassoSampleAdapter.kt
@@ -38,6 +38,7 @@ internal class PicassoSampleAdapter(context: Context?) : BaseAdapter() {
     private val activityClass: Class<out Activity>?
   ) {
     GRID_VIEW("Image Grid View", SampleGridViewActivity::class.java),
+    COMPOSE_UI("Compose UI", SampleComposeActivity::class.java),
     GALLERY("Load from Gallery", SampleGalleryActivity::class.java),
     CONTACTS("Contact Photos", SampleContactsActivity::class.java),
     LIST_DETAIL("List / Detail View", SampleListDetailActivity::class.java),

--- a/picasso-sample/src/main/java/com/example/picasso/SampleComposeActivity.kt
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleComposeActivity.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.example.picasso
+
+import android.os.Bundle
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.GridCells.Adaptive
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale.Companion.Crop
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import com.squareup.picasso3.Picasso
+import com.squareup.picasso3.compose.rememberPainter
+
+class SampleComposeActivity : PicassoSampleActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val composeView = ComposeView(this)
+
+    val urls = Data.URLS.toMutableList().shuffled() +
+      Data.URLS.toMutableList().shuffled() +
+      Data.URLS.toMutableList().shuffled()
+
+    composeView.setContent {
+      ImageGrid(urls = urls)
+    }
+
+    setContentView(composeView)
+  }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ImageGrid(
+  modifier: Modifier = Modifier,
+  urls: List<String>,
+  picasso: Picasso = PicassoInitializer.get()
+) {
+  LazyVerticalGrid(
+    cells = Adaptive(150.dp),
+    modifier = modifier,
+  ) {
+    items(urls.size) {
+      val url = urls[it]
+      Image(
+        painter = picasso.rememberPainter(key = url) {
+          it.load(url).placeholder(R.drawable.placeholder).error(R.drawable.error)
+        },
+        contentDescription = null,
+        contentScale = Crop,
+        modifier = Modifier
+          .fillMaxWidth()
+          .aspectRatio(1f)
+      )
+    }
+  }
+}

--- a/picasso/api/picasso.api
+++ b/picasso/api/picasso.api
@@ -15,6 +15,12 @@ public class com/squareup/picasso3/Callback$EmptyCallback : com/squareup/picasso
 	public fun onSuccess ()V
 }
 
+public abstract interface class com/squareup/picasso3/DrawableTarget {
+	public abstract fun onDrawableFailed (Ljava/lang/Exception;Landroid/graphics/drawable/Drawable;)V
+	public abstract fun onDrawableLoaded (Landroid/graphics/drawable/Drawable;Lcom/squareup/picasso3/Picasso$LoadedFrom;)V
+	public abstract fun onPrepareLoad (Landroid/graphics/drawable/Drawable;)V
+}
+
 public abstract interface class com/squareup/picasso3/EventListener : java/io/Closeable {
 	public abstract fun bitmapDecoded (Landroid/graphics/Bitmap;)V
 	public abstract fun bitmapTransformed (Landroid/graphics/Bitmap;)V
@@ -72,6 +78,7 @@ public final class com/squareup/picasso3/Picasso : androidx/lifecycle/LifecycleO
 	public final fun cancelRequest (Landroid/widget/ImageView;)V
 	public final fun cancelRequest (Landroid/widget/RemoteViews;I)V
 	public final fun cancelRequest (Lcom/squareup/picasso3/BitmapTarget;)V
+	public final fun cancelRequest (Lcom/squareup/picasso3/DrawableTarget;)V
 	public final fun cancelTag (Ljava/lang/Object;)V
 	public final fun evictAll ()V
 	public final fun getIndicatorsEnabled ()Z
@@ -272,6 +279,7 @@ public final class com/squareup/picasso3/RequestCreator {
 	public final fun into (Landroid/widget/RemoteViews;I[I)V
 	public final fun into (Landroid/widget/RemoteViews;I[ILcom/squareup/picasso3/Callback;)V
 	public final fun into (Lcom/squareup/picasso3/BitmapTarget;)V
+	public final fun into (Lcom/squareup/picasso3/DrawableTarget;)V
 	public static synthetic fun into$default (Lcom/squareup/picasso3/RequestCreator;Landroid/widget/ImageView;Lcom/squareup/picasso3/Callback;ILjava/lang/Object;)V
 	public static synthetic fun into$default (Lcom/squareup/picasso3/RequestCreator;Landroid/widget/RemoteViews;IILandroid/app/Notification;Ljava/lang/String;Lcom/squareup/picasso3/Callback;ILjava/lang/Object;)V
 	public static synthetic fun into$default (Lcom/squareup/picasso3/RequestCreator;Landroid/widget/RemoteViews;IILcom/squareup/picasso3/Callback;ILjava/lang/Object;)V

--- a/picasso/src/main/java/com/squareup/picasso3/DrawableTarget.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/DrawableTarget.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso3
+
+import android.graphics.drawable.Drawable
+import com.squareup.picasso3.Picasso.LoadedFrom
+
+/**
+ * Represents an arbitrary listener for image loading.
+ *
+ * Objects implementing this class **must** have a working implementation of
+ * [Object.equals] and [Object.hashCode] for proper storage internally.
+ * Instances of this interface will also be compared to determine if view recycling is occurring.
+ * It is recommended that you add this interface directly on to a custom view type when using in an
+ * adapter to ensure correct recycling behavior.
+ */
+interface DrawableTarget {
+  /**
+   * Callback when an image has been successfully loaded.
+   *
+   */
+  fun onDrawableLoaded(
+    drawable: Drawable,
+    from: LoadedFrom
+  )
+
+  /**
+   * Callback indicating the image could not be successfully loaded.
+   *
+   * **Note:** The passed [Drawable] may be `null` if none has been
+   * specified via [RequestCreator.error].
+   */
+  fun onDrawableFailed(
+    e: Exception,
+    errorDrawable: Drawable?
+  )
+
+  /**
+   * Callback invoked right before your request is submitted.
+   *
+   *
+   * **Note:** The passed [Drawable] may be `null` if none has been
+   * specified via [RequestCreator.placeholder].
+   */
+  fun onPrepareLoad(placeHolderDrawable: Drawable?)
+}

--- a/picasso/src/main/java/com/squareup/picasso3/DrawableTargetAction.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/DrawableTargetAction.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso3
+
+import android.graphics.drawable.Drawable
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import com.squareup.picasso3.RequestHandler.Result
+import com.squareup.picasso3.RequestHandler.Result.Bitmap
+
+internal class DrawableTargetAction(
+  picasso: Picasso,
+  private val target: DrawableTarget,
+  data: Request,
+  private val noFade: Boolean,
+  private val placeholderDrawable: Drawable?,
+  private val errorDrawable: Drawable?,
+  @DrawableRes val errorResId: Int
+) : Action(picasso, data) {
+  override fun complete(result: Result) {
+    if (result is Bitmap) {
+      val bitmap = result.bitmap
+      target.onDrawableLoaded(
+        PicassoDrawable(
+          context = picasso.context,
+          bitmap = bitmap,
+          placeholder = placeholderDrawable,
+          loadedFrom = result.loadedFrom,
+          noFade = noFade,
+          debugging = picasso.indicatorsEnabled
+        ),
+        result.loadedFrom
+      )
+      check(!bitmap.isRecycled) { "Target callback must not recycle bitmap!" }
+    }
+  }
+
+  override fun error(e: Exception) {
+    val drawable = if (errorResId != 0) {
+      ContextCompat.getDrawable(picasso.context, errorResId)
+    } else {
+      errorDrawable
+    }
+
+    target.onDrawableFailed(e, drawable)
+  }
+
+  override fun getTarget(): Any {
+    return target
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
@@ -149,6 +149,12 @@ class Picasso internal constructor(
     cancelExistingRequest(target)
   }
 
+  /** Cancel any existing requests for the specified [DrawableTarget] instance. */
+  fun cancelRequest(target: DrawableTarget) {
+    // checkMain() is called from cancelExistingRequest()
+    cancelExistingRequest(target)
+  }
+
   /**
    * Cancel any existing requests for the specified [RemoteViews] target with the given [viewId].
    */

--- a/picasso/src/test/java/com/squareup/picasso3/BitmapTargetActionTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/BitmapTargetActionTest.kt
@@ -27,8 +27,8 @@ import com.squareup.picasso3.TestUtils.RESOURCE_ID_1
 import com.squareup.picasso3.TestUtils.SIMPLE_REQUEST
 import com.squareup.picasso3.TestUtils.UNUSED_CALL_FACTORY
 import com.squareup.picasso3.TestUtils.makeBitmap
+import com.squareup.picasso3.TestUtils.mockBitmapTarget
 import com.squareup.picasso3.TestUtils.mockPicasso
-import com.squareup.picasso3.TestUtils.mockTarget
 import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,7 +43,7 @@ class BitmapTargetActionTest {
 
   @Test fun invokesSuccessIfTargetIsNotNull() {
     val bitmap = makeBitmap()
-    val target = mockTarget()
+    val target = mockBitmapTarget()
     val request = BitmapTargetAction(
       picasso = mockPicasso(RuntimeEnvironment.application),
       target = target,
@@ -57,7 +57,7 @@ class BitmapTargetActionTest {
 
   @Test fun invokesOnBitmapFailedIfTargetIsNotNullWithErrorDrawable() {
     val errorDrawable = mock(Drawable::class.java)
-    val target = mockTarget()
+    val target = mockBitmapTarget()
     val request = BitmapTargetAction(
       picasso = mockPicasso(RuntimeEnvironment.application),
       target = target,
@@ -74,7 +74,7 @@ class BitmapTargetActionTest {
 
   @Test fun invokesOnBitmapFailedIfTargetIsNotNullWithErrorResourceId() {
     val errorDrawable = mock(Drawable::class.java)
-    val target = mockTarget()
+    val target = mockBitmapTarget()
     val context = mock(Context::class.java)
     val dispatcher = mock(Dispatcher::class.java)
     val cache = PlatformLruCache(0)

--- a/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.kt
@@ -40,11 +40,11 @@ import com.squareup.picasso3.TestUtils.URI_KEY_1
 import com.squareup.picasso3.TestUtils.URI_KEY_2
 import com.squareup.picasso3.TestUtils.makeBitmap
 import com.squareup.picasso3.TestUtils.mockAction
+import com.squareup.picasso3.TestUtils.mockBitmapTarget
 import com.squareup.picasso3.TestUtils.mockCallback
 import com.squareup.picasso3.TestUtils.mockHunter
 import com.squareup.picasso3.TestUtils.mockNetworkInfo
 import com.squareup.picasso3.TestUtils.mockPicasso
-import com.squareup.picasso3.TestUtils.mockTarget
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -156,7 +156,7 @@ class DispatcherTest {
   }
 
   @Test fun performCancelDetachesRequestAndCleansUp() {
-    val target = mockTarget()
+    val target = mockBitmapTarget()
     val action = mockAction(picasso, URI_KEY_1, URI_1, target)
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action)
     hunter.future = FutureTask(mock(Runnable::class.java), mock(Any::class.java))
@@ -181,7 +181,7 @@ class DispatcherTest {
   }
 
   @Test fun performCancelUnqueuesAndDetachesPausedRequest() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget(), tag = "tag")
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget(), tag = "tag")
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action)
     dispatcher.hunterMap[URI_KEY_1 + Request.KEY_SEPARATOR] = hunter
     dispatcher.pausedTags.add("tag")
@@ -248,7 +248,7 @@ class DispatcherTest {
   }
 
   @Test fun performErrorCleansUpAndPostsToMain() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget(), tag = "tag")
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget(), tag = "tag")
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action)
     dispatcher.hunterMap[hunter.key] = hunter
     dispatcher.performError(hunter)
@@ -257,7 +257,7 @@ class DispatcherTest {
   }
 
   @Test fun performErrorCleansUpAndDoesNotPostToMainIfCancelled() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget(), tag = "tag")
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget(), tag = "tag")
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action)
     hunter.future = FutureTask(mock(Runnable::class.java), mock(Any::class.java))
     hunter.future!!.cancel(false)
@@ -268,7 +268,7 @@ class DispatcherTest {
   }
 
   @Test fun performRetrySkipsIfHunterIsCancelled() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget(), tag = "tag")
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget(), tag = "tag")
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action)
     hunter.future = FutureTask(mock(Runnable::class.java), mock(Any::class.java))
     hunter.future!!.cancel(false)
@@ -319,7 +319,7 @@ class DispatcherTest {
 
   @Test fun performRetryMarksForReplayIfSupportedScansNetworkChangesAndShouldNotRetry() {
     val networkInfo = mockNetworkInfo(true)
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget())
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget())
     val hunter = mockHunter(
       picasso,
       RequestHandler.Result.Bitmap(bitmap1, MEMORY),
@@ -348,7 +348,7 @@ class DispatcherTest {
   }
 
   @Test fun performRetryMarksForReplayIfSupportsReplayAndShouldNotRetry() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget())
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget())
     val hunter = mockHunter(
       picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action,
       e = null, shouldRetry = false, supportsReplay = true
@@ -360,7 +360,7 @@ class DispatcherTest {
   }
 
   @Test fun performRetryRetriesIfShouldRetry() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget())
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget())
     val hunter = mockHunter(
       picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action,
       e = null, shouldRetry = true
@@ -372,7 +372,7 @@ class DispatcherTest {
   }
 
   @Test fun performRetrySkipIfServiceShutdown() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget())
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget())
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action)
     service.shutdown()
     dispatcher.performRetry(hunter)
@@ -418,7 +418,7 @@ class DispatcherTest {
   }
 
   @Test fun performPauseTagIsIdempotent() {
-    val action = mockAction(picasso, URI_KEY_1, URI_1, mockTarget(), tag = "tag")
+    val action = mockAction(picasso, URI_KEY_1, URI_1, mockBitmapTarget(), tag = "tag")
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action)
     dispatcher.hunterMap[URI_KEY_1] = hunter
     assertThat(dispatcher.pausedActions).isEmpty()
@@ -468,10 +468,10 @@ class DispatcherTest {
 
   @Test fun performPauseOnlyDetachesPausedRequest() {
     val action1 = mockAction(
-      picasso = picasso, key = URI_KEY_1, uri = URI_1, target = mockTarget(), tag = "tag1"
+      picasso = picasso, key = URI_KEY_1, uri = URI_1, target = mockBitmapTarget(), tag = "tag1"
     )
     val action2 = mockAction(
-      picasso = picasso, key = URI_KEY_1, uri = URI_1, target = mockTarget(), tag = "tag2"
+      picasso = picasso, key = URI_KEY_1, uri = URI_1, target = mockBitmapTarget(), tag = "tag2"
     )
     val hunter = mockHunter(picasso, RequestHandler.Result.Bitmap(bitmap1, MEMORY), action1)
     hunter.attach(action2)

--- a/picasso/src/test/java/com/squareup/picasso3/DrawableTargetActionTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/DrawableTargetActionTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso3
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.Bitmap.Config.ARGB_8888
+import android.graphics.drawable.Drawable
+import com.google.common.truth.Truth.assertThat
+import com.squareup.picasso3.Picasso.LoadedFrom.MEMORY
+import com.squareup.picasso3.Picasso.LoadedFrom.NETWORK
+import com.squareup.picasso3.TestUtils.argumentCaptor
+import com.squareup.picasso3.TestUtils.eq
+import com.squareup.picasso3.TestUtils.makeBitmap
+import com.squareup.picasso3.TestUtils.mockDrawableTarget
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.Mockito.mock
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class DrawableTargetActionTest {
+
+  @Test fun invokesSuccessIfTargetIsNotNull() {
+    val bitmap = makeBitmap()
+    val target = mockDrawableTarget()
+    val drawableCaptor = argumentCaptor<PicassoDrawable>()
+    val placeholder = mock(Drawable::class.java)
+    val action = DrawableTargetAction(
+      picasso = TestUtils.mockPicasso(RuntimeEnvironment.application),
+      target = target,
+      data = TestUtils.SIMPLE_REQUEST,
+      noFade = false,
+      placeholderDrawable = placeholder,
+      errorDrawable = null,
+      errorResId = 0
+    )
+
+    action.complete(RequestHandler.Result.Bitmap(bitmap, NETWORK))
+
+    Mockito.verify(target).onDrawableLoaded(drawableCaptor.capture(), eq(NETWORK))
+    with(drawableCaptor.value) {
+      assertThat(this.bitmap).isEqualTo(bitmap)
+      assertThat(this.placeholder).isEqualTo(placeholder)
+      assertThat(this.animating).isTrue()
+    }
+  }
+
+  @Test fun invokesOnBitmapFailedIfTargetIsNotNullWithErrorDrawable() {
+    val errorDrawable = mock(Drawable::class.java)
+    val target = mockDrawableTarget()
+    val action = DrawableTargetAction(
+      picasso = TestUtils.mockPicasso(RuntimeEnvironment.application),
+      target = target,
+      data = TestUtils.SIMPLE_REQUEST,
+      noFade = true,
+      placeholderDrawable = null,
+      errorDrawable = errorDrawable,
+      errorResId = 0
+    )
+    val e = RuntimeException()
+
+    action.error(e)
+
+    Mockito.verify(target).onDrawableFailed(e, errorDrawable)
+  }
+
+  @Test fun invokesOnBitmapFailedIfTargetIsNotNullWithErrorResourceId() {
+    val errorDrawable = mock(Drawable::class.java)
+    val context = mock(Context::class.java)
+    val dispatcher = mock(Dispatcher::class.java)
+    val cache = PlatformLruCache(0)
+    val picasso = Picasso(
+      context, dispatcher,
+      TestUtils.UNUSED_CALL_FACTORY, null, cache, null,
+      TestUtils.NO_TRANSFORMERS,
+      TestUtils.NO_HANDLERS,
+      TestUtils.NO_EVENT_LISTENERS, ARGB_8888, false, false
+    )
+    val res = mock(Resources::class.java)
+
+    val target = mockDrawableTarget()
+    val action = DrawableTargetAction(
+      picasso = picasso,
+      target = target,
+      data = TestUtils.SIMPLE_REQUEST,
+      noFade = true,
+      placeholderDrawable = null,
+      errorDrawable = null,
+      errorResId = TestUtils.RESOURCE_ID_1
+    )
+
+    Mockito.`when`(context.getDrawable(TestUtils.RESOURCE_ID_1)).thenReturn(errorDrawable)
+    val e = RuntimeException()
+
+    action.error(e)
+
+    Mockito.verify(target).onDrawableFailed(e, errorDrawable)
+  }
+
+  @Test fun recyclingInSuccessThrowsException() {
+    val picasso = TestUtils.mockPicasso(RuntimeEnvironment.application)
+    val bitmap = makeBitmap()
+    val action = DrawableTargetAction(
+      picasso = picasso,
+      target = object : DrawableTarget {
+        override fun onDrawableLoaded(drawable: Drawable, from: Picasso.LoadedFrom) = (drawable as PicassoDrawable).bitmap.recycle()
+        override fun onDrawableFailed(e: Exception, errorDrawable: Drawable?) = throw AssertionError()
+        override fun onPrepareLoad(placeHolderDrawable: Drawable?) = throw AssertionError()
+      },
+      data = TestUtils.SIMPLE_REQUEST,
+      noFade = true,
+      placeholderDrawable = null,
+      errorDrawable = null,
+      errorResId = 0
+    )
+
+    try {
+      action.complete(RequestHandler.Result.Bitmap(bitmap, MEMORY))
+      Assert.fail()
+    } catch (ignored: IllegalStateException) {
+    }
+  }
+}

--- a/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
@@ -37,12 +37,13 @@ import com.squareup.picasso3.TestUtils.URI_KEY_1
 import com.squareup.picasso3.TestUtils.defaultPicasso
 import com.squareup.picasso3.TestUtils.makeBitmap
 import com.squareup.picasso3.TestUtils.mockAction
+import com.squareup.picasso3.TestUtils.mockBitmapTarget
 import com.squareup.picasso3.TestUtils.mockDeferredRequestCreator
+import com.squareup.picasso3.TestUtils.mockDrawableTarget
 import com.squareup.picasso3.TestUtils.mockHunter
 import com.squareup.picasso3.TestUtils.mockImageViewTarget
 import com.squareup.picasso3.TestUtils.mockPicasso
 import com.squareup.picasso3.TestUtils.mockRequestCreator
-import com.squareup.picasso3.TestUtils.mockTarget
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -291,8 +292,20 @@ class PicassoTest {
     assertThat(picasso.targetToDeferredRequestCreator).containsKey(target)
   }
 
-  @Test fun cancelExistingRequestWithTarget() {
-    val target = mockTarget()
+  @Test fun cancelExistingRequestWithBitmapTarget() {
+    val target = mockBitmapTarget()
+    val action = mockAction(picasso, URI_KEY_1, URI_1, target)
+    picasso.enqueueAndSubmit(action)
+    assertThat(picasso.targetToAction).hasSize(1)
+    assertThat(action.cancelled).isFalse()
+    picasso.cancelRequest(target)
+    assertThat(picasso.targetToAction).isEmpty()
+    assertThat(action.cancelled).isTrue()
+    verify(dispatcher).dispatchCancel(action)
+  }
+
+  @Test fun cancelExistingRequestWithDrawableTarget() {
+    val target = mockDrawableTarget()
     val action = mockAction(picasso, URI_KEY_1, URI_1, target)
     picasso.enqueueAndSubmit(action)
     assertThat(picasso.targetToAction).hasSize(1)

--- a/picasso/src/test/java/com/squareup/picasso3/TestUtils.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/TestUtils.kt
@@ -145,7 +145,7 @@ internal object TestUtils {
     picasso: Picasso,
     key: String,
     uri: Uri? = null,
-    target: Any = mockTarget(),
+    target: Any = mockBitmapTarget(),
     resourceId: Int = 0,
     priority: Priority? = null,
     tag: String? = null,
@@ -165,7 +165,7 @@ internal object TestUtils {
     return mockAction(picasso, request, target)
   }
 
-  fun mockAction(picasso: Picasso, request: Request, target: Any = mockTarget()) =
+  fun mockAction(picasso: Picasso, request: Request, target: Any = mockBitmapTarget()) =
     FakeAction(picasso, request, target)
 
   fun mockImageViewTarget(): ImageView = mock(ImageView::class.java)
@@ -183,7 +183,9 @@ internal object TestUtils {
     return mock
   }
 
-  fun mockTarget(): BitmapTarget = mock(BitmapTarget::class.java)
+  fun mockBitmapTarget(): BitmapTarget = mock(BitmapTarget::class.java)
+
+  fun mockDrawableTarget(): DrawableTarget = mock(DrawableTarget::class.java)
 
   fun mockCallback(): Callback = mock(Callback::class.java)
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'picasso-root'
 
 include 'picasso'
+include 'picasso-compose'
 include 'picasso-pollexor'
 include 'picasso-sample'
 include 'picasso-stats'


### PR DESCRIPTION
Introduces a new :picasso-compose module which exposes a Picasso#rememberPainter function for use with Compose UI. To achieve this Picasso exposes a new .into(DrawableTarget) that way we can provide a PicassoDrawable to the Painter which will keep the API consistent with how we load .into(ImageView).

https://user-images.githubusercontent.com/672316/165820488-19354b63-a588-4cea-bdeb-5186324231dd.mp4