### PR TITLE
Fix leaks in BitmapTargetAction, ImageViewAction, DeferredRequestCreator

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Action.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Action.kt
@@ -27,7 +27,7 @@ internal abstract class Action(
   abstract fun complete(result: Result)
   abstract fun error(e: Exception)
 
-  abstract fun getTarget(): Any
+  abstract fun getTarget(): Any?
 
   open fun cancel() {
     cancelled = true

--- a/picasso/src/main/java/com/squareup/picasso3/BitmapTargetAction.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapTargetAction.kt
@@ -20,15 +20,20 @@ import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import com.squareup.picasso3.RequestHandler.Result
 import com.squareup.picasso3.RequestHandler.Result.Bitmap
+import java.lang.ref.WeakReference
 
 internal class BitmapTargetAction(
   picasso: Picasso,
-  private val target: BitmapTarget,
+  target: BitmapTarget,
   data: Request,
   private val errorDrawable: Drawable?,
   @DrawableRes val errorResId: Int
 ) : Action(picasso, data) {
+  private val targetReference = WeakReference(target)
+
   override fun complete(result: Result) {
+    val target = targetReference.get() ?: return
+
     if (result is Bitmap) {
       val bitmap = result.bitmap
       target.onBitmapLoaded(bitmap, result.loadedFrom)
@@ -37,6 +42,8 @@ internal class BitmapTargetAction(
   }
 
   override fun error(e: Exception) {
+    val target = targetReference.get() ?: return
+
     val drawable = if (errorResId != 0) {
       ContextCompat.getDrawable(picasso.context, errorResId)
     } else {
@@ -46,7 +53,7 @@ internal class BitmapTargetAction(
     target.onBitmapFailed(e, drawable)
   }
 
-  override fun getTarget(): Any {
-    return target
+  override fun getTarget(): BitmapTarget? {
+    return targetReference.get()
   }
 }

--- a/picasso/src/main/java/com/squareup/picasso3/ImageViewAction.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/ImageViewAction.kt
@@ -20,22 +20,29 @@ import android.graphics.drawable.Drawable
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import com.squareup.picasso3.RequestHandler.Result
+import java.lang.ref.WeakReference
 
 internal class ImageViewAction(
   picasso: Picasso,
-  val target: ImageView,
+  target: ImageView,
   data: Request,
   val errorDrawable: Drawable?,
   @DrawableRes val errorResId: Int,
   val noFade: Boolean,
   var callback: Callback?
 ) : Action(picasso, data) {
+  private val targetReference = WeakReference(target)
+
   override fun complete(result: Result) {
+    val target = targetReference.get() ?: return
+
     PicassoDrawable.setResult(target, picasso.context, result, noFade, picasso.indicatorsEnabled)
     callback?.onSuccess()
   }
 
   override fun error(e: Exception) {
+    val target = targetReference.get() ?: return
+
     val placeholder = target.drawable
     if (placeholder is Animatable) {
       (placeholder as Animatable).stop()
@@ -48,8 +55,8 @@ internal class ImageViewAction(
     callback?.onError(e)
   }
 
-  override fun getTarget(): Any {
-    return target
+  override fun getTarget(): ImageView? {
+    return targetReference.get()
   }
 
   override fun cancel() {

--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
@@ -129,7 +129,8 @@ class Picasso internal constructor(
 
     val actions = targetToAction.values.toList()
     for (i in actions.indices) {
-      cancelExistingRequest(actions[i].getTarget())
+      val target = actions[i].getTarget() ?: continue
+      cancelExistingRequest(target)
     }
 
     val deferredRequestCreators = targetToDeferredRequestCreator.values.toList()
@@ -177,7 +178,8 @@ class Picasso internal constructor(
     for (i in actions.indices) {
       val action = actions[i]
       if (tag == action.tag) {
-        cancelExistingRequest(action.getTarget())
+        val target = action.getTarget() ?: continue
+        cancelExistingRequest(target)
       }
     }
 
@@ -405,7 +407,7 @@ class Picasso internal constructor(
 
   @JvmName("-enqueueAndSubmit")
   internal fun enqueueAndSubmit(action: Action) {
-    val target = action.getTarget()
+    val target = action.getTarget() ?: return
     if (targetToAction[target] !== action) {
       // This will also check we are on the main thread.
       cancelExistingRequest(target)


### PR DESCRIPTION
Through a series of refactors (https://github.com/square/picasso/pull/1866, https://github.com/square/picasso/pull/1983, https://github.com/square/picasso/pull/1970), we removed some WeakReferences to ImageViews and Bitmap that now result in memory leaks.  This PR fixes that regression.

Closes https://github.com/square/picasso/pull/2322