### PR TITLE
Remove flushing our dispatcher

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Dispatcher.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Dispatcher.kt
@@ -46,7 +46,6 @@ import com.squareup.picasso3.Utils.VERB_IGNORED
 import com.squareup.picasso3.Utils.VERB_PAUSED
 import com.squareup.picasso3.Utils.VERB_REPLAYING
 import com.squareup.picasso3.Utils.VERB_RETRYING
-import com.squareup.picasso3.Utils.flushStackLocalLeaks
 import com.squareup.picasso3.Utils.getLogIdsForHunter
 import com.squareup.picasso3.Utils.hasPermission
 import com.squareup.picasso3.Utils.isAirplaneModeOn
@@ -87,7 +86,6 @@ internal class Dispatcher internal constructor(
     dispatcherThread = DispatcherThread()
     dispatcherThread.start()
     val dispatcherThreadLooper = dispatcherThread.looper
-    flushStackLocalLeaks(dispatcherThreadLooper)
     handler = DispatcherHandler(dispatcherThreadLooper, this)
     scansNetworkChanges = hasPermission(context, ACCESS_NETWORK_STATE)
     receiver = NetworkBroadcastReceiver(this)

--- a/picasso/src/main/java/com/squareup/picasso3/Utils.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Utils.kt
@@ -21,9 +21,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
 import android.content.res.Resources
-import android.os.Handler
 import android.os.Looper
-import android.os.Message
 import android.os.StatFs
 import android.provider.Settings.Global
 import android.util.Log
@@ -42,7 +40,6 @@ internal object Utils {
   private const val PICASSO_CACHE = "picasso-cache"
   private const val MIN_DISK_CACHE_SIZE = 5 * 1024 * 1024 // 5MB
   private const val MAX_DISK_CACHE_SIZE = 50 * 1024 * 1024 // 50MB
-  const val THREAD_LEAK_CLEANING_MS = 1000
 
   /** Thread confined to main thread for key creation.  */
   val MAIN_THREAD_KEY_BUILDER = StringBuilder()
@@ -219,19 +216,5 @@ internal object Utils {
     } catch (e: NameNotFoundException) {
       throw FileNotFoundException("Unable to obtain resources for package: " + data.uri)
     }
-  }
-
-  /**
-   * Prior to Android 5, HandlerThread always keeps a stack local reference to the last message
-   * that was sent to it. This method makes sure that stack local reference never stays there
-   * for too long by sending new messages to it every second.
-   */
-  fun flushStackLocalLeaks(looper: Looper) {
-    val handler: Handler = object : Handler(looper) {
-      override fun handleMessage(msg: Message) {
-        sendMessageDelayed(obtainMessage(), THREAD_LEAK_CLEANING_MS.toLong())
-      }
-    }
-    handler.sendMessageDelayed(handler.obtainMessage(), THREAD_LEAK_CLEANING_MS.toLong())
   }
 }


### PR DESCRIPTION
We no longer support < L with a minSdk of 21. Removed the flush and dumped an hprof and didn't see anything. cc @pyricau 