### PR TITLE
Bump latest compose 1.4.X

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ buildscript {
     'targetSdk': 33,
     'sourceCompatibility': JavaVersion.VERSION_1_8,
     'targetCompatibility': JavaVersion.VERSION_1_8,
-    'kotlin': '1.7.10',
-    'composeUi': '1.2.1',
-    'composeCompiler': '1.3.1',
+    'kotlin': '1.8.21',
+    'composeUi': '1.4.3',
+    'composeCompiler': '1.4.7',
     'okhttp': '4.10.0',
     'okio': '3.2.0',
   ]


### PR DESCRIPTION
Requires kotlin bump as well. Tested compose sample still works as expected.