### PR TITLE
Add painter optimization to load Picasso once canvas size known

### DIFF
--- a/picasso-compose/api/picasso-compose.api
+++ b/picasso-compose/api/picasso-compose.api
@@ -1,4 +1,4 @@
 public final class com/squareup/picasso3/compose/PicassoPainterKt {
-	public static final fun rememberPainter (Lcom/squareup/picasso3/Picasso;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/graphics/painter/Painter;
+	public static final fun rememberPainter (Lcom/squareup/picasso3/Picasso;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Landroidx/compose/ui/graphics/painter/Painter;
 }
 

--- a/picasso-sample/src/main/java/com/example/picasso/SampleComposeActivity.kt
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleComposeActivity.kt
@@ -62,7 +62,7 @@ fun ImageGrid(
     items(urls.size) {
       val url = urls[it]
       Image(
-        painter = picasso.rememberPainter(key = url) {
+        painter = picasso.rememberPainter(key = url, optimizeCanvasSize = true) {
           it.load(url).placeholder(R.drawable.placeholder).error(R.drawable.error)
         },
         contentDescription = null,


### PR DESCRIPTION
Adds an "optimizeCanvasSize" property to the painter which delays loading picasso until DrawScope in order to apply an appropriate resize to the RequestCreator based on DrawScope's size. We apply the resize with only one dimension so picasso maintains the aspect ratio otherwise supplying both creates a fill effect. 

https://user-images.githubusercontent.com/672316/176442056-8049ce0f-7ead-4c36-ba66-ec59f5fa7c06.mp4


