### PR TITLE
Update BaseDispatcher.kt

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BaseDispatcher.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BaseDispatcher.kt
@@ -353,14 +353,8 @@ internal abstract class BaseDispatcher internal constructor(
   }
 
   private fun markForReplay(hunter: BitmapHunter) {
-    val action = hunter.action
-    action?.let { markForReplay(it) }
-    val joined = hunter.actions
-    if (joined != null) {
-      for (i in joined.indices) {
-        markForReplay(joined[i])
-      }
-    }
+    hunter.action?.let { markForReplay(it) }
+    hunter.actions?.forEach { markForReplay(it) }
   }
 
   private fun markForReplay(action: Action) {


### PR DESCRIPTION
The original null check for `joined` is replaced by directly calling `forEach` on `hunter.actions`. If `actions` is null, the block won't be executed, maintaining safety without additional checks.