### PR TITLE
Integrate LeakCanary for instrumentation tests, and the sample app.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ buildscript {
     foundation: "androidx.compose.foundation:foundation:${versions.composeUi}",
     material: "androidx.compose.material:material:${versions.composeUi}",
     leakCanary: "com.squareup.leakcanary:leakcanary-android:${versions.leakCanary}",
+    leakCanaryInstrumentation: "com.squareup.leakcanary:leakcanary-android-instrumentation:${versions.leakCanary}",
   ]
 
   ext.isCi = "true" == System.getenv('CI')

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     'composeCompiler': '1.3.1',
     'okhttp': '4.10.0',
     'okio': '3.2.0',
+    'leakCanary': '2.9.1',
   ]
 
   ext.deps = [
@@ -37,6 +38,7 @@ buildscript {
     runtime: "androidx.compose.runtime:runtime:${versions.composeUi}",
     foundation: "androidx.compose.foundation:foundation:${versions.composeUi}",
     material: "androidx.compose.material:material:${versions.composeUi}",
+    leakCanary: "com.squareup.leakcanary:leakcanary-android:${versions.leakCanary}",
   ]
 
   ext.isCi = "true" == System.getenv('CI')

--- a/picasso-sample/build.gradle
+++ b/picasso-sample/build.gradle
@@ -49,4 +49,6 @@ dependencies {
   implementation project(':picasso')
   implementation project(':picasso-stats')
   implementation project(':picasso-compose')
+
+  debugImplementation deps.leakCanary
 }

--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
   androidTestImplementation deps.androidxJunit
   androidTestImplementation deps.androidxTestRunner
+  androidTestImplementation deps.leakCanaryInstrumentation
   androidTestImplementation deps.truth
 }
 

--- a/picasso/src/androidTest/java/com/squareup/picasso3/AssetRequestHandlerTest.kt
+++ b/picasso/src/androidTest/java/com/squareup/picasso3/AssetRequestHandlerTest.kt
@@ -18,11 +18,17 @@ package com.squareup.picasso3
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import leakcanary.DetectLeaksAfterTestSuccess
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AssetRequestHandlerTest {
+
+  @get:Rule
+  val rule = DetectLeaksAfterTestSuccess()
+
   @Test fun truncatesFilePrefix() {
     val uri = Uri.parse("file:///android_asset/foo/bar.png")
     val request = Request.Builder(uri).build()

--- a/picasso/src/androidTest/java/com/squareup/picasso3/BitmapUtilsTest.kt
+++ b/picasso/src/androidTest/java/com/squareup/picasso3/BitmapUtilsTest.kt
@@ -24,11 +24,16 @@ import com.squareup.picasso3.BitmapUtils.calculateInSampleSize
 import com.squareup.picasso3.BitmapUtils.createBitmapOptions
 import com.squareup.picasso3.BitmapUtils.requiresInSampleSize
 import com.squareup.picasso3.TestUtils.URI_1
+import leakcanary.DetectLeaksAfterTestSuccess
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class BitmapUtilsTest {
+
+  @get:Rule
+  val rule = DetectLeaksAfterTestSuccess()
 
   @Test fun bitmapConfig() {
     for (config in Bitmap.Config.values()) {

--- a/picasso/src/androidTest/java/com/squareup/picasso3/PicassoDrawableTest.kt
+++ b/picasso/src/androidTest/java/com/squareup/picasso3/PicassoDrawableTest.kt
@@ -23,11 +23,17 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.squareup.picasso3.Picasso.LoadedFrom.DISK
+import leakcanary.DetectLeaksAfterTestSuccess
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class PicassoDrawableTest {
+
+  @get:Rule
+  val rule = DetectLeaksAfterTestSuccess()
+
   private val placeholder: Drawable = ColorDrawable(RED)
   private val bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ALPHA_8)
 

--- a/picasso/src/androidTest/java/com/squareup/picasso3/PlatformLruCacheTest.kt
+++ b/picasso/src/androidTest/java/com/squareup/picasso3/PlatformLruCacheTest.kt
@@ -19,11 +19,17 @@ import android.graphics.Bitmap
 import android.graphics.Bitmap.Config.ALPHA_8
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import leakcanary.DetectLeaksAfterTestSuccess
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class PlatformLruCacheTest {
+
+  @get:Rule
+  val rule = DetectLeaksAfterTestSuccess()
+
   // The use of ALPHA_8 simplifies the size math in tests since only one byte is used per-pixel.
   private val A = Bitmap.createBitmap(1, 1, ALPHA_8)
   private val B = Bitmap.createBitmap(1, 1, ALPHA_8)


### PR DESCRIPTION
Not sure if it's even worth enabling in _current_ instrumentation tests. But it's there 😄 