### PR TITLE
Fix `android.resource://` Uri handling for API 28+

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapUtils.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapUtils.kt
@@ -154,7 +154,9 @@ internal object BitmapUtils {
 
   @RequiresApi(28)
   private fun decodeResourceP(context: Context, request: Request): Bitmap {
-    val imageSource = ImageDecoder.createSource(context.resources, request.resourceId)
+    val resourceId = request.resourceId.takeIf { it != 0 }
+      ?: Utils.getResourceId(context.resources, request)
+    val imageSource = ImageDecoder.createSource(context.resources, resourceId)
     return decodeImageSource(imageSource, request)
   }
 


### PR DESCRIPTION
The pre-28 branch uses `Utils.getResourceId()` from the original `android.resource://` handling implementation. This is not being used in the branch for API 28; it would only check the resourceId given to the Request, which is 0 when loading from this Uri string. Resolves #2302.