### PR TITLE
Revert "Remove flushing our dispatcher"

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Dispatcher.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Dispatcher.kt
@@ -46,6 +46,7 @@ import com.squareup.picasso3.Utils.VERB_IGNORED
 import com.squareup.picasso3.Utils.VERB_PAUSED
 import com.squareup.picasso3.Utils.VERB_REPLAYING
 import com.squareup.picasso3.Utils.VERB_RETRYING
+import com.squareup.picasso3.Utils.flushStackLocalLeaks
 import com.squareup.picasso3.Utils.getLogIdsForHunter
 import com.squareup.picasso3.Utils.hasPermission
 import com.squareup.picasso3.Utils.isAirplaneModeOn
@@ -86,6 +87,7 @@ internal class Dispatcher internal constructor(
     dispatcherThread = DispatcherThread()
     dispatcherThread.start()
     val dispatcherThreadLooper = dispatcherThread.looper
+    flushStackLocalLeaks(dispatcherThreadLooper)
     handler = DispatcherHandler(dispatcherThreadLooper, this)
     scansNetworkChanges = hasPermission(context, ACCESS_NETWORK_STATE)
     receiver = NetworkBroadcastReceiver(this)

--- a/picasso/src/main/java/com/squareup/picasso3/Utils.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Utils.kt
@@ -222,9 +222,11 @@ internal object Utils {
   }
 
   /**
-   * Prior to Android 5, HandlerThread always keeps a stack local reference to the last message
+   * Prior to Android 12, HandlerThread always keeps a stack local reference to the last message
    * that was sent to it. This method makes sure that stack local reference never stays there
    * for too long by sending new messages to it every second.
+   *
+   * https://github.com/square/leakcanary/blob/main/plumber-android-core/src/main/java/leakcanary/AndroidLeakFixes.kt#L153
    */
   fun flushStackLocalLeaks(looper: Looper) {
     val handler: Handler = object : Handler(looper) {


### PR DESCRIPTION
Unfortunately it seems this bug didn't get fixed in Android 5 but did eventually get fixed in Android 12. Updated the comment to reflect LeakCanary's [tracking](https://github.com/square/leakcanary/blob/main/plumber-android-core/src/main/java/leakcanary/AndroidLeakFixes.kt#L153) of the bug