### PR TITLE
Refactor lint configurations and update dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,9 +8,9 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = lf
 
-[*.{kt, kts}]
+[*.{kt,kts}]
 ktlint_code_style = intellij_idea
-ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,kotlinx.**,^
+ij_kotlin_imports_layout = *, java.**, javax.**, kotlin.**, kotlinx.**, ^
 ij_kotlin_allow_trailing_comma = false
 ij_kotlin_allow_trailing_comma_on_call_site = false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ Version 2.71828 *(2018-03-07)*
 ------------------------------
 
 This version is not fully backwards compatible with previous 2.x releases!
-It is intended to be a stable, pre-3.0 release that users of 3.0.0-SNAPSHOT can use in the mean time.
+It is intended to be a stable, pre-3.0 release that users of 3.0.0-SNAPSHOT can use in the mean
+time.
 
 Its changes are many, as evidenced by the nearly 3 years since 2.5.2. If you are interested
-in them you can browse the commits here: https://github.com/square/picasso/compare/picasso-parent-2.5.2...2.71828
+in them you can browse the commits
+here: https://github.com/square/picasso/compare/picasso-parent-2.5.2...2.71828
 
 Otherwise, stay tuned for 3.0 whose change log will be in relation to 2.5.2 and thus encompass any
 changes present in this release.
@@ -17,130 +19,127 @@ changes present in this release.
 Version 2.5.2 *(2015-03-20)*
 ----------------------------
 
- * Fix: Correct problems with adapter-based recycling of drawables and interop with external libraries like RoundImageView.
-
+* Fix: Correct problems with adapter-based recycling of drawables and interop with external
+  libraries like RoundImageView.
 
 Version 2.5.1 *(2015-03-19)*
 ----------------------------
 
- * Specifying transformations in a request now accepts a list.
- * Fix: Correctly handle `null` values from content providers.
- * Fix: Ensure contact photo thumbnail Uris are loaded with the correct request handler.
- * Fix: Eliminate potential (albeit temporary) memory leak on pre-5.0 Android due to message pooling.
- * Fix: Prevent placeholder image aspect ratio from changing while crossfading in image.
-
+* Specifying transformations in a request now accepts a list.
+* Fix: Correctly handle `null` values from content providers.
+* Fix: Ensure contact photo thumbnail Uris are loaded with the correct request handler.
+* Fix: Eliminate potential (albeit temporary) memory leak on pre-5.0 Android due to message pooling.
+* Fix: Prevent placeholder image aspect ratio from changing while crossfading in image.
 
 Version 2.5.0 *(2015-02-06)*
 --------------------------
 
- * Update to OkHttp 2.x's native API. If you are using OkHttp you must use version 2.0 or newer (the latest is 2.2 at time of writing) and you no longer need to use the `okhttp-urlconnection` shim.
- * Memory and Network policy API controls reading and storing bitmaps in memory and/or disk cache.
- * Allow returning `InputStream` from `RequestHandler`.
- * Allow removing items from memory cache using `clearKeyUri`.
- * `fetch()` can now accept a `Callback`.
- * Provide option with `onlyScaleDown` to perform scaling only if the source bitmap is larger than the target.
- * Fix: Potential workaround handling improperly cached responses with unknown `Content-Length`. (#632)
- * Fix: Ensure resized images completely fill ImageView (#769)
- * Fix: Properly report correct exception when disk cache fails to load (504 gateway error).
- * Fix: Resize now properly maintains aspect ratio if width or height is 0.
- * Fix: Update debug indicators for the visually impaired (blue color instead of yellow for disk cache hits).
-
+* Update to OkHttp 2.x's native API. If you are using OkHttp you must use version 2.0 or newer (the
+  latest is 2.2 at time of writing) and you no longer need to use the `okhttp-urlconnection` shim.
+* Memory and Network policy API controls reading and storing bitmaps in memory and/or disk cache.
+* Allow returning `InputStream` from `RequestHandler`.
+* Allow removing items from memory cache using `clearKeyUri`.
+* `fetch()` can now accept a `Callback`.
+* Provide option with `onlyScaleDown` to perform scaling only if the source bitmap is larger than
+  the target.
+* Fix: Potential workaround handling improperly cached responses with unknown `Content-Length`. (
+  #632)
+* Fix: Ensure resized images completely fill ImageView (#769)
+* Fix: Properly report correct exception when disk cache fails to load (504 gateway error).
+* Fix: Resize now properly maintains aspect ratio if width or height is 0.
+* Fix: Update debug indicators for the visually impaired (blue color instead of yellow for disk
+  cache hits).
 
 Version 2.4.0 *(2014-11-04)*
 --------------------------
 
- * New `RequestHandler` beta API adds support for custom bitmap loading.
- * `priority` API for setting request priority. By default `fetch()` requests are set to `Priority.LOW`.
- * Requests can now be grouped with a `tag` and can be batch paused, resumed, or canceled.
- * Resizing with either height or width of 0 will now maintain aspect ratio.
- * `Picasso.setSingletonInstance` allows setting the global Picasso instance returned from `Picasso.with`.
- * Request `stableKey` provides an override value for the URI or resource ID when caching.
- * Fix: Properly calculate sample size for requests with `centerInside()`.
- * Fix: `ConcurrentModificationException` could occur in the `Dispatcher` when submitting a request.
- * Fix: Correctly log when a request was canceled due to garbage collection.
- * Fix: Provide correct target for `RemoteViews` requests.
- * Fix: Propagate exceptions thrown from custom transformations.
- * Fix: Invoking `shutdown()` now will close the disk cache.
-
+* New `RequestHandler` beta API adds support for custom bitmap loading.
+* `priority` API for setting request priority. By default `fetch()` requests are set to
+  `Priority.LOW`.
+* Requests can now be grouped with a `tag` and can be batch paused, resumed, or canceled.
+* Resizing with either height or width of 0 will now maintain aspect ratio.
+* `Picasso.setSingletonInstance` allows setting the global Picasso instance returned from
+  `Picasso.with`.
+* Request `stableKey` provides an override value for the URI or resource ID when caching.
+* Fix: Properly calculate sample size for requests with `centerInside()`.
+* Fix: `ConcurrentModificationException` could occur in the `Dispatcher` when submitting a request.
+* Fix: Correctly log when a request was canceled due to garbage collection.
+* Fix: Provide correct target for `RemoteViews` requests.
+* Fix: Propagate exceptions thrown from custom transformations.
+* Fix: Invoking `shutdown()` now will close the disk cache.
 
 Version 2.3.4 *(2014-08-25)*
 ----------------------------
 
- * Fix: Revert fail fast when missing internet permission.
- * Fix: Account for null paths when naming a Request.
- * Add API to allow canceling of remote views requests.
-
+* Fix: Revert fail fast when missing internet permission.
+* Fix: Account for null paths when naming a Request.
+* Add API to allow canceling of remote views requests.
 
 Version 2.3.3 *(2014-07-21)*
 ----------------------------
 
- * Fix: Crash when attempting to swap dimension for EXIF transformation.
- * Fix: Properly honor alpha value in PicassoDrawable.
- * Fix: Use `getWidth()` and `getHeight()` instead of `getMeasuredWidth()` and `getMeasuredHeight()` during `fit()`.
-
+* Fix: Crash when attempting to swap dimension for EXIF transformation.
+* Fix: Properly honor alpha value in PicassoDrawable.
+* Fix: Use `getWidth()` and `getHeight()` instead of `getMeasuredWidth()` and `getMeasuredHeight()`
+  during `fit()`.
 
 Version 2.3.2 *(2014-06-05)*
 ----------------------------
 
- * Fix: Correctly invalidate PicassoDrawable for GB.
- * Fix: Attempt to decode responses with missing `Content-Length` header.
- * Fix: Prevent race condition to initial `with()` call.
-
+* Fix: Correctly invalidate PicassoDrawable for GB.
+* Fix: Attempt to decode responses with missing `Content-Length` header.
+* Fix: Prevent race condition to initial `with()` call.
 
 Version 2.3.1 *(2014-05-29)*
 ----------------------------
 
- * Fix: Deprecated Response constructor used 0 for content-length.
- 
+* Fix: Deprecated Response constructor used 0 for content-length.
 
 Version 2.3.0 *(2014-05-29)*
 ----------------------------
 
- * Requests will now be automatically replayed if they failed due to network errors.
- * Add API for logging. This is mostly useful for debugging Picasso itself.
- * Add API for loading images into remote views (notifications and widgets).
- * Stats now provide download statistics.
- * Updated to use Pollexor 2.0.
- * When using OkHttp version 1.6 or newer (including 2.0+) is now required.
- * `MediaStoreBitmapHunter` now properly returns video thumbnails if requested URI is for a video.
- * All API calls now properly validate the current thread they must run on.
- * Performance: Various optimizations for reducing object allocations.
- * Fix: Stats were incorrectly invoked even if the bitmap failed to decode.
- * Fix: Handle `null` intent case in network broadcast receiver extras.
- * Fix: `Target` now correctly invokes bitmap failed if an error drawable or resource is supplied.
-
+* Requests will now be automatically replayed if they failed due to network errors.
+* Add API for logging. This is mostly useful for debugging Picasso itself.
+* Add API for loading images into remote views (notifications and widgets).
+* Stats now provide download statistics.
+* Updated to use Pollexor 2.0.
+* When using OkHttp version 1.6 or newer (including 2.0+) is now required.
+* `MediaStoreBitmapHunter` now properly returns video thumbnails if requested URI is for a video.
+* All API calls now properly validate the current thread they must run on.
+* Performance: Various optimizations for reducing object allocations.
+* Fix: Stats were incorrectly invoked even if the bitmap failed to decode.
+* Fix: Handle `null` intent case in network broadcast receiver extras.
+* Fix: `Target` now correctly invokes bitmap failed if an error drawable or resource is supplied.
 
 Version 2.2.0 *(2014-01-31)*
 ----------------------------
 
- * Add support decoding various contact photo URIs. 
- * Add support for loading `android.resource` URIs (e.g. load assets from other packages).
- * Add support for MICRO/MINI thumbnails for media images.
- * Add API to supply custom `Bitmap.Config` for decoding.
- * Performance: Reduce GC by reusing same `StringBuilder` instance on main thread for key creation.
- * Performance: Reduce default buffer allocation to 4k for `MarkableInputStream`.
- * Fix: Detect and decode WebP streams from byte array.
- * Fix: Non-200 HTTP responses will now display error drawable if supplied.
- * Fix: All exceptions during decode will now dispatch a failure.
- * Fix: Catch `OutOfMemory` errors, dispatch a failure, and output stats in logcat.
- * Fix: `fit()` now handles cases where either width or height was not zero.
- * Fix: Prevent crash from `null` intent on `NetworkBroadcastReceiver`.
- * Fix: Honor exif orientation when no custom transformations supplied.
- * Fix: Exceptions during transformations propagate to the main thread. 
- * Fix: Correct skia decoding problem during underflow.
- * Fix: Placeholder uses full bounds.
-
+* Add support decoding various contact photo URIs.
+* Add support for loading `android.resource` URIs (e.g. load assets from other packages).
+* Add support for MICRO/MINI thumbnails for media images.
+* Add API to supply custom `Bitmap.Config` for decoding.
+* Performance: Reduce GC by reusing same `StringBuilder` instance on main thread for key creation.
+* Performance: Reduce default buffer allocation to 4k for `MarkableInputStream`.
+* Fix: Detect and decode WebP streams from byte array.
+* Fix: Non-200 HTTP responses will now display error drawable if supplied.
+* Fix: All exceptions during decode will now dispatch a failure.
+* Fix: Catch `OutOfMemory` errors, dispatch a failure, and output stats in logcat.
+* Fix: `fit()` now handles cases where either width or height was not zero.
+* Fix: Prevent crash from `null` intent on `NetworkBroadcastReceiver`.
+* Fix: Honor exif orientation when no custom transformations supplied.
+* Fix: Exceptions during transformations propagate to the main thread.
+* Fix: Correct skia decoding problem during underflow.
+* Fix: Placeholder uses full bounds.
 
 Version 2.1.1 *(2013-10-04)*
 ----------------------------
 
- * `Target` now has callback for applying placeholder. This makes it symmetric with image views when
-   using `into()`.
- * Fix: Another work around for Android's header decoding algorthm readin more than 4K of image data
-   when decoding bounds.
- * Fix: Ensure default network-based executor is unregistered when instance is shut down.
- * Fix: Ensure connection is always closed for non-2xx response codes.
-
+* `Target` now has callback for applying placeholder. This makes it symmetric with image views when
+  using `into()`.
+* Fix: Another work around for Android's header decoding algorthm readin more than 4K of image data
+  when decoding bounds.
+* Fix: Ensure default network-based executor is unregistered when instance is shut down.
+* Fix: Ensure connection is always closed for non-2xx response codes.
 
 Version 2.1.0 *(2013-10-01)*
 ----------------------------
@@ -151,76 +150,69 @@ Version 2.1.0 *(2013-10-01)*
 Version 2.0.2 *(2013-09-11)*
 ----------------------------
 
- * Fix: Additional work around for Android's header decoding algorithm reading more than 4K of image
-   data when decoding bounds.
-
+* Fix: Additional work around for Android's header decoding algorithm reading more than 4K of image
+  data when decoding bounds.
 
 Version 2.0.1 *(2013-09-04)*
 ----------------------------
 
- * Enable filtered bitmaps for higher transform quality.
- * Fix: Using callbacks with `into()` on `fit()` requests are now always invoked.
- * Fix: Ensure final frame of cross-fade between place holder and image renders correctly.
- * Fix: Work around Android's behavior of reading more than 1K of image header data when decoding
-   bounds for some images.
-
+* Enable filtered bitmaps for higher transform quality.
+* Fix: Using callbacks with `into()` on `fit()` requests are now always invoked.
+* Fix: Ensure final frame of cross-fade between place holder and image renders correctly.
+* Fix: Work around Android's behavior of reading more than 1K of image header data when decoding
+  bounds for some images.
 
 Version 2.0.0 *(2013-08-30)*
 ----------------------------
 
- * New architecture distances Picasso further from the main thread using a dedicated dispatcher
-   thread to manage requests.
- * Request merging. Two requests on the same key will be combined and the result will be delivered
-   to both at the same time.
- * `fetch()` requests are now properly wired up to be used as "warm up the cache" type of requests
-   without a target.
- * `fit()` will now automatically wait for the view to be measured before executing the request.
- * `shutdown()` API added. Clears the memory cache and stops all threads. Submitting new requests
-   will cause a crash after `shutdown()` has been called.
- * Batch completed requests to the main thread to reduce main thread re-layout/draw calls.
- * Variable thread count depending on network connectivity. The faster the network the more threads
-   and vice versa.
- * Ability to specify a callback with `ImageView` requests.
- * Picasso will now decode the bounds of the target bitmap over the network. This helps avoid
-   decoding 2000x2000 images meant for 100x100 views.
- * Support loading asset URIs in the form `file:///android_asset/...`.
- * BETA: Ability to rewrite requests on the fly. This is useful if you want to add custom logic for
-   wiring up requests differently.
-
+* New architecture distances Picasso further from the main thread using a dedicated dispatcher
+  thread to manage requests.
+* Request merging. Two requests on the same key will be combined and the result will be delivered
+  to both at the same time.
+* `fetch()` requests are now properly wired up to be used as "warm up the cache" type of requests
+  without a target.
+* `fit()` will now automatically wait for the view to be measured before executing the request.
+* `shutdown()` API added. Clears the memory cache and stops all threads. Submitting new requests
+  will cause a crash after `shutdown()` has been called.
+* Batch completed requests to the main thread to reduce main thread re-layout/draw calls.
+* Variable thread count depending on network connectivity. The faster the network the more threads
+  and vice versa.
+* Ability to specify a callback with `ImageView` requests.
+* Picasso will now decode the bounds of the target bitmap over the network. This helps avoid
+  decoding 2000x2000 images meant for 100x100 views.
+* Support loading asset URIs in the form `file:///android_asset/...`.
+* BETA: Ability to rewrite requests on the fly. This is useful if you want to add custom logic for
+  wiring up requests differently.
 
 Version 1.1.1 *(2013-06-14)*
 ----------------------------
 
- * Fix: Ensure old requests for targets are cancelled when using a `null` image.
-
+* Fix: Ensure old requests for targets are cancelled when using a `null` image.
 
 Version 1.1.0 *(2013-06-13)*
 ----------------------------
 
- * `load` method can now take a `Uri`.
- * Support loading contact photos given a contact `Uri`.
- * Add `centerInside()` image transformation.
- * Fix: Prevent network stream decodes from blocking each other.
-
+* `load` method can now take a `Uri`.
+* Support loading contact photos given a contact `Uri`.
+* Add `centerInside()` image transformation.
+* Fix: Prevent network stream decodes from blocking each other.
 
 Version 1.0.2 *(2013-05-23)*
 ----------------------------
 
- * Auto-scale disk cache based on file system size.
- * `placeholder` now accepts `null` for clearing an existing image when used in an adapter and
-   without an explicit placeholder image.
- * New global failure listener for reporting load errors to a remote analytics or crash service.
- * Fix: Ensure disk cache folder is created before initialization.
- * Fix: Only use the built-in disk cache on API 14+ (but you're all using [OkHttp][1] anyways,
-   right?).
-
+* Auto-scale disk cache based on file system size.
+* `placeholder` now accepts `null` for clearing an existing image when used in an adapter and
+  without an explicit placeholder image.
+* New global failure listener for reporting load errors to a remote analytics or crash service.
+* Fix: Ensure disk cache folder is created before initialization.
+* Fix: Only use the built-in disk cache on API 14+ (but you're all using [OkHttp][1] anyways,
+  right?).
 
 Version 1.0.1 *(2013-05-14)*
 ----------------------------
 
- * Fix: Properly set priority for download threads.
- * Fix: Ensure stats thread is always initialized.
-
+* Fix: Properly set priority for download threads.
+* Fix: Ensure stats thread is always initialized.
 
 Version 1.0.0 *(2013-05-14)*
 ----------------------------
@@ -228,6 +220,4 @@ Version 1.0.0 *(2013-05-14)*
 Initial release.
 
 
-
-
- [1]: http://square.github.io/okhttp/
+[1]: http://square.github.io/okhttp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,4 +11,4 @@ Before your code can be accepted into the project you must also sign the
 [Individual Contributor License Agreement (CLA)][1].
 
 
- [1]: https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1
+[1]: https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@ Picasso
 =======
 
 **Attention**: This library is deprecated.
-Please use alternatives like [Coil](https://coil-kt.github.io/coil/) for future projects, and start planning to migrate existing projects, especially if they rely on Compose UI.
+Please use alternatives like [Coil](https://coil-kt.github.io/coil/) for future projects, and start
+planning to migrate existing projects, especially if they rely on Compose UI.
 Existing versions will continue to function, but no new work is planned.
-While some changes may land in the repo as we support internal legacy usage and migration, there will be no more public releases to Maven Central.
+While some changes may land in the repo as we support internal legacy usage and migration, there
+will be no more public releases to Maven Central.
 
 Thank you to all who used and/or contributed to Picasso over its decade of image loading.
 
@@ -22,11 +24,15 @@ Download
 --------
 
 Download the latest AAR from [Maven Central][2] or grab via Gradle:
+
 ```groovy
 implementation 'com.squareup.picasso:picasso:2.8'
 ```
+
 or Maven:
+
 ```xml
+
 <dependency>
   <groupId>com.squareup.picasso</groupId>
   <artifactId>picasso</artifactId>
@@ -42,7 +48,8 @@ Picasso requires at minimum Java 8 and API 21.
 ProGuard
 --------
 
-If you are using ProGuard you might need to add OkHttp's rules: https://github.com/square/okhttp/#r8--proguard
+If you are using ProGuard you might need to add OkHttp's
+rules: https://github.com/square/okhttp/#r8--proguard
 
 
 
@@ -63,7 +70,8 @@ License
     See the License for the specific language governing permissions and
     limitations under the License.
 
+[1]: https://square.github.io/picasso/
 
- [1]: https://square.github.io/picasso/
- [2]: https://search.maven.org/search?q=g:com.squareup.picasso%20AND%20a:picasso
- [snap]: https://s01.oss.sonatype.org/content/repositories/snapshots/
+[2]: https://search.maven.org/search?q=g:com.squareup.picasso%20AND%20a:picasso
+
+[snap]: https://s01.oss.sonatype.org/content/repositories/snapshots/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,13 @@
 Releasing
 ========
 
- 1. Update `VERSION_NAME` in `gradle.properties` to the release (non-SNAPSHOT) version.
- 2. Update `CHANGELOG.md` for the impending release.
- 3. Update the `README.md` with the new version.
- 4. `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
- 5. `git tag -a X.Y.Z -m "X.Y.Z"` (where X.Y.Z is the new version)
- 6. Update `VERSION_NAME` in `gradle.properties` to the next SNAPSHOT version.
- 7. `git commit -am "Prepare next development version"`
- 8. `git push && git push --tags`
+1. Update `VERSION_NAME` in `gradle.properties` to the release (non-SNAPSHOT) version.
+2. Update `CHANGELOG.md` for the impending release.
+3. Update the `README.md` with the new version.
+4. `git commit -am "Prepare for release X.Y.Z"` (where X.Y.Z is the new version)
+5. `git tag -a X.Y.Z -m "X.Y.Z"` (where X.Y.Z is the new version)
+6. Update `VERSION_NAME` in `gradle.properties` to the next SNAPSHOT version.
+7. `git commit -am "Prepare next development version"`
+8. `git push && git push --tags`
 
 This will trigger a GitHub Action workflow which will upload the release artifacts to Maven Central.

--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,7 @@ subprojects {
          *
          * internalUrl=YOUR_INTERNAL_URL
          * internalUsername=YOUR_USERNAME
-         * internalPassword=YOUR_PASSWORD
-         */
+         * internalPassword=YOUR_PASSWORD*/
         maven {
           name = "internal"
           url = providers.gradleProperty("internalUrl")
@@ -88,6 +87,6 @@ dependencies {
 
 tasks.register('deployJavadoc', JavaExec) {
   classpath = configurations.osstrich
-  main = 'com.squareup.osstrich.JavadocPublisher'
-  args "$buildDir/osstrich", 'git@github.com:square/picasso.git', 'com.squareup.picasso'
+  mainClass.main = 'com.squareup.osstrich.JavadocPublisher'
+  args "${layout.buildDirectory}/osstrich", 'git@github.com:square/picasso.git', 'com.squareup.picasso'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,28 +1,21 @@
 GROUP=com.squareup.picasso3
 VERSION_NAME=3.0.0-SNAPSHOT
-
 POM_URL=https://github.com/square/picasso/
 POM_SCM_URL=https://github.com/square/picasso/
 POM_SCM_CONNECTION=scm:git:git://github.com/square/picasso.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/square/picasso.git
-
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
-
 POM_DEVELOPER_ID=square
 POM_DEVELOPER_NAME=Square, Inc.
-
 org.gradle.jvmargs=-Xmx1536M
-
 android.useAndroidX=true
-
 android.defaults.buildfeatures.buildconfig=false
 android.defaults.buildfeatures.aidl=false
 android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
-
 SONATYPE_HOST=S01
 RELEASE_SIGNING_ENABLED=true
 SONATYPE_AUTOMATIC_RELEASE=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,26 +1,25 @@
 [versions]
-agp = '8.7.2'
+agp = "8.10.0"
 coroutines = '1.8.1'
-composeUi = '1.6.8'
+composeUi = '1.8.1'
 javaTarget = '1.8'
 kotlin = '2.0.0'
 ktlint = '1.2.1'
 okhttp = '4.12.0'
-okio = '3.2.0'
 paparazzi = '1.3.4'
 
 minSdk = '21'
-compileSdk = '34'
+compileSdk = '36'
 
 [libraries]
 androidx-annotations = { module = 'androidx.annotation:annotation', version = '1.9.1' }
-androidx-core = { module = 'androidx.core:core', version = '1.13.1' }
+androidx-core = { module = 'androidx.core:core', version = '1.16.0' }
 androidx-cursorAdapter = { module = 'androidx.cursoradapter:cursoradapter', version = '1.0.0' }
-androidx-exifInterface = { module = 'androidx.exifinterface:exifinterface', version = '1.3.7' }
-androidx-fragment = { module = 'androidx.fragment:fragment', version = '1.8.1' }
+androidx-exifInterface = { module = 'androidx.exifinterface:exifinterface', version = '1.4.1' }
+androidx-fragment = { module = 'androidx.fragment:fragment', version = '1.8.6' }
 androidx-junit = { module = 'androidx.test.ext:junit', version = '1.2.1' }
-androidx-lifecycle = { module = 'androidx.lifecycle:lifecycle-common', version = '2.8.7' }
-androidx-startup = { module = 'androidx.startup:startup-runtime', version = '1.1.1' }
+androidx-lifecycle = { module = 'androidx.lifecycle:lifecycle-common', version = '2.9.0' }
+androidx-startup = { module = 'androidx.startup:startup-runtime', version = '1.2.0' }
 androidx-testRunner = { module = 'androidx.test:runner', version = '1.6.2' }
 
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = 'coroutines' }
@@ -56,4 +55,3 @@ plugin-kotlin-compose = { module = "org.jetbrains.kotlin:compose-compiler-gradle
 plugin-paparazzi = { module = 'app.cash.paparazzi:paparazzi-gradle-plugin', version.ref = 'paparazzi' }
 plugin-publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version = '0.29.0' }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = '6.25.0' }
-plugin-test-aggregation = { module = "io.github.gmazzo.test.aggregation:plugin", version = '2.2.1' }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/lint.xml
+++ b/lint.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
-  <issue id="KotlinPropertyAccess" severity="error"/>
-  <issue id="LambdaLast" severity="error"/>
-  <issue id="NoHardKeywords" severity="error"/>
-  <issue id="UnknownNullness" severity="error"/>
-  <issue id="SyntheticAccessor" severity="error"/>
+  <issue id="KotlinPropertyAccess" severity="error" />
+  <issue id="LambdaLast" severity="error" />
+  <issue id="NoHardKeywords" severity="error" />
+  <issue id="UnknownNullness" severity="error" />
+  <issue id="SyntheticAccessor" severity="error" />
 </lint>

--- a/picasso-compose/build.gradle
+++ b/picasso-compose/build.gradle
@@ -26,12 +26,12 @@ android {
   kotlinOptions {
     jvmTarget = libs.versions.javaTarget.get()
   }
-
-  lintOptions {
-    textOutput 'stdout'
+  lint {
+    lintConfig file('lint.xml')
+    textOutput file('stdout')
     textReport true
-    lintConfig rootProject.file('lint.xml')
   }
+
 }
 
 dependencies {

--- a/picasso-paparazzi-sample/build.gradle
+++ b/picasso-paparazzi-sample/build.gradle
@@ -1,3 +1,5 @@
+import com.diffplug.gradle.spotless.SpotlessTask
+
 apply plugin: 'com.android.library'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'app.cash.paparazzi'
@@ -20,16 +22,16 @@ android {
     jvmTarget = libs.versions.javaTarget.get()
   }
 
-  lintOptions {
-    textOutput 'stdout'
-    textReport true
-    lintConfig rootProject.file('lint.xml')
-  }
 
   testOptions {
     unitTests {
       includeAndroidResources = true
     }
+  }
+  lint {
+    lintConfig file('lint.xml')
+    textOutput file('stdout')
+    textReport true
   }
 }
 
@@ -40,6 +42,6 @@ dependencies {
 }
 
 // https://github.com/diffplug/spotless/issues/1572
-tasks.withType(com.diffplug.gradle.spotless.SpotlessTask).configureEach {
+tasks.withType(SpotlessTask).configureEach {
   dependsOn(tasks.withType(Test))
 }

--- a/picasso-pollexor/build.gradle
+++ b/picasso-pollexor/build.gradle
@@ -19,12 +19,12 @@ android {
   kotlinOptions {
     jvmTarget = libs.versions.javaTarget.get()
   }
-
-  lintOptions {
-    textOutput 'stdout'
+  lint {
+    lintConfig file('lint.xml')
+    textOutput file('stdout')
     textReport true
-    lintConfig rootProject.file('lint.xml')
   }
+
 }
 
 dependencies {

--- a/picasso-sample/build.gradle
+++ b/picasso-sample/build.gradle
@@ -24,15 +24,13 @@ android {
   kotlinOptions {
     jvmTarget = libs.versions.javaTarget.get()
   }
-
-  lintOptions {
+  lint {
+    disable 'InvalidPackage'
     lintConfig file('lint.xml')
-    textOutput 'stdout'
+    textOutput file('stdout')
     textReport true
-
-    // https://github.com/square/okhttp/issues/896
-    ignore 'InvalidPackage'
   }
+
 }
 
 dependencies {

--- a/picasso-sample/lint.xml
+++ b/picasso-sample/lint.xml
@@ -4,7 +4,7 @@
   <issue id="NewApi">
     <ignore path="src/main/res/values/styles.xml" />
   </issue>
-  <issue id="IconColors" severity="ignore"/>
-  <issue id="IconDensities" severity="ignore"/>
-  <issue id="IconLocation" severity="ignore"/>
+  <issue id="IconColors" severity="ignore" />
+  <issue id="IconDensities" severity="ignore" />
+  <issue id="IconLocation" severity="ignore" />
 </lint>

--- a/picasso-stats/build.gradle
+++ b/picasso-stats/build.gradle
@@ -19,12 +19,12 @@ android {
   kotlinOptions {
     jvmTarget = libs.versions.javaTarget.get()
   }
-
-  lintOptions {
-    textOutput 'stdout'
+  lint {
+    lintConfig file('lint.xml')
+    textOutput file('stdout')
     textReport true
-    lintConfig rootProject.file('lint.xml')
   }
+
 }
 
 dependencies {

--- a/picasso/build.gradle
+++ b/picasso/build.gradle
@@ -23,16 +23,16 @@ android {
     jvmTarget = libs.versions.javaTarget.get()
   }
 
-  lintOptions {
-    textOutput 'stdout'
-    textReport true
-    lintConfig rootProject.file('lint.xml')
-  }
 
   testOptions {
     unitTests {
       includeAndroidResources = true
     }
+  }
+  lint {
+    lintConfig file('lint.xml')
+    textOutput file('stdout')
+    textReport true
   }
 }
 
@@ -60,7 +60,6 @@ spotless {
   kotlin {
     targetExclude(
       // Non-Square licensed files
-      "src/test/java/com/squareup/picasso3/PlatformLruCacheTest.kt",
-    )
+      "src/test/java/com/squareup/picasso3/PlatformLruCacheTest.kt",)
   }
 }

--- a/website/index.html
+++ b/website/index.html
@@ -1,63 +1,74 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Picasso</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A powerful image downloading and caching library for Android">
-    <link href="static/bootstrap-combined.min.css" rel="stylesheet">
-    <link href="static/app.css" rel="stylesheet">
-    <link href="static/app-theme.css" rel="stylesheet">
-    <link href="http://fonts.googleapis.com/css?family=Roboto:400,300italic,100,100italic,300" rel="stylesheet" type="text/css">
-    <!--[if lt IE 9]><script src="static/html5shiv.min.js"></script><![endif]-->
-  </head>
-  <body data-target=".content-nav">
-    <header>
-      <div class="container">
-        <div class="row">
-          <div class="span5">
-            <h1>Picasso</h1>
-          </div>
-          <div class="span7">
-            <menu>
-              <ul>
-                <li><a href="#download" class="menu download">Download <span class="version-tag">Latest</span></a></li>
-                <li><a href="http://github.com/square/picasso" data-title="View GitHub Project" class="menu github"><img src="static/icon-github.png" alt="GitHub"/></a></li>
-                <li><a href="http://square.github.io/" data-title="Square Open Source Portal" class="menu square"><img src="static/icon-square.png" alt="Square"/></a></li>
-              </ul>
-            </menu>
-          </div>
+<head>
+  <meta charset="utf-8">
+  <title>Picasso</title>
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <meta content="A powerful image downloading and caching library for Android" name="description">
+  <link href="static/bootstrap-combined.min.css" rel="stylesheet">
+  <link href="static/app.css" rel="stylesheet">
+  <link href="static/app-theme.css" rel="stylesheet">
+  <link href="http://fonts.googleapis.com/css?family=Roboto:400,300italic,100,100italic,300"
+        rel="stylesheet" type="text/css">
+  <!--[if lt IE 9]>
+  <script src="static/html5shiv.min.js"></script><![endif]-->
+</head>
+<body data-target=".content-nav">
+<header>
+  <div class="container">
+    <div class="row">
+      <div class="span5">
+        <h1>Picasso</h1>
       </div>
-    </header>
-    <section id="subtitle">
-      <div class="container">
-        <div class="row">
-          <div class="span12">
-            <h2>A powerful <strong>image downloading</strong> and <strong>caching</strong> library for Android</h2>
-          </div>
-        </div>
+      <div class="span7">
+        <menu>
+          <ul>
+            <li><a class="menu download" href="#download">Download <span
+              class="version-tag">Latest</span></a></li>
+            <li><a class="menu github" data-title="View GitHub Project"
+                   href="http://github.com/square/picasso"><img alt="GitHub"
+                                                                src="static/icon-github.png"/></a>
+            </li>
+            <li><a class="menu square" data-title="Square Open Source Portal"
+                   href="http://square.github.io/"><img alt="Square" src="static/icon-square.png"/></a>
+            </li>
+          </ul>
+        </menu>
       </div>
-    </section>
-    <section id="body">
-      <div class="container">
-        <div class="row">
-          <div class="span9">
-            <h3 id="introduction">Introduction</h3>
-            <p>Images add much-needed context and visual flair to Android applications. Picasso allows for hassle-free image loading in your application&mdash;often in one line of code!</p>
-            <pre class="prettyprint">Picasso.get().load("https://i.imgur.com/DvpvklR.png").into(imageView);</pre>
-            <p>Many common pitfalls of image loading on Android are handled automatically by Picasso:</p>
-            <ul>
-              <li>Handling <code>ImageView</code> recycling and download cancelation in an adapter.</li>
-              <li>Complex image transformations with minimal memory use.</li>
-              <li>Automatic memory and disk caching.</li>
-            </ul>
-            <p class="screenshot"><img src="static/sample.png" alt="Sample application screenshot."></p>
+    </div>
+</header>
+<section id="subtitle">
+  <div class="container">
+    <div class="row">
+      <div class="span12">
+        <h2>A powerful <strong>image downloading</strong> and <strong>caching</strong> library for
+          Android</h2>
+      </div>
+    </div>
+  </div>
+</section>
+<section id="body">
+  <div class="container">
+    <div class="row">
+      <div class="span9">
+        <h3 id="introduction">Introduction</h3>
+        <p>Images add much-needed context and visual flair to Android applications. Picasso allows
+          for hassle-free image loading in your application&mdash;often in one line of code!</p>
+        <pre class="prettyprint">Picasso.get().load("https://i.imgur.com/DvpvklR.png").into(imageView);</pre>
+        <p>Many common pitfalls of image loading on Android are handled automatically by
+          Picasso:</p>
+        <ul>
+          <li>Handling <code>ImageView</code> recycling and download cancelation in an adapter.</li>
+          <li>Complex image transformations with minimal memory use.</li>
+          <li>Automatic memory and disk caching.</li>
+        </ul>
+        <p class="screenshot"><img alt="Sample application screenshot." src="static/sample.png"></p>
 
-            <h3 id="features">Features</h3>
+        <h3 id="features">Features</h3>
 
-            <h4>Adapter Downloads</h4>
-            <p>Adapter re-use is automatically detected and the previous download canceled.</p>
-            <pre class="prettyprint">@Override public void getView(int position, View convertView, ViewGroup parent) {
+        <h4>Adapter Downloads</h4>
+        <p>Adapter re-use is automatically detected and the previous download canceled.</p>
+        <pre class="prettyprint">@Override public void getView(int position, View convertView, ViewGroup parent) {
   SquaredImageView view = (SquaredImageView) convertView;
   if (view == null) {
     view = new SquaredImageView(context);
@@ -67,15 +78,15 @@
   Picasso.get().load(url).into(view);
 }</pre>
 
-            <h4>Image Transformations</h4>
-            <p>Transform images to better fit into layouts and to reduce memory size.</p>
-            <pre class="prettyprint">Picasso.get()
+        <h4>Image Transformations</h4>
+        <p>Transform images to better fit into layouts and to reduce memory size.</p>
+        <pre class="prettyprint">Picasso.get()
   .load(url)
   .resize(50, 50)
   .centerCrop()
   .into(imageView)</pre>
-            <p>You can also specify custom transformations for more advanced effects.</p>
-            <pre class="prettyprint">public class CropSquareTransformation implements Transformation {
+        <p>You can also specify custom transformations for more advanced effects.</p>
+        <pre class="prettyprint">public class CropSquareTransformation implements Transformation {
   @Override public Bitmap transform(Bitmap source) {
     int size = Math.min(source.getWidth(), source.getHeight());
     int x = (source.getWidth() - size) / 2;
@@ -89,49 +100,60 @@
 
   @Override public String key() { return "square()"; }
 }</pre>
-            <p>Pass an instance of this class to the <code>transform</code> method.</p>
+        <p>Pass an instance of this class to the <code>transform</code> method.</p>
 
-            <h4>Place Holders</h4>
-            <p>Picasso supports both download and error placeholders as optional features.</p>
-            <pre class-"prettyprint">Picasso.get()
-    .load(url)
-    .placeholder(R.drawable.user_placeholder)
-    .error(R.drawable.user_placeholder_error)
-    .into(imageView);</pre>
-            <p>A request will be retried three times before the error placeholder is shown.</p>
+        <h4>Place Holders</h4>
+        <p>Picasso supports both download and error placeholders as optional features.</p>
+        <pre class-
+        "prettyprint">Picasso.get()
+        .load(url)
+        .placeholder(R.drawable.user_placeholder)
+        .error(R.drawable.user_placeholder_error)
+        .into(imageView);</pre>
+        <p>A request will be retried three times before the error placeholder is shown.</p>
 
 
-            <h4>Resource Loading</h4>
-            <p>Resources, assets, files, content providers are all supported as image sources.</p>
-            <pre class="prettyprint">Picasso.get().load(R.drawable.landing_screen).into(imageView1);
+        <h4>Resource Loading</h4>
+        <p>Resources, assets, files, content providers are all supported as image sources.</p>
+        <pre class="prettyprint">Picasso.get().load(R.drawable.landing_screen).into(imageView1);
 Picasso.get().load("file:///android_asset/DvpvklR.png").into(imageView2);
 Picasso.get().load(new File(...)).into(imageView3);</pre>
 
-            <h4>Debug Indicators</h4>
-            <p>For development you can enable the display of a colored ribbon which indicates the image source. Call <code>setIndicatorsEnabled(true)</code> on the Picasso instance.</p>
-            <p class="screenshot"><img src="static/debug.png" alt="Debug ribbon indicators"></p>
+        <h4>Debug Indicators</h4>
+        <p>For development you can enable the display of a colored ribbon which indicates the image
+          source. Call <code>setIndicatorsEnabled(true)</code> on the Picasso instance.</p>
+        <p class="screenshot"><img alt="Debug ribbon indicators" src="static/debug.png"></p>
 
-            <h3 id="download">Download</h3>
-            <p><a href="https://search.maven.org/remote_content?g=com.squareup.picasso&a=picasso&v=2.8&e=aar" class="dl version-href">&darr; <span class="version-tag">Latest</span> AAR</a></p>
-            <p>The source code to the Picasso, its samples, and this website is <a href="http://github.com/square/picasso">available on GitHub</a>.</p>
+        <h3 id="download">Download</h3>
+        <p><a
+          class="dl version-href"
+          href="https://search.maven.org/remote_content?g=com.squareup.picasso&a=picasso&v=2.8&e=aar">&darr;
+          <span class="version-tag">Latest</span> AAR</a></p>
+        <p>The source code to the Picasso, its samples, and this website is <a
+          href="http://github.com/square/picasso">available on GitHub</a>.</p>
 
-            <h4>Maven</h4>
-            <pre class="prettyprint">&lt;dependency>
+        <h4>Maven</h4>
+        <pre class="prettyprint">&lt;dependency>
   &lt;groupId>com.squareup.picasso3&lt;/groupId>
   &lt;artifactId>picasso&lt;/artifactId>
   &lt;version><span class="version pln"><em>(insert latest version)</em></span>&lt;/version>
 &lt;/dependency></pre>
 
-            <h4>Gradle</h4>
-            <pre class="prettyprint">implementation 'com.squareup.picasso:picasso:<span class="version pln"><em>(insert latest version)</em></span>'</pre>
+        <h4>Gradle</h4>
+        <pre class="prettyprint">implementation 'com.squareup.picasso:picasso:<span
+          class="version pln"><em>(insert latest version)</em></span>'</pre>
 
-            <h3 id="contributing">Contributing</h3>
-            <p>If you would like to contribute code you can do so through GitHub by forking the repository and sending a pull request.</p>
-            <p>When submitting code, please make every effort to follow existing conventions and style in order to keep the code as readable as possible. Please also make sure your code compiles by running <code>mvn clean verify</code>.</p>
-            <p>Before your code can be accepted into the project you must also sign the <a href="http://squ.re/sign-the-cla">Individual Contributor License Agreement (CLA)</a>.</p>
+        <h3 id="contributing">Contributing</h3>
+        <p>If you would like to contribute code you can do so through GitHub by forking the
+          repository and sending a pull request.</p>
+        <p>When submitting code, please make every effort to follow existing conventions and style
+          in order to keep the code as readable as possible. Please also make sure your code
+          compiles by running <code>mvn clean verify</code>.</p>
+        <p>Before your code can be accepted into the project you must also sign the <a
+          href="http://squ.re/sign-the-cla">Individual Contributor License Agreement (CLA)</a>.</p>
 
-            <h3 id="license">License</h3>
-            <pre>Copyright 2013 Square, Inc.
+        <h3 id="license">License</h3>
+        <pre>Copyright 2013 Square, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -144,68 +166,69 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.</pre>
-          </div>
-          <div class="span3">
-            <div class="content-nav" data-spy="affix" data-offset-top="80">
-              <ul class="nav nav-tabs nav-stacked primary">
-                <li><a href="#introduction">Introduction</a></li>
-                <li><a href="#features">Features</a></li>
-                <li><a href="#download">Download</a></li>
-                <li><a href="#contributing">Contributing</a></li>
-                <li><a href="#license">License</a></li>
-              </ul>
-              <ul class="nav nav-pills nav-stacked secondary">
-                <li><a href="2.x/picasso/">Javadoc</a></li>
-                <li><a href="http://stackoverflow.com/questions/tagged/picasso?sort=active">StackOverflow</a></li>
-              </ul>
-            </div>
-          </div>
-        </div>
-        <div class="row">
-          <div class="span12 logo">
-            <a href="https://squareup.com"><img src="static/logo-square.png" alt="Square, Inc."/></a>
-          </div>
+      </div>
+      <div class="span3">
+        <div class="content-nav" data-offset-top="80" data-spy="affix">
+          <ul class="nav nav-tabs nav-stacked primary">
+            <li><a href="#introduction">Introduction</a></li>
+            <li><a href="#features">Features</a></li>
+            <li><a href="#download">Download</a></li>
+            <li><a href="#contributing">Contributing</a></li>
+            <li><a href="#license">License</a></li>
+          </ul>
+          <ul class="nav nav-pills nav-stacked secondary">
+            <li><a href="2.x/picasso/">Javadoc</a></li>
+            <li><a href="http://stackoverflow.com/questions/tagged/picasso?sort=active">StackOverflow</a>
+            </li>
+          </ul>
         </div>
       </div>
-    </section>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script src="static/bootstrap.min.js"></script>
-    <script src="static/jquery.smooth-scroll.min.js"></script>
-    <script src="static/jquery-maven-artifact.min.js"></script>
-    <script src="static/prettify.js"></script>
-    <script type="text/javascript">
-      $(function() {
-        // Syntax highlight code blocks.
-        prettyPrint();
+    </div>
+    <div class="row">
+      <div class="span12 logo">
+        <a href="https://squareup.com"><img alt="Square, Inc." src="static/logo-square.png"/></a>
+      </div>
+    </div>
+  </div>
+</section>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="static/bootstrap.min.js"></script>
+<script src="static/jquery.smooth-scroll.min.js"></script>
+<script src="static/jquery-maven-artifact.min.js"></script>
+<script src="static/prettify.js"></script>
+<script type="text/javascript">
+  $(function() {
+    // Syntax highlight code blocks.
+    prettyPrint();
 
-        // Spy on scroll position for real-time updating of current section.
-        $('body').scrollspy();
+    // Spy on scroll position for real-time updating of current section.
+    $('body').scrollspy();
 
-        // Use smooth-scroll for internal links.
-        $('a').smoothScroll();
+    // Use smooth-scroll for internal links.
+    $('a').smoothScroll();
 
-        // Enable tooltips on the header nav image items.
-        $('.menu').tooltip({
-          placement: 'bottom',
-          trigger: 'hover',
-          container: 'body',
-          delay: {
-            show: 500,
-            hide: 0
-          }
-        });
+    // Enable tooltips on the header nav image items.
+    $('.menu').tooltip({
+      placement: 'bottom',
+      trigger: 'hover',
+      container: 'body',
+      delay: {
+        show: 500,
+        hide: 0
+      }
+    });
 
-        // Look up the latest version of the library.
-        $.fn.artifactVersion({
-          'groupId': 'com.squareup.picasso',
-          'artifactId': 'picasso',
-          'packaging': 'aar'
-        }, function (version, url) {
-            $('.version').text(version);
-            $('.version-tag').text('v' + version);
-            $('.version-href').attr('href', url);
-          });
-        });
-    </script>
-  </body>
+    // Look up the latest version of the library.
+    $.fn.artifactVersion({
+      'groupId': 'com.squareup.picasso',
+      'artifactId': 'picasso',
+      'packaging': 'aar'
+    }, function (version, url) {
+        $('.version').text(version);
+        $('.version-tag').text('v' + version);
+        $('.version-href').attr('href', url);
+      });
+    });
+</script>
+</body>
 </html>


### PR DESCRIPTION
This commit refactors the lint configurations across various modules for consistency and updates several dependencies to their latest versions.

Key changes include:
- Moved lint configuration (`lintOptions` block) to the more modern `lint` block in `build.gradle` files for `picasso-sample`, `picasso`, `picasso-stats`, `picasso-pollexor`, `picasso-paparazzi-sample`, and `picasso-compose`.
- Updated Android Gradle Plugin to `8.10.0`.
- Updated various AndroidX libraries (core, cursorAdapter, exifInterface, fragment, lifecycle, startup, testRunner, junit).
- Updated Kotlin Coroutines to `1.8.1`.
- Updated Compose UI to `1.8.1`.
- Updated `compileSdk` to `36`.
- Updated `okHttp` to `4.12.0`.
- Removed `okio` dependency.
- Removed `plugin-test-aggregation`.
- Updated Gradle wrapper to `8.14`.
- Minor formatting adjustments in `.editorconfig`, `lint.xml`, `RELEASING.md`, `website/index.html`, `gradle.properties`, `CHANGELOG.md`, `README.md`, and `CONTRIBUTING.md`.
- Updated `deployJavadoc` task in `build.gradle` to use `mainClass.main` and `layout.buildDirectory`.
- Ensured Spotless task in `picasso-paparazzi-sample/build.gradle` depends on Test tasks using a direct class reference.