### PR TITLE
Fix Request's newBuilder not copying headers

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/Request.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/Request.kt
@@ -330,6 +330,7 @@ class Request internal constructor(builder: Builder) {
       priority = request.priority
       memoryPolicy = request.memoryPolicy
       networkPolicy = request.networkPolicy
+      headers = request.headers
     }
 
     fun hasImage(): Boolean {

--- a/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/RequestCreatorTest.kt
@@ -710,4 +710,15 @@ class RequestCreatorTest {
     assertThat(actionCaptor.value.request.headers!![CUSTOM_HEADER_NAME])
       .isEqualTo(CUSTOM_HEADER_VALUE)
   }
+
+  @Test fun imageViewActionWithCustomHeadersCopiesHeaders() {
+    RequestCreator(picasso, URI_1, 0)
+      .addHeader(CUSTOM_HEADER_NAME, CUSTOM_HEADER_VALUE)
+      .into(mockImageViewTarget())
+    verify(picasso).enqueueAndSubmit(actionCaptor.capture())
+
+    val newRequest = actionCaptor.value.request.newBuilder().build()
+
+    assertThat(newRequest.headers!![CUSTOM_HEADER_NAME]).isEqualTo(CUSTOM_HEADER_VALUE)
+  }
 }


### PR DESCRIPTION
We weren't copying the headers 😢 