### PR TITLE
Add opt-in CoroutineDispatcher api for controlling Picasso's internal thread

### DIFF
--- a/picasso-paparazzi-sample/src/test/java/com/example/picasso/paparazzi/PicassoPaparazziTest.kt
+++ b/picasso-paparazzi-sample/src/test/java/com/example/picasso/paparazzi/PicassoPaparazziTest.kt
@@ -26,6 +26,7 @@ import com.squareup.picasso3.RequestHandler
 import com.squareup.picasso3.layoutlib.LayoutlibExecutorService
 import org.junit.Rule
 import org.junit.Test
+import kotlinx.coroutines.Dispatchers
 
 class PicassoPaparazziTest {
   @get:Rule val paparazzi = Paparazzi()
@@ -35,6 +36,7 @@ class PicassoPaparazziTest {
     val picasso = Picasso.Builder(paparazzi.context)
       .callFactory { throw AssertionError() } // Removes network
       .executor(LayoutlibExecutorService())
+      .dispatcher(Dispatchers.Main)
       .addRequestHandler(FakeRequestHandler())
       .build()
 

--- a/picasso/api/picasso.api
+++ b/picasso/api/picasso.api
@@ -107,6 +107,7 @@ public final class com/squareup/picasso3/Picasso$Builder {
 	public final fun callFactory (Lokhttp3/Call$Factory;)Lcom/squareup/picasso3/Picasso$Builder;
 	public final fun client (Lokhttp3/OkHttpClient;)Lcom/squareup/picasso3/Picasso$Builder;
 	public final fun defaultBitmapConfig (Landroid/graphics/Bitmap$Config;)Lcom/squareup/picasso3/Picasso$Builder;
+	public final fun dispatcher (Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/squareup/picasso3/Picasso$Builder;
 	public final fun executor (Ljava/util/concurrent/ExecutorService;)Lcom/squareup/picasso3/Picasso$Builder;
 	public final fun indicatorsEnabled (Z)Lcom/squareup/picasso3/Picasso$Builder;
 	public final fun listener (Lcom/squareup/picasso3/Picasso$Listener;)Lcom/squareup/picasso3/Picasso$Builder;

--- a/picasso/src/main/java/com/squareup/picasso3/InternalCoroutineDispatcher.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/InternalCoroutineDispatcher.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso3
+
+import android.content.Context
+import android.net.NetworkInfo
+import android.os.Handler
+import java.util.concurrent.ExecutorService
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class InternalCoroutineDispatcher internal constructor(
+  context: Context,
+  service: ExecutorService,
+  mainThreadHandler: Handler,
+  cache: PlatformLruCache,
+  val picassoDispatcher: CoroutineDispatcher
+) : Dispatcher(context, service, mainThreadHandler, cache) {
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  private val scope = CoroutineScope(picassoDispatcher.limitedParallelism(1))
+
+  override fun shutdown() {
+    super.shutdown()
+    scope.cancel()
+  }
+
+  override fun dispatchSubmit(action: Action) {
+    scope.launch {
+      performSubmit(action)
+    }
+  }
+
+  override fun dispatchCancel(action: Action) {
+    scope.launch {
+      performCancel(action)
+    }
+  }
+
+  override fun dispatchPauseTag(tag: Any) {
+    scope.launch {
+      performPauseTag(tag)
+    }
+  }
+
+  override fun dispatchResumeTag(tag: Any) {
+    scope.launch {
+      performResumeTag(tag)
+    }
+  }
+
+  override fun dispatchComplete(hunter: BitmapHunter) {
+    scope.launch {
+      performComplete(hunter)
+    }
+  }
+
+  override fun dispatchRetry(hunter: BitmapHunter) {
+    scope.launch {
+      delay(RETRY_DELAY)
+      performRetry(hunter)
+    }
+  }
+
+  override fun dispatchFailed(hunter: BitmapHunter) {
+    scope.launch {
+      performError(hunter)
+    }
+  }
+
+  override fun dispatchNetworkStateChange(info: NetworkInfo) {
+    scope.launch {
+      performNetworkStateChange(info)
+    }
+  }
+
+  override fun dispatchAirplaneModeChange(airplaneMode: Boolean) {
+    scope.launch {
+      performAirplaneModeChange(airplaneMode)
+    }
+  }
+
+  override fun dispatchCompleteMain(hunter: BitmapHunter) {
+    scope.launch(Dispatchers.Main) {
+      performCompleteMain(hunter)
+    }
+  }
+
+  override fun dispatchBatchResumeMain(batch: MutableList<Action>) {
+    scope.launch(Dispatchers.Main) {
+      performBatchResumeMain(batch)
+    }
+  }
+}


### PR DESCRIPTION
This adds a new `Picasso#dispatcher` API for setting a CoroutineDispatcher to be used in lieu of a HandlerThread. We keep this dispatcher limited to execute on a single coroutine at a time since this class is accessing internal state. We still rely on an ExecutorService for handling BitmapHunter operations and priority, working on a follow up to remove the need for an ExecutorService and could rely solely on a CoroutineDispatcher.

Using `Dispatchers.IO`

https://github.com/square/picasso/assets/672316/a10d353e-a8eb-4b8e-bcf4-376f5b97edcb


