### PR TITLE
Fix IllegalStateException when not specifying a placeholder or error in Compose.

### DIFF
--- a/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
+++ b/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
@@ -107,6 +107,6 @@ internal class PicassoPainter(
 }
 
 private object EmptyPainter : Painter() {
-  override val intrinsicSize = Size.Zero
+  override val intrinsicSize = Size.Unspecified
   override fun DrawScope.onDraw() = Unit
 }


### PR DESCRIPTION
Fixes #2337 which produces a crash when you use the `Painter` object created via `rememberPainter` and don't specify a placeholder or error drawable. This crash is due to the fact that the painter's intrinsic initial size is set to `Zero` rather than `Unspecified`. 

As the docs for `Painter.intrinsicSize` states:

```
Return the intrinsic size of the Painter. If the there is no intrinsic size (i.e. filling bounds with an arbitrary color) return 
Size.Unspecified. If there is no intrinsic size in a single dimension, return Size with Float.NaN in the desired dimension. If a 
Painter does not have an intrinsic size, it will always draw within the full bounds of the destination
```

I tested and verified this fix on the sample app in this repo by commenting out both `placeholder` and `error` methods in `RequestCreator` object.