### PR TITLE
Reverts enabling jvm-default=all flag

### DIFF
--- a/picasso-compose/build.gradle
+++ b/picasso-compose/build.gradle
@@ -22,11 +22,6 @@ android {
     targetCompatibility versions.targetCompatibility
   }
 
-  kotlinOptions {
-    jvmTarget = versions.targetCompatibility
-    freeCompilerArgs += '-Xjvm-default=all'
-  }
-
   lintOptions {
     textOutput 'stdout'
     textReport true

--- a/picasso-pollexor/build.gradle
+++ b/picasso-pollexor/build.gradle
@@ -14,11 +14,6 @@ android {
     targetCompatibility versions.targetCompatibility
   }
 
-  kotlinOptions {
-    jvmTarget = versions.targetCompatibility
-    freeCompilerArgs += '-Xjvm-default=all'
-  }
-
   lintOptions {
     textOutput 'stdout'
     textReport true

--- a/picasso-sample/build.gradle
+++ b/picasso-sample/build.gradle
@@ -23,11 +23,6 @@ android {
     targetCompatibility versions.targetCompatibility
   }
 
-  kotlinOptions {
-    jvmTarget = versions.targetCompatibility
-    freeCompilerArgs += '-Xjvm-default=all'
-  }
-
   lintOptions {
     lintConfig file('lint.xml')
     textOutput 'stdout'

--- a/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.kt
+++ b/picasso-sample/src/main/java/com/example/picasso/SampleGalleryActivity.kt
@@ -22,7 +22,7 @@ import android.provider.MediaStore.Images.Media
 import android.view.View
 import android.widget.ImageView
 import android.widget.ViewAnimator
-import com.squareup.picasso3.Callback
+import com.squareup.picasso3.Callback.EmptyCallback
 
 class SampleGalleryActivity : PicassoSampleActivity() {
   private lateinit var imageView: ImageView
@@ -78,7 +78,7 @@ class SampleGalleryActivity : PicassoSampleActivity() {
       .centerInside()
       .into(
         imageView,
-        object : Callback {
+        object : EmptyCallback() {
           override fun onSuccess() {
             // Index 0 is the image view.
             animator.displayedChild = 0

--- a/picasso-stats/api/picasso-stats.api
+++ b/picasso-stats/api/picasso-stats.api
@@ -6,6 +6,7 @@ public final class com/squareup/picasso3/stats/StatsEventListener : com/squareup
 	public fun cacheMaxSize (I)V
 	public fun cacheMiss ()V
 	public fun cacheSize (I)V
+	public fun close ()V
 	public fun downloadFinished (J)V
 	public final fun getSnapshot ()Lcom/squareup/picasso3/stats/StatsEventListener$Snapshot;
 }

--- a/picasso-stats/build.gradle
+++ b/picasso-stats/build.gradle
@@ -14,11 +14,6 @@ android {
     targetCompatibility versions.targetCompatibility
   }
 
-  kotlinOptions {
-    jvmTarget = versions.targetCompatibility
-    freeCompilerArgs += '-Xjvm-default=all'
-  }
-
   lintOptions {
     textOutput 'stdout'
     textReport true

--- a/picasso/api/picasso.api
+++ b/picasso/api/picasso.api
@@ -5,6 +5,12 @@ public abstract interface class com/squareup/picasso3/BitmapTarget {
 }
 
 public abstract interface class com/squareup/picasso3/Callback {
+	public abstract fun onError (Ljava/lang/Throwable;)V
+	public abstract fun onSuccess ()V
+}
+
+public class com/squareup/picasso3/Callback$EmptyCallback : com/squareup/picasso3/Callback {
+	public fun <init> ()V
 	public fun onError (Ljava/lang/Throwable;)V
 	public fun onSuccess ()V
 }
@@ -22,8 +28,12 @@ public abstract interface class com/squareup/picasso3/EventListener : java/io/Cl
 	public abstract fun cacheMaxSize (I)V
 	public abstract fun cacheMiss ()V
 	public abstract fun cacheSize (I)V
-	public fun close ()V
+	public abstract fun close ()V
 	public abstract fun downloadFinished (J)V
+}
+
+public final class com/squareup/picasso3/EventListener$DefaultImpls {
+	public static fun close (Lcom/squareup/picasso3/EventListener;)V
 }
 
 public abstract interface annotation class com/squareup/picasso3/Initializer : java/lang/annotation/Annotation {

--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -17,11 +17,6 @@ android {
     targetCompatibility versions.targetCompatibility
   }
 
-  kotlinOptions {
-    jvmTarget = versions.targetCompatibility
-    freeCompilerArgs += '-Xjvm-default=all'
-  }
-
   lintOptions {
     textOutput 'stdout'
     textReport true

--- a/picasso/src/main/java/com/squareup/picasso3/Callback.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Callback.kt
@@ -16,6 +16,10 @@
 package com.squareup.picasso3
 
 interface Callback {
-  fun onSuccess() = Unit
-  fun onError(t: Throwable) = Unit
+  fun onSuccess()
+  fun onError(t: Throwable)
+  open class EmptyCallback : Callback {
+    override fun onSuccess() = Unit
+    override fun onError(t: Throwable) = Unit
+  }
 }


### PR DESCRIPTION
Enabling requires consumers to opt in and can result in binary incompatibility.