### PR TITLE
BitmapHunter resets Thread's name to original name

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapHunter.kt
@@ -20,7 +20,6 @@ import com.squareup.picasso3.MemoryPolicy.Companion.shouldReadFromMemoryCache
 import com.squareup.picasso3.Picasso.LoadedFrom
 import com.squareup.picasso3.RequestHandler.Result.Bitmap
 import com.squareup.picasso3.Utils.OWNER_HUNTER
-import com.squareup.picasso3.Utils.THREAD_IDLE_NAME
 import com.squareup.picasso3.Utils.THREAD_PREFIX
 import com.squareup.picasso3.Utils.VERB_DECODED
 import com.squareup.picasso3.Utils.VERB_EXECUTING
@@ -64,6 +63,7 @@ internal open class BitmapHunter(
     get() = future?.isCancelled ?: false
 
   override fun run() {
+    val originalName = Thread.currentThread().name
     try {
       updateThreadName(data)
 
@@ -84,7 +84,7 @@ internal open class BitmapHunter(
       exception = e
       dispatcher.dispatchFailed(this)
     } finally {
-      Thread.currentThread().name = THREAD_IDLE_NAME
+      Thread.currentThread().name = originalName
     }
   }
 

--- a/picasso/src/main/java/com/squareup/picasso3/PicassoExecutorService.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/PicassoExecutorService.kt
@@ -49,6 +49,7 @@ class PicassoExecutorService(
 
     private class PicassoThread(r: Runnable) : Thread(r) {
       override fun run() {
+        name = Utils.THREAD_IDLE_NAME
         Process.setThreadPriority(THREAD_PRIORITY_BACKGROUND)
         super.run()
       }


### PR DESCRIPTION
If an external executor is supplied we clobber any Thread name that may already be set. Instead we'll default our own threads to the idle name which'll get reset after hunting.