### PR TITLE
Rely on only major versions for GH actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Configure JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 17
@@ -50,7 +50,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Configure JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 17
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure JDK
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 17

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Run Tests
         run: ./gradlew check
@@ -53,7 +53,7 @@ jobs:
         uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - run: ./gradlew assembleAndroidTest
 
@@ -77,7 +77,7 @@ jobs:
         uses: actions/setup-java@v3.11.0
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Publish Artifacts
         run: ./gradlew publishMavenPublicationToMavenCentralRepository

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
     androidxTestRunner: 'androidx.test:runner:1.5.2',
     junit: 'junit:junit:4.13.2',
     truth: 'com.google.truth:truth:1.1.3',
-    robolectric: 'org.robolectric:robolectric:4.6.1',
+    robolectric: 'org.robolectric:robolectric:4.7',
     mockito: 'org.mockito:mockito-core:5.3.1',
     drawablePainter: 'com.google.accompanist:accompanist-drawablepainter:0.30.1',
     composeUi: "androidx.compose.ui:ui:${versions.composeUi}",

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
   ]
 
   ext.deps = [
-    androidPlugin: 'com.android.tools.build:gradle:7.4.2',
+    androidPlugin: 'com.android.tools.build:gradle:8.0.2',
     kotlinPlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
     okhttp: "com.squareup.okhttp3:okhttp:${versions.okhttp}",
     okio: "com.squareup.okio:okio:${versions.okio}",


### PR DESCRIPTION
Also, delete dependabot.yaml since we now use Renovate