### PR TITLE
Resolve memory leaks in v3 created during Kotlin conversion

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Dispatcher.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Dispatcher.kt
@@ -51,6 +51,7 @@ import com.squareup.picasso3.Utils.getLogIdsForHunter
 import com.squareup.picasso3.Utils.hasPermission
 import com.squareup.picasso3.Utils.isAirplaneModeOn
 import com.squareup.picasso3.Utils.log
+import java.util.WeakHashMap
 import java.util.concurrent.ExecutorService
 
 internal class Dispatcher internal constructor(
@@ -63,10 +64,10 @@ internal class Dispatcher internal constructor(
   internal val hunterMap = mutableMapOf<String, BitmapHunter>()
 
   @get:JvmName("-failedActions")
-  internal val failedActions = mutableMapOf<Any, Action>()
+  internal val failedActions = WeakHashMap<Any, Action>()
 
   @get:JvmName("-pausedActions")
-  internal val pausedActions = mutableMapOf<Any, Action>()
+  internal val pausedActions = WeakHashMap<Any, Action>()
 
   @get:JvmName("-pausedTags")
   internal val pausedTags = mutableSetOf<Any>()

--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
@@ -378,6 +378,7 @@ class Picasso internal constructor(
     for (deferredRequestCreator in targetToDeferredRequestCreator.values) {
       deferredRequestCreator.cancel()
     }
+    targetToAction.clear()
     targetToDeferredRequestCreator.clear()
     shutdown = true
   }

--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
@@ -52,6 +52,7 @@ import okhttp3.Call
 import okhttp3.OkHttpClient
 import java.io.File
 import java.io.IOException
+import java.util.WeakHashMap
 import java.util.concurrent.ExecutorService
 
 /**
@@ -92,10 +93,10 @@ class Picasso internal constructor(
   internal val eventListeners: List<EventListener> = eventListeners.toList()
 
   @get:JvmName("-targetToAction")
-  internal val targetToAction = mutableMapOf<Any, Action>()
+  internal val targetToAction = WeakHashMap<Any, Action>()
 
   @get:JvmName("-targetToDeferredRequestCreator")
-  internal val targetToDeferredRequestCreator = mutableMapOf<ImageView, DeferredRequestCreator>()
+  internal val targetToDeferredRequestCreator = WeakHashMap<ImageView, DeferredRequestCreator>()
 
   @get:JvmName("-shutdown")
   @set:JvmName("-shutdown")

--- a/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/PicassoTest.kt
@@ -392,6 +392,12 @@ class PicassoTest {
     assertThat(picasso.shutdown).isTrue()
   }
 
+  @Test fun shutdownClearsTargetsToActions() {
+    picasso.targetToAction[mockImageViewTarget()] = mock(ImageViewAction::class.java)
+    picasso.shutdown()
+    assertThat(picasso.targetToAction).isEmpty()
+  }
+
   @Test fun shutdownClearsDeferredRequests() {
     val target = mockImageViewTarget()
     val creator = mockRequestCreator(picasso)


### PR DESCRIPTION
Context: https://square.slack.com/archives/C0366FCTYKC/p1663532908850359

## Commits

* Clear `targetToAction` map in `Picasso.shutdown()`.
* Make a few map properties WeakHashMaps again, to avoid leaks.