### PR TITLE
BitmapHunter returns RequestHandler.Drawable if found

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
@@ -18,6 +18,7 @@ package com.squareup.picasso3
 import android.net.NetworkInfo
 import com.squareup.picasso3.MemoryPolicy.Companion.shouldReadFromMemoryCache
 import com.squareup.picasso3.Picasso.LoadedFrom
+import com.squareup.picasso3.RequestHandler.Result
 import com.squareup.picasso3.RequestHandler.Result.Bitmap
 import com.squareup.picasso3.Utils.OWNER_HUNTER
 import com.squareup.picasso3.Utils.THREAD_IDLE_NAME
@@ -88,7 +89,7 @@ internal open class BitmapHunter(
     }
   }
 
-  fun hunt(): Bitmap? {
+  fun hunt(): Result? {
     if (shouldReadFromMemoryCache(data.memoryPolicy)) {
       cache[key]?.let { bitmap ->
         picasso.cacheHit()
@@ -104,7 +105,7 @@ internal open class BitmapHunter(
       data = data.newBuilder().networkPolicy(NetworkPolicy.OFFLINE).build()
     }
 
-    val resultReference = AtomicReference<RequestHandler.Result?>()
+    val resultReference = AtomicReference<Result?>()
     val exceptionReference = AtomicReference<Throwable>()
 
     val latch = CountDownLatch(1)
@@ -113,7 +114,7 @@ internal open class BitmapHunter(
         picasso = picasso,
         request = data,
         callback = object : RequestHandler.Callback {
-          override fun onSuccess(result: RequestHandler.Result?) {
+          override fun onSuccess(result: Result?) {
             resultReference.set(result)
             latch.countDown()
           }
@@ -139,7 +140,7 @@ internal open class BitmapHunter(
       }
     }
 
-    val result = resultReference.get() as? Bitmap ?: return null
+    val result = resultReference.get() as? Bitmap ?: return resultReference.get()
     val bitmap = result.bitmap
     if (picasso.isLoggingEnabled) {
       log(OWNER_HUNTER, VERB_DECODED, data.logId())

--- a/picasso/src/main/java/com/squareup/picasso3/DrawableTargetAction.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/DrawableTargetAction.kt
@@ -19,7 +19,6 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
 import com.squareup.picasso3.RequestHandler.Result
-import com.squareup.picasso3.RequestHandler.Result.Bitmap
 
 internal class DrawableTargetAction(
   picasso: Picasso,
@@ -31,20 +30,28 @@ internal class DrawableTargetAction(
   @DrawableRes val errorResId: Int
 ) : Action(picasso, data) {
   override fun complete(result: Result) {
-    if (result is Bitmap) {
-      val bitmap = result.bitmap
-      target.onDrawableLoaded(
-        PicassoDrawable(
-          context = picasso.context,
-          bitmap = bitmap,
-          placeholder = placeholderDrawable,
-          loadedFrom = result.loadedFrom,
-          noFade = noFade,
-          debugging = picasso.indicatorsEnabled
-        ),
-        result.loadedFrom
-      )
-      check(!bitmap.isRecycled) { "Target callback must not recycle bitmap!" }
+    when (result) {
+      is Result.Bitmap -> {
+        val bitmap = result.bitmap
+        target.onDrawableLoaded(
+          PicassoDrawable(
+            context = picasso.context,
+            bitmap = bitmap,
+            placeholder = placeholderDrawable,
+            loadedFrom = result.loadedFrom,
+            noFade = noFade,
+            debugging = picasso.indicatorsEnabled
+          ),
+          result.loadedFrom
+        )
+        check(!bitmap.isRecycled) { "Target callback must not recycle bitmap!" }
+      }
+      is Result.Drawable -> {
+        target.onDrawableLoaded(
+          result.drawable,
+          result.loadedFrom
+        )
+      }
     }
   }
 

--- a/picasso/src/main/java/com/squareup/picasso3/RequestCreator.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/RequestCreator.kt
@@ -35,6 +35,7 @@ import com.squareup.picasso3.PicassoDrawable.Companion.setResult
 import com.squareup.picasso3.RemoteViewsAction.AppWidgetAction
 import com.squareup.picasso3.RemoteViewsAction.NotificationAction
 import com.squareup.picasso3.RemoteViewsAction.RemoteViewsTarget
+import com.squareup.picasso3.RequestHandler.Result
 import com.squareup.picasso3.Utils.OWNER_MAIN
 import com.squareup.picasso3.Utils.VERB_COMPLETED
 import com.squareup.picasso3.Utils.checkMain
@@ -353,7 +354,7 @@ class RequestCreator internal constructor(
     val request = createRequest(started)
     val action = GetAction(picasso, request)
     val result =
-      forRequest(picasso, picasso.dispatcher, picasso.cache, action).hunt() ?: return null
+      forRequest(picasso, picasso.dispatcher, picasso.cache, action).hunt() as? Result.Bitmap ?: return null
 
     val bitmap = result.bitmap
     if (shouldWriteToMemoryCache(request.memoryPolicy)) {

--- a/picasso/src/test/java/com/squareup/picasso3/BitmapHunterTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/BitmapHunterTest.kt
@@ -17,6 +17,7 @@ package com.squareup.picasso3
 
 import android.content.Context
 import android.graphics.Bitmap.Config.ARGB_8888
+import android.graphics.drawable.BitmapDrawable
 import android.net.NetworkInfo
 import android.net.Uri
 import android.os.Looper
@@ -35,6 +36,7 @@ import com.squareup.picasso3.Picasso.Priority.LOW
 import com.squareup.picasso3.Picasso.Priority.NORMAL
 import com.squareup.picasso3.Request.Companion.KEY_SEPARATOR
 import com.squareup.picasso3.RequestHandler.Result.Bitmap
+import com.squareup.picasso3.RequestHandler.Result.Drawable
 import com.squareup.picasso3.TestUtils.ASSET_KEY_1
 import com.squareup.picasso3.TestUtils.ASSET_URI_1
 import com.squareup.picasso3.TestUtils.BITMAP_RESOURCE_VALUE
@@ -145,7 +147,7 @@ class BitmapHunterTest {
     val result = hunter.hunt()
     assertThat(cache.missCount()).isEqualTo(1)
     assertThat(result).isNotNull()
-    assertThat(result!!.bitmap).isEqualTo(bitmap)
+    assertThat((result as Bitmap).bitmap).isEqualTo(bitmap)
     assertThat(result.loadedFrom).isEqualTo(NETWORK)
     assertThat(eventRecorder.decodedBitmap).isEqualTo(bitmap)
   }
@@ -160,7 +162,7 @@ class BitmapHunterTest {
     val result = hunter.hunt()
     assertThat(cache.hitCount()).isEqualTo(1)
     assertThat(result).isNotNull()
-    assertThat(result!!.bitmap).isEqualTo(bitmap)
+    assertThat((result as Bitmap).bitmap).isEqualTo(bitmap)
     assertThat(result.loadedFrom).isEqualTo(MEMORY)
     assertThat(eventRecorder.decodedBitmap).isNull()
   }
@@ -175,12 +177,12 @@ class BitmapHunterTest {
     }
   }
 
-  @Test fun huntDecodesWithRequestHandler() {
+  @Test fun huntDecodesDrawableWithRequestHandler() {
     val picasso = mockPicasso(context, CustomRequestHandler())
     val action = mockAction(picasso, CUSTOM_URI_KEY, CUSTOM_URI)
     val hunter = forRequest(picasso, dispatcher, cache, action)
     val result = hunter.hunt()
-    assertThat(result!!.bitmap).isEqualTo(bitmap)
+    assertThat(((result as Drawable).drawable as BitmapDrawable).bitmap).isEqualTo(bitmap)
   }
 
   @Test fun attachSingleRequest() {
@@ -1079,7 +1081,7 @@ class BitmapHunterTest {
     }
 
     override fun load(picasso: Picasso, request: Request, callback: Callback) {
-      callback.onSuccess(Result.Bitmap(bitmap, MEMORY))
+      callback.onSuccess(Drawable(BitmapDrawable(context.resources, bitmap), MEMORY))
     }
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso3/DrawableTargetActionTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/DrawableTargetActionTest.kt
@@ -137,4 +137,25 @@ class DrawableTargetActionTest {
     } catch (ignored: IllegalStateException) {
     }
   }
+
+  @Test fun returnsResultDrawableToTarget() {
+    val target = mockDrawableTarget()
+    val drawableCaptor = argumentCaptor<Drawable>()
+
+    val action = DrawableTargetAction(
+      picasso = TestUtils.mockPicasso(RuntimeEnvironment.application),
+      target = target,
+      data = TestUtils.SIMPLE_REQUEST,
+      noFade = false,
+      placeholderDrawable = null,
+      errorDrawable = null,
+      errorResId = 0
+    )
+
+    val drawable = mock(Drawable::class.java)
+    action.complete(RequestHandler.Result.Drawable(drawable, NETWORK))
+
+    Mockito.verify(target).onDrawableLoaded(drawableCaptor.capture(), eq(NETWORK))
+    assertThat(drawableCaptor.value).isEqualTo(drawable)
+  }
 }


### PR DESCRIPTION
XML Resources are decoded as a RequestHandler.Drawable which currently gets dropped by BitmapHunter.

Following the git path:
https://github.com/square/picasso/commit/0b8820bd2066114cf2995eaf1cbab21a53843820
->
https://github.com/square/picasso/commit/466781f8feca2418e5d36eb45aa0cc0a7d8e1b62#diff-784cde17fbe31aebe95c90d89fa6132a3820770bb98ee34db723fef46ca26c5bR196-R216

BitmapHunter used to return the result if not a bitmap instead of null.
<img width="1609" alt="Screen Shot 2022-11-01 at 3 31 23 PM" src="https://user-images.githubusercontent.com/672316/199322022-5ce12924-0f71-4395-9c32-7e916071ed35.png">
