### PR TITLE
Ensure openInputStream cannot kill calling process

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/ContentStreamRequestHandler.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/ContentStreamRequestHandler.kt
@@ -15,9 +15,11 @@
  */
 package com.squareup.picasso3
 
+import android.annotation.SuppressLint
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import android.os.DeadObjectException
 import androidx.exifinterface.media.ExifInterface
 import androidx.exifinterface.media.ExifInterface.ORIENTATION_NORMAL
 import androidx.exifinterface.media.ExifInterface.TAG_ORIENTATION
@@ -25,6 +27,7 @@ import com.squareup.picasso3.Picasso.LoadedFrom.DISK
 import okio.Source
 import okio.source
 import java.io.FileNotFoundException
+import java.io.IOException
 
 internal open class ContentStreamRequestHandler(val context: Context) : RequestHandler() {
   override fun canHandleRequest(data: Request): Boolean =
@@ -51,11 +54,21 @@ internal open class ContentStreamRequestHandler(val context: Context) : RequestH
     }
   }
 
+  @SuppressLint("Recycle")
   fun getSource(uri: Uri): Source {
-    val contentResolver = context.contentResolver
-    val inputStream = contentResolver.openInputStream(uri)
-      ?: throw FileNotFoundException("can't open input stream, uri: $uri")
-    return inputStream.source()
+    return if (ContentResolver.SCHEME_CONTENT == uri.scheme) {
+      context.contentResolver.acquireContentProviderClient(uri)?.use {
+        try {
+          it.openTypedAssetFileDescriptor(uri, "r", null)?.createInputStream()
+        } catch (e: IOException) {
+          null
+        } catch (e: DeadObjectException) {
+          null
+        }
+      }
+    } else {
+      context.contentResolver.openInputStream(uri)
+    }?.source() ?: throw FileNotFoundException("can't open input stream, uri: $uri")
   }
 
   protected open fun getExifOrientation(uri: Uri): Int {


### PR DESCRIPTION
This addresses issue #2339

ContentResolver.openInputStream falls back to using a stable content provider which will kill the main process if it fails. Never trust an external process as there may be many things that might cause this such as reinstalls, application updates, etc. Fall back to a FileNotFoundException.