### PR TITLE
Remove BitmapCompat.getAllocationByteCount().

### DIFF
--- a/picasso-stats/src/main/java/com/squareup/picasso3/stats/StatsEventListener.kt
+++ b/picasso-stats/src/main/java/com/squareup/picasso3/stats/StatsEventListener.kt
@@ -17,7 +17,6 @@ package com.squareup.picasso3.stats
 
 import android.graphics.Bitmap
 import android.util.Log
-import androidx.core.graphics.BitmapCompat
 import com.squareup.picasso3.EventListener
 import com.squareup.picasso3.TAG
 import okio.Buffer
@@ -66,7 +65,7 @@ class StatsEventListener : EventListener {
   }
 
   override fun bitmapDecoded(bitmap: Bitmap) {
-    val bitmapSize = BitmapCompat.getAllocationByteCount(bitmap)
+    val bitmapSize = bitmap.allocationByteCount
 
     originalBitmapCount++
     totalOriginalBitmapSize += bitmapSize
@@ -74,7 +73,7 @@ class StatsEventListener : EventListener {
   }
 
   override fun bitmapTransformed(bitmap: Bitmap) {
-    val bitmapSize = BitmapCompat.getAllocationByteCount(bitmap)
+    val bitmapSize = bitmap.allocationByteCount
 
     transformedBitmapCount++
     totalTransformedBitmapSize += bitmapSize

--- a/picasso/src/main/java/com/squareup/picasso3/PlatformLruCache.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/PlatformLruCache.kt
@@ -17,11 +17,9 @@ package com.squareup.picasso3
 
 import android.graphics.Bitmap
 import android.util.LruCache
-import androidx.core.graphics.BitmapCompat
 
 /** A memory cache which uses a least-recently used eviction policy.  */
 internal class PlatformLruCache(maxByteCount: Int) {
-
   /** Create a cache with a given maximum size in bytes.  */
   val cache =
     object : LruCache<String, BitmapAndSize>(if (maxByteCount != 0) maxByteCount else 1) {
@@ -37,7 +35,7 @@ internal class PlatformLruCache(maxByteCount: Int) {
     key: String,
     bitmap: Bitmap
   ) {
-    val byteCount = BitmapCompat.getAllocationByteCount(bitmap)
+    val byteCount = bitmap.allocationByteCount
     // If the bitmap is too big for the cache, don't even attempt to store it. Doing so will cause
     // the cache to be cleared. Instead just evict an existing element with the same key if it
     // exists.


### PR DESCRIPTION
Remove calls to `BitmapCompat.getAllocationByteCount()`, as the minimum API level is 21 and [`Bitmap#getAllocationByteCount()`](https://developer.android.com/reference/android/graphics/Bitmap#getAllocationByteCount()) is supported from API level 19 onward.