### PR TITLE
Limit network image buffering to prevent OOM on oversized responses

### DIFF
--- a/picasso/src/main/java/com/squareup/picasso3/BitmapUtils.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/BitmapUtils.kt
@@ -104,14 +104,14 @@ internal object BitmapUtils {
    * about the supplied request in order to do the decoding efficiently (such as through leveraging
    * `inSampleSize`).
    */
-  fun decodeStream(source: Source, request: Request): Bitmap {
+  fun decodeStream(source: Source, request: Request, maxByteCount: Long = Long.MAX_VALUE): Bitmap {
     val exceptionCatchingSource = ExceptionCatchingSource(source)
     val bufferedSource = exceptionCatchingSource.buffer()
     val bitmap =
       if (VERSION.SDK_INT >= 28) {
-        decodeStreamP(request, bufferedSource)
+        decodeStreamP(request, bufferedSource, maxByteCount)
       } else {
-        decodeStreamPreP(request, bufferedSource)
+        decodeStreamPreP(request, bufferedSource, maxByteCount)
       }
     exceptionCatchingSource.throwIfCaught()
     return bitmap
@@ -119,19 +119,28 @@ internal object BitmapUtils {
 
   @RequiresApi(28)
   @SuppressLint("Override")
-  private fun decodeStreamP(request: Request, bufferedSource: BufferedSource): Bitmap {
-    val imageSource = ImageDecoder.createSource(ByteBuffer.wrap(bufferedSource.readByteArray()))
+  private fun decodeStreamP(
+    request: Request,
+    bufferedSource: BufferedSource,
+    maxByteCount: Long
+  ): Bitmap {
+    val bytes = readByteArrayWithLimit(bufferedSource, maxByteCount)
+    val imageSource = ImageDecoder.createSource(ByteBuffer.wrap(bytes))
     return decodeImageSource(imageSource, request)
   }
 
-  private fun decodeStreamPreP(request: Request, bufferedSource: BufferedSource): Bitmap {
+  private fun decodeStreamPreP(
+    request: Request,
+    bufferedSource: BufferedSource,
+    maxByteCount: Long
+  ): Bitmap {
     val isWebPFile = Utils.isWebPFile(bufferedSource)
     val options = createBitmapOptions(request)
     val calculateSize = requiresInSampleSize(options)
     // We decode from a byte array because, when decoding a WebP network stream, BitmapFactory
     // throws a JNI Exception, so we workaround by decoding a byte array.
     val bitmap = if (isWebPFile) {
-      val bytes = bufferedSource.readByteArray()
+      val bytes = readByteArrayWithLimit(bufferedSource, maxByteCount)
       if (calculateSize) {
         BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options)
         calculateInSampleSize(request.targetWidth, request.targetHeight, options!!, request)
@@ -149,6 +158,25 @@ internal object BitmapUtils {
       throw IOException("Failed to decode bitmap.")
     }
     return bitmap
+  }
+
+  @Throws(IOException::class)
+  private fun readByteArrayWithLimit(source: BufferedSource, maxByteCount: Long): ByteArray {
+    if (maxByteCount == Long.MAX_VALUE) {
+      return source.readByteArray()
+    }
+    require(maxByteCount > 0L) { "maxByteCount must be > 0." }
+    val sink = Buffer()
+    var totalRead = 0L
+    while (true) {
+      val read = source.read(sink, 8 * 1024L)
+      if (read == -1L) break
+      totalRead += read
+      if (totalRead > maxByteCount) {
+        throw IOException("Source exceeds max size of $maxByteCount bytes.")
+      }
+    }
+    return sink.readByteArray()
   }
 
   fun decodeResource(context: Context, request: Request): Bitmap {

--- a/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.kt
+++ b/picasso/src/main/java/com/squareup/picasso3/NetworkRequestHandler.kt
@@ -63,11 +63,21 @@ internal class NetworkRequestHandler(
             )
             return
           }
+          if (body!!.contentLength() > MAX_RESPONSE_BODY_SIZE) {
+            body.close()
+            callback.onError(
+              ContentLengthException(
+                "Received response with content-length ${body.contentLength()} bytes " +
+                  "that exceeds max size of $MAX_RESPONSE_BODY_SIZE bytes."
+              )
+            )
+            return
+          }
           if (loadedFrom == NETWORK && body!!.contentLength() > 0) {
             picasso.downloadFinished(body.contentLength())
           }
           try {
-            val bitmap = decodeStream(body!!.source(), request)
+            val bitmap = decodeStream(body!!.source(), request, MAX_RESPONSE_BODY_SIZE)
             callback.onSuccess(Result.Bitmap(bitmap, loadedFrom))
           } catch (e: IOException) {
             body!!.close()
@@ -128,5 +138,6 @@ internal class NetworkRequestHandler(
   private companion object {
     private const val SCHEME_HTTP = "http"
     private const val SCHEME_HTTPS = "https"
+    private const val MAX_RESPONSE_BODY_SIZE = 50L * 1024 * 1024 // 50MB
   }
 }

--- a/picasso/src/test/java/com/squareup/picasso3/NetworkRequestHandlerTest.kt
+++ b/picasso/src/test/java/com/squareup/picasso3/NetworkRequestHandlerTest.kt
@@ -188,6 +188,36 @@ class NetworkRequestHandlerTest {
     assertThat(latch.await(10, SECONDS)).isTrue()
   }
 
+  @Test fun oversizedNetworkResponseThrowsAndClosesBody() {
+    val closed = AtomicBoolean()
+    val body = object : ResponseBody() {
+      override fun contentType(): MediaType? = null
+      override fun contentLength(): Long = 50L * 1024 * 1024 + 1L
+      override fun source(): BufferedSource = Buffer()
+      override fun close() {
+        closed.set(true)
+        super.close()
+      }
+    }
+    responses += responseOf(body)
+    val action = TestUtils.mockAction(picasso, URI_KEY_1, URI_1)
+    val latch = CountDownLatch(1)
+    networkHandler.load(
+      picasso = picasso,
+      request = action.request,
+      callback = object : RequestHandler.Callback {
+        override fun onSuccess(result: Result?): Unit = throw AssertionError()
+
+        override fun onError(t: Throwable) {
+          assertThat(t).isInstanceOf(NetworkRequestHandler.ContentLengthException::class.java)
+          assertTrue(closed.get())
+          latch.countDown()
+        }
+      }
+    )
+    assertThat(latch.await(10, SECONDS)).isTrue()
+  }
+
   @Test fun cachedResponseDoesNotDispatchToStats() {
     val eventRecorder = EventRecorder()
     val picasso = picasso.newBuilder().addEventListener(eventRecorder).build()


### PR DESCRIPTION
  I found that the network decode path could buffer an arbitrarily large response body into memory on byte-array decode flows, which can
  lead to OOM risk with oversized payloads.

  I kept this change focused and minimal: I added a hard size guard for network responses and enforced the same limit in the decode path.

  ## Root cause

  On network requests, byte-array decode paths (`readByteArray()`) did not enforce a maximum response size before loading data into
  memory.

  ## What I changed

  - I added a max response size guard (`50MB`) in `NetworkRequestHandler` before decode.
  - I now pass that max size into `BitmapUtils.decodeStream(...)` for network decodes.
  - I added a bounded reader helper in `BitmapUtils` (`readByteArrayWithLimit`) and used it for:
    - API 28+ decode path
    - pre-P WebP byte-array decode path
  - I added a regression unit test:
    - `oversizedNetworkResponseThrowsAndClosesBody`
    - Verifies oversized responses fail with `ContentLengthException` and response body is closed.

  ## Before / After

  - Before: oversized network payloads could be fully buffered in memory by byte-array decode paths.
  - After: oversized payloads are rejected early and decode paths enforce a byte limit.