### PR TITLE
Use same target bytecode for layoutlib-compat artifact

### DIFF
--- a/picasso-layoutlib-compat/build.gradle
+++ b/picasso-layoutlib-compat/build.gradle
@@ -4,3 +4,14 @@ apply plugin: 'com.vanniktech.maven.publish'
 dependencies {
   compileOnly libs.layoutlib
 }
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = libs.versions.javaTarget.get()
+  targetCompatibility = libs.versions.javaTarget.get()
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = libs.versions.javaTarget.get()
+  }
+}


### PR DESCRIPTION
Before:
```
$ file picasso-compose/build/tmp/kotlin-classes/release/com/squareup/picasso3/compose/EmptyPainter.class
picasso-compose/build/tmp/kotlin-classes/release/com/squareup/picasso3/compose/EmptyPainter.class: compiled Java class data, version 52.0 (Java 1.8)
$ file picasso-layoutlib-compat/build/classes/kotlin/main/com/squareup/picasso3/layoutlib/LayoutlibExecutorService.class
picasso-layoutlib-compat/build/classes/kotlin/main/com/squareup/picasso3/layoutlib/LayoutlibExecutorService.class: compiled Java class data, version 61.0
```

After:
```
$ file picasso-layoutlib-compat/build/classes/kotlin/main/com/squareup/picasso3/layoutlib/LayoutlibExecutorService.class
picasso-layoutlib-compat/build/classes/kotlin/main/com/squareup/picasso3/layoutlib/LayoutlibExecutorService.class: compiled Java class data, version 52.0 (Java 1.8)
```