### PR TITLE
Extract HandlerThread implementation from Dispatcher

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/HandlerDispatcher.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/HandlerDispatcher.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso3
+
+import android.content.Context
+import android.net.NetworkInfo
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.os.Message
+import android.os.Process.THREAD_PRIORITY_BACKGROUND
+import com.squareup.picasso3.Utils.flushStackLocalLeaks
+import java.util.concurrent.ExecutorService
+
+internal class HandlerDispatcher internal constructor(
+  context: Context,
+  service: ExecutorService,
+  mainThreadHandler: Handler,
+  cache: PlatformLruCache
+) : Dispatcher(context, service, mainThreadHandler, cache) {
+
+  private val dispatcherThread: DispatcherThread
+  private val handler: Handler
+
+  init {
+    dispatcherThread = DispatcherThread()
+    dispatcherThread.start()
+    val dispatcherThreadLooper = dispatcherThread.looper
+    flushStackLocalLeaks(dispatcherThreadLooper)
+    handler = DispatcherHandler(dispatcherThreadLooper, this)
+  }
+
+  override fun shutdown() {
+    super.shutdown()
+
+    dispatcherThread.quit()
+  }
+
+  override fun dispatchSubmit(action: Action) {
+    handler.sendMessage(handler.obtainMessage(REQUEST_SUBMIT, action))
+  }
+
+  override fun dispatchCancel(action: Action) {
+    handler.sendMessage(handler.obtainMessage(REQUEST_CANCEL, action))
+  }
+
+  override fun dispatchPauseTag(tag: Any) {
+    handler.sendMessage(handler.obtainMessage(TAG_PAUSE, tag))
+  }
+
+  override fun dispatchResumeTag(tag: Any) {
+    handler.sendMessage(handler.obtainMessage(TAG_RESUME, tag))
+  }
+
+  override fun dispatchComplete(hunter: BitmapHunter) {
+    handler.sendMessage(handler.obtainMessage(HUNTER_COMPLETE, hunter))
+  }
+
+  override fun dispatchRetry(hunter: BitmapHunter) {
+    handler.sendMessageDelayed(handler.obtainMessage(HUNTER_RETRY, hunter), RETRY_DELAY)
+  }
+
+  override fun dispatchFailed(hunter: BitmapHunter) {
+    handler.sendMessage(handler.obtainMessage(HUNTER_DECODE_FAILED, hunter))
+  }
+
+  override fun dispatchNetworkStateChange(info: NetworkInfo) {
+    handler.sendMessage(handler.obtainMessage(NETWORK_STATE_CHANGE, info))
+  }
+
+  override fun dispatchAirplaneModeChange(airplaneMode: Boolean) {
+    handler.sendMessage(
+      handler.obtainMessage(
+        AIRPLANE_MODE_CHANGE,
+        if (airplaneMode) AIRPLANE_MODE_ON else AIRPLANE_MODE_OFF,
+        0
+      )
+    )
+  }
+
+  private class DispatcherHandler(
+    looper: Looper,
+    private val dispatcher: Dispatcher
+  ) : Handler(looper) {
+    override fun handleMessage(msg: Message) {
+      when (msg.what) {
+        REQUEST_SUBMIT -> {
+          val action = msg.obj as Action
+          dispatcher.performSubmit(action)
+        }
+        REQUEST_CANCEL -> {
+          val action = msg.obj as Action
+          dispatcher.performCancel(action)
+        }
+        TAG_PAUSE -> {
+          val tag = msg.obj
+          dispatcher.performPauseTag(tag)
+        }
+        TAG_RESUME -> {
+          val tag = msg.obj
+          dispatcher.performResumeTag(tag)
+        }
+        HUNTER_COMPLETE -> {
+          val hunter = msg.obj as BitmapHunter
+          dispatcher.performComplete(hunter)
+        }
+        HUNTER_RETRY -> {
+          val hunter = msg.obj as BitmapHunter
+          dispatcher.performRetry(hunter)
+        }
+        HUNTER_DECODE_FAILED -> {
+          val hunter = msg.obj as BitmapHunter
+          dispatcher.performError(hunter)
+        }
+        NETWORK_STATE_CHANGE -> {
+          val info = msg.obj as NetworkInfo
+          dispatcher.performNetworkStateChange(info)
+        }
+        AIRPLANE_MODE_CHANGE -> {
+          dispatcher.performAirplaneModeChange(msg.arg1 == AIRPLANE_MODE_ON)
+        }
+        else -> {
+          Picasso.HANDLER.post {
+            throw AssertionError("Unknown handler message received: ${msg.what}")
+          }
+        }
+      }
+    }
+  }
+
+  internal class DispatcherThread : HandlerThread(
+    Utils.THREAD_PREFIX + DISPATCHER_THREAD_NAME,
+    THREAD_PRIORITY_BACKGROUND
+  )
+  internal companion object {
+    private const val RETRY_DELAY = 500L
+    private const val AIRPLANE_MODE_ON = 1
+    private const val AIRPLANE_MODE_OFF = 0
+    private const val REQUEST_SUBMIT = 1
+    private const val REQUEST_CANCEL = 2
+    private const val HUNTER_RETRY = 5
+    private const val HUNTER_DECODE_FAILED = 6
+    private const val AIRPLANE_MODE_CHANGE = 10
+    private const val TAG_PAUSE = 11
+    private const val TAG_RESUME = 12
+    private const val DISPATCHER_THREAD_NAME = "Dispatcher"
+  }
+}

--- a/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Picasso.kt
@@ -668,7 +668,7 @@ class Picasso internal constructor(
         service = PicassoExecutorService()
       }
 
-      val dispatcher = Dispatcher(context, service!!, HANDLER, cache!!)
+      val dispatcher = HandlerDispatcher(context, service!!, HANDLER, cache!!)
 
       return Picasso(
         context, dispatcher, callFactory!!, unsharedCache, cache!!, listener,

--- a/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/DispatcherTest.kt
@@ -586,7 +586,7 @@ class DispatcherTest {
     `when`(context.checkCallingOrSelfPermission(anyString())).thenReturn(
       if (scansNetworkChanges) PERMISSION_GRANTED else PERMISSION_DENIED
     )
-    return Dispatcher(context, service, Handler(getMainLooper()), cache)
+    return HandlerDispatcher(context, service, Handler(getMainLooper()), cache)
   }
 
   private fun noopAction(data: Request): Action {


### PR DESCRIPTION
(Handler)Thread's operate differently on the JVM vs Android in that on Android the thread is started immediately and the Looper is available in the same call frame however on the JVM the thread gets started async which means during Paparazzi Tests / Compose Previews we have a race condition between the JVM thread starting and giving us access to a Looper and our main thread proceeding which can occasionally result in NPE's.

This is the first step in surfacing a mechanism to provide control over where Picasso executes instead of hiding it behind a HandlerThread which is created internally for every Picasso instance that gets built.