### PR TITLE
Proof-of-concept: Make PicassoPainter's request restart when read state is changed

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ composeRuntime = { module = 'androidx.compose.runtime:runtime', version.ref = 'c
 composeUi-foundation = { module = 'androidx.compose.foundation:foundation', version.ref = 'composeUi' }
 composeUi-material = { module = 'androidx.compose.material:material', version.ref = 'composeUi' }
 composeUi-uiTooling = { module = 'androidx.compose.ui:ui-tooling', version.ref = 'composeUi' }
+composeUi-test = { module = 'androidx.compose.ui:ui-test-junit4', version.ref = 'composeUi' }
 
 drawablePainter = { module = 'com.google.accompanist:accompanist-drawablepainter', version = '0.30.1' }
 

--- a/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
+++ b/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
@@ -40,14 +40,31 @@ fun Picasso.rememberPainter(
   request: (Picasso) -> RequestCreator
 ): Painter {
   return remember(key) { PicassoPainter(this, request, onError) }
+    .also { painter ->
+      DisposableEffect(painter) {
+        painter.start()
+        onDispose(painter::stop)
+      }
+    }
 }
 
 internal class PicassoPainter(
   private val picasso: Picasso,
-  private val request: (Picasso) -> RequestCreator,
+  request: (Picasso) -> RequestCreator,
   private val onError: ((Exception) -> Unit)? = null
 ) : Painter(), RememberObserver, DrawableTarget {
 
+  private val stateObserver = SnapshotStateObserver(onChangeExecutor = { callback ->
+      if (Looper.myLooper == Looper.mainLooper) {
+        callback()
+      } else {
+        postToMainThread(callback)
+      }
+    })
+  private val request: RequestCreator by derivedStateOf { request.invoke(picasso) }
+  // This is technically written to from composition once, by onRemembered. However it's
+  // never written to from composition again so it doesn't need to be snapshot state.
+  private var lastRequest: RequestCreator? = null
   private var painter: Painter by mutableStateOf(EmptyPainter)
   private var alpha: Float by mutableStateOf(DefaultAlpha)
   private var colorFilter: ColorFilter? by mutableStateOf(null)
@@ -72,7 +89,7 @@ internal class PicassoPainter(
   }
 
   override fun onRemembered() {
-    request.invoke(picasso).into(this)
+    loadRequest()
   }
 
   override fun onAbandoned() {
@@ -85,6 +102,39 @@ internal class PicassoPainter(
     (painter as? RememberObserver)?.onForgotten()
     painter = EmptyPainter
     picasso.cancelRequest(this)
+  }
+
+  fun start() {
+    stateObserver.start()
+    // Even though loadRequest was called in onRemembered, we need to call it
+    // again now that the observer is started to observe state reads.
+    loadRequest()
+  }
+
+  fun stop() {
+    stateObserver.stop()
+    stateObserver.clear()
+    // Picasso state will be cleaned up by onForgotten, we don't need to
+    // do it here.
+  }
+
+  private fun loadRequest() {
+    // Because this will get called from composition, and we don't care about
+    // lastRequest changing and are handling request reads ourself.
+    // It will get called again from start() and that will observe the reads.
+    Snapshot.withoutReadObservation {
+      // The first time this is called, from composition, the observer won't
+      // have been started yet so this will run the block but not observe it.
+      val newRequest = stateObserver.observeReads(this, onCommitAffectingRequest) {
+        request
+      }
+      // Can be != if RequestCreators are comparable. Identity comparison works
+      // because derivedStateOf will return a cached instance if nothing changed.
+      if (newRequest !== lastRequest) {
+        lastRequest = newRequest
+        newRequest.into(this)
+      }
+    }
   }
 
   override fun onPrepareLoad(placeHolderDrawable: Drawable?) {
@@ -103,6 +153,12 @@ internal class PicassoPainter(
   private fun setPainter(drawable: Drawable) {
     (painter as? RememberObserver)?.onForgotten()
     painter = DrawablePainter(drawable).apply(DrawablePainter::onRemembered)
+  }
+
+  private companion object {
+    val onCommitAffectingRequest: (PicassoPainter) -> Unit = { painter ->
+      painter.loadRequest()
+    }
   }
 }
 

--- a/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
+++ b/picasso-compose/src/main/java/com/squareup/picasso3/compose/PicassoPainter.kt
@@ -18,10 +18,12 @@ package com.squareup.picasso3.compose
 import android.graphics.drawable.Drawable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.DefaultAlpha
@@ -48,12 +50,19 @@ internal class PicassoPainter(
   private val onError: ((Exception) -> Unit)? = null
 ) : Painter(), RememberObserver, DrawableTarget {
 
+  private var lastRequestCreator: RequestCreator? by mutableStateOf(null)
+  private val requestCreator: RequestCreator by derivedStateOf { request(picasso) }
   private var painter: Painter by mutableStateOf(EmptyPainter)
   private var alpha: Float by mutableStateOf(DefaultAlpha)
   private var colorFilter: ColorFilter? by mutableStateOf(null)
 
   override val intrinsicSize: Size
-    get() = painter.intrinsicSize
+    get() {
+      // Make sure we're using the latest request. If the request function reads any state, it will
+      // invalidate whatever scope this property is being read from.
+      load()
+      return painter.intrinsicSize
+    }
 
   override fun applyAlpha(alpha: Float): Boolean {
     this.alpha = alpha
@@ -66,13 +75,20 @@ internal class PicassoPainter(
   }
 
   override fun DrawScope.onDraw() {
+    // Make sure we're using the latest request. If the request function reads any state, it will
+    // invalidate this draw scope when it changes.
+    load()
     with(painter) {
       draw(size, alpha, colorFilter)
     }
   }
 
   override fun onRemembered() {
-    request.invoke(picasso).into(this)
+    // This is called from composition, but if the request provider function reads any state we
+    // don't want that to invalidate composition. It will invalidate draw, later.
+    Snapshot.withoutReadObservation {
+      load()
+    }
   }
 
   override fun onAbandoned() {
@@ -98,6 +114,20 @@ internal class PicassoPainter(
   override fun onDrawableFailed(e: Exception, errorDrawable: Drawable?) {
     onError?.invoke(e)
     errorDrawable?.let(::setPainter)
+  }
+
+  private fun load() {
+    // This derived state read will return the same instance of RequestCreator if one has been
+    // cached and none of the state dependencies have since changed.
+    val requestCreator = requestCreator
+    // lastRequestCreator is just used for diffing, we don't want it to invalidate anything.
+    val lastRequestCreator = Snapshot.withoutReadObservation { lastRequestCreator }
+
+    // Only launch a new request if anything has actually changed.
+    if (requestCreator != lastRequestCreator) {
+      this.lastRequestCreator = requestCreator
+      requestCreator.into(this)
+    }
   }
 
   private fun setPainter(drawable: Drawable) {

--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -23,6 +23,14 @@ android {
     jvmTarget = libs.versions.javaTarget.get()
   }
 
+  // For tests.
+  buildFeatures {
+    compose true
+  }
+  composeOptions {
+    kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
+  }
+
   lintOptions {
     textOutput 'stdout'
     textReport true
@@ -51,8 +59,11 @@ dependencies {
   testImplementation libs.mockito
   testImplementation libs.okhttp.mockWebServer
 
+  androidTestImplementation project(":picasso-compose")
   androidTestImplementation libs.androidx.junit
   androidTestImplementation libs.androidx.testRunner
+  androidTestImplementation libs.composeUi.foundation
+  androidTestImplementation libs.composeUi.test
   androidTestImplementation libs.truth
 }
 

--- a/picasso/src/androidTest/java/com/squareup/picasso3/PicassoComposePainterTest.kt
+++ b/picasso/src/androidTest/java/com/squareup/picasso3/PicassoComposePainterTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2013 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.picasso3
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.common.truth.Truth.assertThat
+import com.squareup.picasso3.compose.rememberPainter
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PicassoComposePainterTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun firstFrameConsumesStateFromLayout() {
+        lateinit var lastRequest: Request
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val picasso = Picasso.Builder(context)
+            .addRequestHandler(object : RequestHandler() {
+                override fun canHandleRequest(data: Request): Boolean = true
+                override fun load(picasso: Picasso, request: Request, callback: Callback) {
+                    lastRequest = request
+                }
+            })
+            .build()
+        var size: IntSize by mutableStateOf(IntSize.Zero)
+        var initialFrame = true
+
+        rule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                val painter = picasso.rememberPainter {
+                    it.load("http://example.com/")
+                        .addHeader("width", size.width.toString())
+                        .addHeader("height", size.height.toString())
+                }
+                Canvas(
+                    Modifier
+                        .requiredSize(9.dp)
+                        .onSizeChanged { size = it }
+                ) {
+                    val canvasSize = this.size
+
+                    if (initialFrame) {
+                        initialFrame = false
+                        // Initial request was made with uninitialized size.
+                        assertThat(lastRequest.headers?.toMultimap()).containsAtLeastEntriesIn(
+                            mapOf(
+                                "width" to listOf("0"),
+                                "height" to listOf("0"),
+                            )
+                        )
+                    }
+
+                    with(painter) {
+                        draw(canvasSize)
+                    }
+
+                    // Draw triggers request was made with size.
+                    assertThat(lastRequest.headers?.toMultimap()).containsAtLeastEntriesIn(
+                        mapOf(
+                            "width" to listOf("9"),
+                            "height" to listOf("9"),
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun redrawDoesNotReexecuteUnchangedRequest() {
+        var requestCount = 0
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val picasso = Picasso.Builder(context)
+            .addRequestHandler(object : RequestHandler() {
+                override fun canHandleRequest(data: Request): Boolean = true
+                override fun load(picasso: Picasso, request: Request, callback: Callback) {
+                    requestCount++
+                }
+            })
+            .build()
+        var drawInvalidator by mutableStateOf(0)
+
+        rule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                val painter = picasso.rememberPainter {
+                    it.load("http://example.com/")
+                }
+                Canvas(Modifier.fillMaxSize()) {
+                    println(drawInvalidator)
+                    val canvasSize = this.size
+                    with(painter) {
+                        draw(canvasSize)
+                    }
+                }
+            }
+        }
+
+        rule.runOnIdle {
+            assertThat(requestCount).isEqualTo(1)
+        }
+
+        drawInvalidator++
+
+        rule.runOnIdle {
+            assertThat(requestCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun newRequestLoaded_whenRequestDependenciesChangedAfterFirstFrame() {
+        lateinit var lastRequest: Request
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val picasso = Picasso.Builder(context)
+            .addRequestHandler(object : RequestHandler() {
+                override fun canHandleRequest(data: Request): Boolean = true
+                override fun load(picasso: Picasso, request: Request, callback: Callback) {
+                    lastRequest = request
+                }
+            })
+            .build()
+        var testHeader by mutableStateOf("one")
+
+        rule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                val painter = picasso.rememberPainter {
+                    it.load("http://example.com/")
+                        .addHeader("testHeader", testHeader)
+                }
+                Canvas(Modifier.fillMaxSize()) {
+                    val canvasSize = this.size
+
+                    with(painter) {
+                        draw(canvasSize)
+                    }
+                }
+            }
+        }
+
+        rule.runOnIdle {
+            assertThat(lastRequest.headers?.get("testHeader")).isEqualTo("one")
+        }
+
+        testHeader = "two"
+
+        rule.runOnIdle {
+            assertThat(lastRequest.headers?.get("testHeader")).isEqualTo("two")
+        }
+
+        testHeader = "three"
+
+        rule.runOnIdle {
+            assertThat(lastRequest.headers?.get("testHeader")).isEqualTo("three")
+        }
+    }
+}


### PR DESCRIPTION
Allows `rememberPainter` to support the use case where the `request` function reads some snapshot state that gets changed between the initial `rememberPainter` call and the first `onDraw` call. For example:
```kotlin
@Composable fun MyImage() {
  var size: IntSize by remember { mutableStateOf(IntSize.Zero) }
  Image(
    modifier = Modifier.onSizeChanged { size = it },
    painter = picasso.rememberPainter {
      // 1. Composition: This will get called immediately, before size has
      //    been initialized by the first layout phase.
      //        - size=IntSize.Zero
      //        - load(null)
      //        - painter=placeholder
      // 2. Layout: onSizeChanged invoked and size is updated.
      //        - size=IntSize(width, height)
      //        - load not called yet
      //        - painter=placeholder (unchanged)
      // 3. Draw: Before Painter draws loaded image, it will see the
      //    dependencies have changed and call this lambda again. If the
      //    resulting image request can be loaded from memory, it will be
      //    immediately available for drawing in that same frame.
      //        - size=IntSize(width, height)
      //        - load("some://url.with/size?width,height")
      //        - if image was cached in memory,
      //            - painter=loaded image
      //            - painter=placeholder until async load finishes
      val imageUrl = if (size == IntSize.Zero) null else getImageUrl(size = size)
      it.load(imageUrl)
    }
  )
}
```

This change ensures that if `request` has any state dependencies, that when those dependencies are changed:
1. Composition is _not_ invalidated.
    - Previously, since `request` was called from `onRemembered`, the first change would invalidate the composition, and then subsequent changes wouldn't invalidate anything.
2. Anything that read the `PicassoPainter`'s `intrinsicSize` or called `draw` _is_ invalidated.

It also ensures that any time `intrinsicSize` or `onDraw` is called, we call `RequestCreator.into` if the request has been invalidated, before consuming the drawable, to allow the latest `RequestCreator` to be loaded from memory if available. It relies on `derivedStateOf` returning the cached instance to avoid executing redundant `into` calls if `request`'s dependencies haven't changed.

This approach unfortunately means that the `request` function might run during the draw phase, which means that at the very least a new `RequestCreator` would be allocated, in addition to whatever other work the function might be doing. It's generally not good to allocate or do any non-draw-related work during the draw pass, but I don't think it can be avoided. Because `Painter`s don't necessarily participate in layout, `onDraw` is the only hook we have that's guaranteed to run after any layout code (as required in the example above) but still in the current frame. If Picasso's public Compose API was something that participated in layout directly, like an `Image`-like composable or a modifier, then this could be done more efficiently since the `request` function would only need to be checked before its own measurement, not in every draw pass. 