### PR TITLE
Migrate instrumentation-tests macos-latest > ubuntu-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,7 @@ jobs:
             **/build/reports/tests/test/
 
   instrumentation-tests:
-    # We build on a Mac to get hardware acceleration for the Android emulator.
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -58,6 +57,12 @@ jobs:
           java-version: 17
 
       - run: ./gradlew assembleAndroidTest
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
macos-latest is now arm based causing issues with launching the emulator for running tests. ubuntu-latest now has [hardware acceleration](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) so we can move to that runner instead and continue using the x86 emulator.